### PR TITLE
Move internal failures to server repo

### DIFF
--- a/temporal/api/errordetails/v1/message.proto
+++ b/temporal/api/errordetails/v1/message.proto
@@ -47,23 +47,6 @@ message NamespaceNotActiveFailure {
     string active_cluster = 3;
 }
 
-message RetryTaskFailure {
-    string namespace_id = 1;
-    string workflow_id = 2;
-    string run_id = 3;
-    int64 next_event_id = 4;
-}
-
-message RetryTaskV2Failure {
-    string namespace_id = 1;
-    string workflow_id = 2;
-    string run_id = 3;
-    int64 start_event_id = 4;
-    int64 start_event_version = 5;
-    int64 end_event_id = 6;
-    int64 end_event_version = 7;
-}
-
 message ClientVersionNotSupportedFailure {
     string client_version = 1;
     string client_impl = 2;
@@ -76,14 +59,6 @@ message FeatureVersionNotSupportedFailure {
     string supported_versions = 3;
 }
 
-message CurrentBranchChangedFailure {
-    bytes current_branch_token = 1;
-}
-
-message ShardOwnershipLostFailure {
-    string owner = 1;
-}
-
 message NamespaceAlreadyExistsFailure {
 }
 
@@ -91,7 +66,4 @@ message CancellationAlreadyRequestedFailure {
 }
 
 message QueryFailedFailure {
-}
-
-message EventAlreadyStartedFailure {
 }

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -82,7 +82,7 @@ service WorkflowService {
     }
 
     // PollWorkflowTaskQueue is called by application worker to process WorkflowTask from a specific task queue.  A
-    // WorkflowTask is dispatched to callers for active workflow executions, with pending commands.
+    // WorkflowTask is dispatched to callers for active workflow executions, with pending workflow tasks.
     // Application is then expected to call 'RespondWorkflowTaskCompleted' API when it is done processing the WorkflowTask.
     // It will also create a 'WorkflowTaskStarted' event in the history for that session before handing off WorkflowTask to
     // application worker.


### PR DESCRIPTION
Some failures are used by internal server APIs only. Moving them out of external API repo.

Closes https://github.com/temporalio/temporal/issues/75.