### PR TITLE
Rename workflow_task_timeout_seconds

### DIFF
--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -55,7 +55,7 @@ message WorkflowExecutionConfig {
     temporal.api.taskqueue.v1.TaskQueue task_queue = 1;
     int32 workflow_execution_timeout_seconds = 2;
     int32 workflow_run_timeout_seconds = 3;
-    int32 workflow_task_timeout_seconds = 4;
+    int32 default_workflow_task_timeout_seconds = 4;
 }
 
 message PendingActivityInfo {


### PR DESCRIPTION
to `default_workflow_taks_timeout_secods` for consistency with mutable state field name.