### PR TITLE
Move to Proto Time, Use Gogo Time Ext

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ go-grpc: clean $(PROTO_OUT)
 
 gogo-grpc: clean $(PROTO_OUT)
 	printf $(COLOR) "Compiling for gogo-gRPC..."
-	$(foreach PROTO_DIR,$(PROTO_DIRS),protoc $(PROTO_IMPORTS) --gogoslick_out=Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:$(PROTO_OUT) $(PROTO_DIR)*.proto;)
+	$(foreach PROTO_DIR,$(PROTO_DIRS),protoc $(PROTO_IMPORTS) --gogoslick_out=Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:$(PROTO_OUT) $(PROTO_DIR)*.proto;)
 
 fix-path:
 	mv -f $(PROTO_OUT)/temporal/api/* $(PROTO_OUT) && rm -rf $(PROTO_OUT)/temporal

--- a/api-linter.yaml
+++ b/api-linter.yaml
@@ -9,7 +9,11 @@
     - 'core::0122::name-suffix'
     - 'core::0123::resource-annotation'
     - 'core::0140::prepositions'    # should be gone after time fields conversion
-    - 'core::0142::time-field-type' # should be gone after time fields conversion
+
+- included_paths:
+    - '**/workflow/v1/message.proto'
+  disabled_rules:
+    - 'core::0214::resource-expiry' # Need field_behavior import fixed
 
 - included_paths:
     - '**/workflowservice/v1/request_response.proto'
@@ -21,7 +25,6 @@
     - 'core::0132::request-unknown-fields'
     - 'core::0132::response-unknown-fields'
     - 'core::0134::request-unknown-fields'
-    - 'core::0142::time-field-type' # should be gone after time fields conversion
     - 'core::0158::request-page-size-field'
     - 'core::0158::request-page-token-field'
     - 'core::0158::response-next-page-token-field'
@@ -35,3 +38,9 @@
     - 'core::0131::method-signature'
     - 'core::0131::response-message-name'
     - 'core::0136::prepositions' # should be gone after time fields conversion
+
+- included_paths:
+    - 'dependencies/**'
+  disabled_rules:
+    - 'core::0191::proto-version'
+    - 'core::0215::versioned-packages'

--- a/buf.yaml
+++ b/buf.yaml
@@ -2,5 +2,7 @@ build:
   roots:
     - .
 lint:
+  ignore:
+    - dependencies
   use:
     - DEFAULT

--- a/dependencies/gogoproto/v1/gogo.proto
+++ b/dependencies/gogoproto/v1/gogo.proto
@@ -1,0 +1,145 @@
+// Protocol Buffers for Go with Gadgets
+//
+// Copyright (c) 2013, The GoGo Authors. All rights reserved.
+// http://github.com/temporalio/gogo-protobuf
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+syntax = "proto2";
+package gogoproto;
+
+import "google/protobuf/descriptor.proto";
+
+option go_package = "go.temporal.io/dependencies/gogoproto/v1;gogoproto";
+option java_package = "com.gogoproto";
+option java_outer_classname = "GogoProto";
+option java_multiple_files = true;
+
+extend google.protobuf.EnumOptions {
+	optional bool goproto_enum_prefix = 62001;
+	optional bool goproto_enum_stringer = 62021;
+	optional bool enum_stringer = 62022;
+	optional string enum_customname = 62023;
+	optional bool enumdecl = 62024;
+}
+
+extend google.protobuf.EnumValueOptions {
+	optional string enumvalue_customname = 66001;
+}
+
+extend google.protobuf.FileOptions {
+	optional bool goproto_getters_all = 63001;
+	optional bool goproto_enum_prefix_all = 63002;
+	optional bool goproto_stringer_all = 63003;
+	optional bool verbose_equal_all = 63004;
+	optional bool face_all = 63005;
+	optional bool gostring_all = 63006;
+	optional bool populate_all = 63007;
+	optional bool stringer_all = 63008;
+	optional bool onlyone_all = 63009;
+
+	optional bool equal_all = 63013;
+	optional bool description_all = 63014;
+	optional bool testgen_all = 63015;
+	optional bool benchgen_all = 63016;
+	optional bool marshaler_all = 63017;
+	optional bool unmarshaler_all = 63018;
+	optional bool stable_marshaler_all = 63019;
+
+	optional bool sizer_all = 63020;
+
+	optional bool goproto_enum_stringer_all = 63021;
+	optional bool enum_stringer_all = 63022;
+
+	optional bool unsafe_marshaler_all = 63023;
+	optional bool unsafe_unmarshaler_all = 63024;
+
+	optional bool goproto_extensions_map_all = 63025;
+	optional bool goproto_unrecognized_all = 63026;
+	optional bool gogoproto_import = 63027;
+	optional bool protosizer_all = 63028;
+	optional bool compare_all = 63029;
+    optional bool typedecl_all = 63030;
+    optional bool enumdecl_all = 63031;
+
+	optional bool goproto_registration = 63032;
+	optional bool messagename_all = 63033;
+
+	optional bool goproto_sizecache_all = 63034;
+	optional bool goproto_unkeyed_all = 63035;
+}
+
+extend google.protobuf.MessageOptions {
+	optional bool goproto_getters = 64001;
+	optional bool goproto_stringer = 64003;
+	optional bool verbose_equal = 64004;
+	optional bool face = 64005;
+	optional bool gostring = 64006;
+	optional bool populate = 64007;
+	optional bool stringer = 67008;
+	optional bool onlyone = 64009;
+
+	optional bool equal = 64013;
+	optional bool description = 64014;
+	optional bool testgen = 64015;
+	optional bool benchgen = 64016;
+	optional bool marshaler = 64017;
+	optional bool unmarshaler = 64018;
+	optional bool stable_marshaler = 64019;
+
+	optional bool sizer = 64020;
+
+	optional bool unsafe_marshaler = 64023;
+	optional bool unsafe_unmarshaler = 64024;
+
+	optional bool goproto_extensions_map = 64025;
+	optional bool goproto_unrecognized = 64026;
+
+	optional bool protosizer = 64028;
+	optional bool compare = 64029;
+
+	optional bool typedecl = 64030;
+
+	optional bool messagename = 64033;
+
+	optional bool goproto_sizecache = 64034;
+	optional bool goproto_unkeyed = 64035;
+}
+
+extend google.protobuf.FieldOptions {
+	optional bool nullable = 65001;
+	optional bool embed = 65002;
+	optional string customtype = 65003;
+	optional string customname = 65004;
+	optional string jsontag = 65005;
+	optional string moretags = 65006;
+	optional string casttype = 65007;
+	optional string castkey = 65008;
+	optional string castvalue = 65009;
+
+	optional bool stdtime = 65010;
+	optional bool stdduration = 65011;
+	optional bool wktpointer = 65012;
+
+}

--- a/temporal/api/command/v1/message.proto
+++ b/temporal/api/command/v1/message.proto
@@ -30,6 +30,10 @@ option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 option ruby_package = "Temporal::Api::Decision::V1";
 
+import "google/protobuf/duration.proto";
+
+import "dependencies/gogoproto/v1/gogo.proto";
+
 import "temporal/api/enums/v1/workflow.proto";
 import "temporal/api/enums/v1/command_type.proto";
 import "temporal/api/common/v1/message.proto";
@@ -46,16 +50,16 @@ message ScheduleActivityTaskCommandAttributes {
     // Indicates how long the caller is willing to wait for an activity completion.
     // Limits for how long retries are happening. Either this or start_to_close_timeout_seconds must be specified.
     // When not specified defaults to the workflow execution timeout.
-    int32 schedule_to_close_timeout_seconds = 7;
+    google.protobuf.Duration schedule_to_close_timeout = 7 [(gogoproto.stdduration) = true];
     // Limits time an activity task can stay in a task queue before a worker picks it up.
     // This timeout is always non retryable as all a retry would achieve is to put it back into the same queue.
     // Defaults to schedule_to_close_timeout_seconds or workflow execution timeout if not specified.
-    int32 schedule_to_start_timeout_seconds = 8;
+    google.protobuf.Duration schedule_to_start_timeout = 8 [(gogoproto.stdduration) = true];
     // Maximum time an activity is allowed to execute after a pick up by a worker.
     // This timeout is always retryable. Either this or schedule_to_close_timeout_seconds must be specified.
-    int32 start_to_close_timeout_seconds = 9;
+    google.protobuf.Duration start_to_close_timeout = 9 [(gogoproto.stdduration) = true];
     // Maximum time between successful worker heartbeats.
-    int32 heartbeat_timeout_seconds = 10;
+    google.protobuf.Duration heartbeat_timeout = 10 [(gogoproto.stdduration) = true];
     // Activities are provided by a default retry policy controlled through the service dynamic configuration.
     // Retries are happening up to schedule_to_close_timeout.
     // To disable retries set retry_policy.maximum_attempts to 1.
@@ -68,7 +72,7 @@ message RequestCancelActivityTaskCommandAttributes {
 
 message StartTimerCommandAttributes {
     string timer_id = 1;
-    int64 start_to_fire_timeout_seconds = 2;
+    google.protobuf.Duration start_to_fire_timeout = 2 [(gogoproto.stdduration) = true];
 }
 
 message CompleteWorkflowExecutionCommandAttributes {
@@ -121,10 +125,10 @@ message ContinueAsNewWorkflowExecutionCommandAttributes {
     temporal.api.common.v1.Payloads input = 3;
     // workflow_execution_timeout is omitted as it shouldn'be overridden from within a workflow.
     // Timeout of a single workflow run.
-    int32 workflow_run_timeout_seconds = 4;
+    google.protobuf.Duration workflow_run_timeout = 4 [(gogoproto.stdduration) = true];
     // Timeout of a single workflow task.
-    int32 workflow_task_timeout_seconds = 5;
-    int32 backoff_start_interval_in_seconds = 6;
+    google.protobuf.Duration workflow_task_timeout = 5 [(gogoproto.stdduration) = true];
+    google.protobuf.Duration backoff_start_interval = 6 [(gogoproto.stdduration) = true];
     temporal.api.common.v1.RetryPolicy retry_policy = 7;
     temporal.api.enums.v1.ContinueAsNewInitiator initiator = 8;
     temporal.api.failure.v1.Failure failure = 9;
@@ -142,11 +146,11 @@ message StartChildWorkflowExecutionCommandAttributes {
     temporal.api.taskqueue.v1.TaskQueue task_queue = 4;
     temporal.api.common.v1.Payloads input = 5;
     // Total workflow execution timeout including retries and continue as new.
-    int32 workflow_execution_timeout_seconds = 6;
+    google.protobuf.Duration workflow_execution_timeout = 6 [(gogoproto.stdduration) = true];
     // Timeout of a single workflow run.
-    int32 workflow_run_timeout_seconds = 7;
+    google.protobuf.Duration workflow_run_timeout = 7 [(gogoproto.stdduration) = true];
     // Timeout of a single workflow task.
-    int32 workflow_task_timeout_seconds = 8;
+    google.protobuf.Duration workflow_task_timeout = 8 [(gogoproto.stdduration) = true];
     // Default: PARENT_CLOSE_POLICY_TERMINATE.
     temporal.api.enums.v1.ParentClosePolicy parent_close_policy = 9;
     string control = 10;

--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -30,6 +30,10 @@ option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 option ruby_package = "Temporal::Api::Common::V1";
 
+import "google/protobuf/duration.proto";
+
+import "dependencies/gogoproto/v1/gogo.proto";
+
 import "temporal/api/enums/v1/common.proto";
 
 message DataBlob {
@@ -73,14 +77,14 @@ message ActivityType {
 
 message RetryPolicy {
     // Interval of the first retry. If retryBackoffCoefficient is 1.0 then it is used for all retries.
-    int32 initial_interval_in_seconds = 1;
+    google.protobuf.Duration initial_interval = 1 [(gogoproto.stdduration) = true];
     // Coefficient used to calculate the next retry interval.
     // The next retry interval is previous interval multiplied by the coefficient.
     // Must be 1 or larger.
     double backoff_coefficient = 2;
     // Maximum interval between retries. Exponential backoff leads to interval increase.
     // This value is the cap of the increase. Default is 100x of the initial interval.
-    int32 maximum_interval_in_seconds = 3;
+    google.protobuf.Duration maximum_interval = 3 [(gogoproto.stdduration) = true];
     // Maximum number of attempts. When exceeded the retries stop even if not expired yet.
     // 1 disables retries. 0 means unlimited (up to the timeouts)
     int32 maximum_attempts = 4;

--- a/temporal/api/filter/v1/message.proto
+++ b/temporal/api/filter/v1/message.proto
@@ -30,6 +30,10 @@ option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 option ruby_package = "Temporal::Api::Filter::V1";
 
+import "google/protobuf/timestamp.proto";
+
+import "dependencies/gogoproto/v1/gogo.proto";
+
 import "temporal/api/enums/v1/workflow.proto";
 
 message WorkflowExecutionFilter {
@@ -42,8 +46,8 @@ message WorkflowTypeFilter {
 }
 
 message StartTimeFilter {
-    int64 earliest_time = 1;
-    int64 latest_time = 2;
+    google.protobuf.Timestamp earliest_time = 1 [(gogoproto.stdtime) = true];
+    google.protobuf.Timestamp latest_time = 2 [(gogoproto.stdtime) = true];
 }
 
 message StatusFilter {

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -30,6 +30,11 @@ option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 option ruby_package = "Temporal::Api::History::V1";
 
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+
+import "dependencies/gogoproto/v1/gogo.proto";
+
 import "temporal/api/enums/v1/event_type.proto";
 import "temporal/api/enums/v1/failed_cause.proto";
 import "temporal/api/enums/v1/workflow.proto";
@@ -46,11 +51,11 @@ message WorkflowExecutionStartedEventAttributes {
     temporal.api.taskqueue.v1.TaskQueue task_queue = 5;
     temporal.api.common.v1.Payloads input = 6;
     // Total workflow execution timeout including retries and continue as new.
-    int32 workflow_execution_timeout_seconds = 7;
+    google.protobuf.Duration workflow_execution_timeout = 7 [(gogoproto.stdduration) = true];
     // Timeout of a single workflow run.
-    int32 workflow_run_timeout_seconds = 8;
+    google.protobuf.Duration workflow_run_timeout = 8 [(gogoproto.stdduration) = true];
     // Timeout of a single workflow task.
-    int32 workflow_task_timeout_seconds = 9;
+    google.protobuf.Duration workflow_task_timeout = 9 [(gogoproto.stdduration) = true];
     string continued_execution_run_id = 10;
     temporal.api.enums.v1.ContinueAsNewInitiator initiator = 11;
     temporal.api.failure.v1.Failure continued_failure = 12;
@@ -64,9 +69,9 @@ message WorkflowExecutionStartedEventAttributes {
     int32 attempt = 18;
     // The absolute time at which workflow is timed out.
     // This time is passed without change to the next run/retry of a workflow.
-    int64 workflow_execution_expiration_timestamp = 19;
+    google.protobuf.Timestamp workflow_execution_expiration_time = 19 [(gogoproto.stdtime) = true];
     string cron_schedule = 20;
-    int32 first_workflow_task_backoff_seconds = 21;
+    google.protobuf.Duration first_workflow_task_backoff = 21 [(gogoproto.stdduration) = true];
     temporal.api.common.v1.Memo memo = 22;
     temporal.api.common.v1.SearchAttributes search_attributes = 23;
     temporal.api.workflow.v1.ResetPoints prev_auto_reset_points = 24;
@@ -95,11 +100,11 @@ message WorkflowExecutionContinuedAsNewEventAttributes {
     temporal.api.common.v1.Payloads input = 4;
     // workflow_execution_timeout is omitted as it shouldn'be overridden from within a workflow.
     // Timeout of a single workflow run.
-    int32 workflow_run_timeout_seconds = 5;
+    google.protobuf.Duration workflow_run_timeout = 5 [(gogoproto.stdduration) = true];
     // Timeout of a single workflow task.
-    int32 workflow_task_timeout_seconds = 6;
+    google.protobuf.Duration workflow_task_timeout = 6 [(gogoproto.stdduration) = true];
     int64 workflow_task_completed_event_id = 7;
-    int32 backoff_start_interval_in_seconds = 8;
+    google.protobuf.Duration backoff_start_interval = 8 [(gogoproto.stdduration) = true];
     temporal.api.enums.v1.ContinueAsNewInitiator initiator = 9;
     temporal.api.failure.v1.Failure failure = 10;
     temporal.api.common.v1.Payloads last_completion_result = 11;
@@ -110,7 +115,7 @@ message WorkflowExecutionContinuedAsNewEventAttributes {
 
 message WorkflowTaskScheduledEventAttributes {
     temporal.api.taskqueue.v1.TaskQueue task_queue = 1;
-    int32 start_to_close_timeout_seconds = 2;
+    google.protobuf.Duration start_to_close_timeout = 2 [(gogoproto.stdduration) = true];
     int64 attempt = 3;
 }
 
@@ -155,16 +160,16 @@ message ActivityTaskScheduledEventAttributes {
     temporal.api.common.v1.Payloads input = 6;
     // Indicates how long the caller is willing to wait for an activity completion.
     // Limits for how long retries are happening. Either this or start_to_close_timeout_seconds must be specified.
-    int32 schedule_to_close_timeout_seconds = 7;
+    google.protobuf.Duration schedule_to_close_timeout = 7 [(gogoproto.stdduration) = true];
     // Limits time an activity task can stay in a task queue before a worker picks it up.
     // This timeout is always non retryable as all a retry would achieve is to put it back into the same queue.
     // Defaults to schedule_to_close_timeout_seconds or workflow execution timeout if not specified.
-    int32 schedule_to_start_timeout_seconds = 8;
+    google.protobuf.Duration schedule_to_start_timeout = 8 [(gogoproto.stdduration) = true];
     // Maximum time an activity is allowed to execute after a pick up by a worker.
     // This timeout is always retryable. Either this or schedule_to_close_timeout_seconds must be specified.
-    int32 start_to_close_timeout_seconds = 9;
+    google.protobuf.Duration start_to_close_timeout = 9 [(gogoproto.stdduration) = true];
     // Maximum time between successful worker heartbeats.
-    int32 heartbeat_timeout_seconds = 10;
+    google.protobuf.Duration heartbeat_timeout = 10 [(gogoproto.stdduration) = true];
     int64 workflow_task_completed_event_id = 11;
     // Activities are provided by a default retry policy controlled through the service dynamic configuration.
     // Retries are happening up to schedule_to_close_timeout.
@@ -218,7 +223,7 @@ message ActivityTaskCanceledEventAttributes {
 
 message TimerStartedEventAttributes {
     string timer_id = 1;
-    int64 start_to_fire_timeout_seconds = 2;
+    google.protobuf.Duration start_to_fire_timeout = 2 [(gogoproto.stdduration) = true];
     int64 workflow_task_completed_event_id = 3;
 }
 
@@ -327,11 +332,11 @@ message StartChildWorkflowExecutionInitiatedEventAttributes {
     temporal.api.taskqueue.v1.TaskQueue task_queue = 4;
     temporal.api.common.v1.Payloads input = 5;
     // Total workflow execution timeout including retries and continue as new.
-    int32 workflow_execution_timeout_seconds = 6;
+    google.protobuf.Duration workflow_execution_timeout = 6 [(gogoproto.stdduration) = true];
     // Timeout of a single workflow run.
-    int32 workflow_run_timeout_seconds = 7;
+    google.protobuf.Duration workflow_run_timeout = 7 [(gogoproto.stdduration) = true];
     // Timeout of a single workflow task.
-    int32 workflow_task_timeout_seconds = 8;
+    google.protobuf.Duration workflow_task_timeout = 8 [(gogoproto.stdduration) = true];
     // Default: PARENT_CLOSE_POLICY_TERMINATE.
     temporal.api.enums.v1.ParentClosePolicy parent_close_policy = 9;
     string control = 10;
@@ -410,7 +415,7 @@ message ChildWorkflowExecutionTerminatedEventAttributes {
 
 message HistoryEvent {
     int64 event_id = 1;
-    int64 timestamp = 2;
+    google.protobuf.Timestamp event_time = 2 [(gogoproto.stdtime) = true];
     temporal.api.enums.v1.EventType event_type = 3;
     int64 version = 4;
     int64 task_id = 5;

--- a/temporal/api/namespace/v1/message.proto
+++ b/temporal/api/namespace/v1/message.proto
@@ -30,8 +30,13 @@ option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 option ruby_package = "Temporal::Api::Namespace::V1";
 
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+
+import "dependencies/gogoproto/v1/gogo.proto";
+
 import "temporal/api/enums/v1/namespace.proto";
-import "google/protobuf/wrappers.proto";
+
 
 message NamespaceInfo {
     string name = 1;
@@ -44,7 +49,7 @@ message NamespaceInfo {
 }
 
 message NamespaceConfig {
-    int32 workflow_execution_retention_period_in_days = 1;
+    google.protobuf.Duration workflow_execution_retention_ttl = 1 [(gogoproto.stdduration) = true];
     BadBinaries bad_binaries = 2;
     // If unspecified (ARCHIVAL_STATE_UNSPECIFIED) then default server configuration is used.
     temporal.api.enums.v1.ArchivalState history_archival_state = 3;
@@ -61,7 +66,7 @@ message BadBinaries {
 message BadBinaryInfo {
     string reason = 1;
     string operator = 2;
-    int64 create_time_nano = 3;
+    google.protobuf.Timestamp create_time = 3 [(gogoproto.stdtime) = true];
 }
 
 message UpdateNamespaceInfo {

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -30,8 +30,13 @@ option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 option ruby_package = "Temporal::Api::TaskQueue::V1";
 
-import "temporal/api/enums/v1/task_queue.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
+
+import "dependencies/gogoproto/v1/gogo.proto";
+
+import "temporal/api/enums/v1/task_queue.proto";
 
 message TaskQueue {
     string name = 1;
@@ -63,12 +68,12 @@ message TaskQueuePartitionMetadata {
 
 message PollerInfo {
     // Unix Nano
-    int64 last_access_time = 1;
+    google.protobuf.Timestamp last_access_time = 1 [(gogoproto.stdtime) = true];
     string identity = 2;
     double rate_per_second = 3;
 }
 
 message StickyExecutionAttributes {
     TaskQueue worker_task_queue = 1;
-    int32 schedule_to_start_timeout_seconds = 2;
+    google.protobuf.Duration schedule_to_start_timeout = 2 [(gogoproto.stdduration) = true];
 }

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -30,22 +30,26 @@ option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 option ruby_package = "Temporal::Api::Workflow::V1";
 
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+
+import "dependencies/gogoproto/v1/gogo.proto";
+
 import "temporal/api/enums/v1/workflow.proto";
 import "temporal/api/common/v1/message.proto";
 import "temporal/api/failure/v1/message.proto";
 import "temporal/api/taskqueue/v1/message.proto";
-import "google/protobuf/wrappers.proto";
 
 message WorkflowExecutionInfo {
     temporal.api.common.v1.WorkflowExecution execution = 1;
     temporal.api.common.v1.WorkflowType type = 2;
-    google.protobuf.Int64Value start_time = 3;
-    google.protobuf.Int64Value close_time = 4;
+    google.protobuf.Timestamp start_time = 3 [(gogoproto.stdtime) = true];
+    google.protobuf.Timestamp close_time = 4 [(gogoproto.stdtime) = true];
     temporal.api.enums.v1.WorkflowExecutionStatus status = 5;
     int64 history_length = 6;
     string parent_namespace_id = 7;
     temporal.api.common.v1.WorkflowExecution parent_execution = 8;
-    int64 execution_time = 9;
+    google.protobuf.Timestamp execution_time = 9 [(gogoproto.stdtime) = true];
     temporal.api.common.v1.Memo memo = 10;
     temporal.api.common.v1.SearchAttributes search_attributes = 11;
     ResetPoints auto_reset_points = 12;
@@ -54,9 +58,9 @@ message WorkflowExecutionInfo {
 
 message WorkflowExecutionConfig {
     temporal.api.taskqueue.v1.TaskQueue task_queue = 1;
-    int32 workflow_execution_timeout_seconds = 2;
-    int32 workflow_run_timeout_seconds = 3;
-    int32 default_workflow_task_timeout_seconds = 4;
+    google.protobuf.Duration workflow_execution_timeout = 2 [(gogoproto.stdduration) = true];
+    google.protobuf.Duration workflow_run_timeout = 3 [(gogoproto.stdduration) = true];
+    google.protobuf.Duration default_workflow_task_timeout = 4 [(gogoproto.stdduration) = true];
 }
 
 message PendingActivityInfo {
@@ -64,12 +68,12 @@ message PendingActivityInfo {
     temporal.api.common.v1.ActivityType activity_type = 2;
     temporal.api.enums.v1.PendingActivityState state = 3;
     temporal.api.common.v1.Payloads heartbeat_details = 4;
-    int64 last_heartbeat_timestamp = 5;
-    int64 last_started_timestamp = 6;
+    google.protobuf.Timestamp last_heartbeat_time = 5 [(gogoproto.stdtime) = true];
+    google.protobuf.Timestamp last_started_time = 6 [(gogoproto.stdtime) = true];
     int32 attempt = 7;
     int32 maximum_attempts = 8;
-    int64 scheduled_timestamp = 9;
-    int64 expiration_timestamp = 10;
+    google.protobuf.Timestamp scheduled_time = 9 [(gogoproto.stdtime) = true];
+    google.protobuf.Timestamp expiration_time = 10 [(gogoproto.stdtime) = true];
     temporal.api.failure.v1.Failure last_failure = 11;
     string last_worker_identity = 12;
 }
@@ -91,9 +95,9 @@ message ResetPointInfo {
     string binary_checksum = 1;
     string run_id = 2;
     int64 first_workflow_task_completed_id = 3;
-    int64 create_time_nano = 4;
+    google.protobuf.Timestamp create_time = 4 [(gogoproto.stdtime) = true];
     // The time that the run is deleted due to retention.
-    int64 expire_time_nano = 5;
+    google.protobuf.Timestamp expire_time = 5 [(gogoproto.stdtime) = true];
     // false if the reset point has pending childWFs/reqCancels/signalExternals.
     bool resettable = 6;
 }

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -30,6 +30,11 @@ option java_multiple_files = true;
 option java_outer_classname = "RequestResponseProto";
 option ruby_package = "Temporal::Api::WorkflowService::V1";
 
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+
+import "dependencies/gogoproto/v1/gogo.proto";
+
 import "temporal/api/enums/v1/workflow.proto";
 import "temporal/api/enums/v1/namespace.proto";
 import "temporal/api/enums/v1/failed_cause.proto";
@@ -52,7 +57,7 @@ message RegisterNamespaceRequest {
     string name = 1;
     string description = 2;
     string owner_email = 3;
-    int32 workflow_execution_retention_period_days = 4;
+    google.protobuf.Duration workflow_execution_retention_period = 4 [(gogoproto.stdduration) = true];
     repeated temporal.api.replication.v1.ClusterReplicationConfig clusters = 5;
     string active_cluster_name = 6;
     // A key-value map for any customized purpose.
@@ -129,11 +134,11 @@ message StartWorkflowExecutionRequest {
     temporal.api.taskqueue.v1.TaskQueue task_queue = 4;
     temporal.api.common.v1.Payloads input = 5;
     // Total workflow execution timeout including retries and continue as new.
-    int32 workflow_execution_timeout_seconds = 6;
+    google.protobuf.Duration workflow_execution_timeout = 6 [(gogoproto.stdduration) = true];
     // Timeout of a single workflow run.
-    int32 workflow_run_timeout_seconds = 7;
+    google.protobuf.Duration workflow_run_timeout = 7 [(gogoproto.stdduration) = true];
     // Timeout of a single workflow task.
-    int32 workflow_task_timeout_seconds = 8;
+    google.protobuf.Duration workflow_task_timeout = 8 [(gogoproto.stdduration) = true];
     string identity = 9;
     string request_id = 10;
     // Default: WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE.
@@ -187,8 +192,8 @@ message PollWorkflowTaskQueueResponse {
     bytes next_page_token = 9;
     temporal.api.query.v1.WorkflowQuery query = 10;
     temporal.api.taskqueue.v1.TaskQueue workflow_execution_task_queue = 11;
-    int64 scheduled_timestamp = 12;
-    int64 started_timestamp = 13;
+    google.protobuf.Timestamp scheduled_time = 12 [(gogoproto.stdtime) = true];
+    google.protobuf.Timestamp started_time = 13 [(gogoproto.stdtime) = true];
     map<string, temporal.api.query.v1.WorkflowQuery> queries = 14;
 }
 
@@ -235,17 +240,17 @@ message PollActivityTaskQueueResponse {
     temporal.api.common.v1.Header header = 7;
     temporal.api.common.v1.Payloads input = 8;
     temporal.api.common.v1.Payloads heartbeat_details = 9;
-    int64 scheduled_timestamp = 10;
+    google.protobuf.Timestamp scheduled_time = 10 [(gogoproto.stdtime) = true];
     int64 scheduled_timestamp_this_attempt = 11;
-    int64 started_timestamp = 12;
+    google.protobuf.Timestamp started_time = 12 [(gogoproto.stdtime) = true];
     int32 attempt = 13;
     // (-- api-linter: core::0140::prepositions=disabled
     //     aip.dev/not-precedent: "to" is used to indicate interval. --)
-    int32 schedule_to_close_timeout_seconds = 14;
+    google.protobuf.Duration schedule_to_close_timeout = 14 [(gogoproto.stdduration) = true];
     // (-- api-linter: core::0140::prepositions=disabled
     //     aip.dev/not-precedent: "to" is used to indicate interval. --)
-    int32 start_to_close_timeout_seconds = 15;
-    int32 heartbeat_timeout_seconds = 16;
+    google.protobuf.Duration start_to_close_timeout = 15 [(gogoproto.stdduration) = true];
+    google.protobuf.Duration heartbeat_timeout = 16 [(gogoproto.stdduration) = true];
     // This is an actual retry policy the service uses.
     // It can be different from the one provided (or not) during activity scheduling
     // as the service can override the provided one in case its values are not specified
@@ -369,11 +374,11 @@ message SignalWithStartWorkflowExecutionRequest {
     temporal.api.taskqueue.v1.TaskQueue task_queue = 4;
     temporal.api.common.v1.Payloads input = 5;
     // Total workflow execution timeout including retries and continue as new
-    int32 workflow_execution_timeout_seconds = 6;
+    google.protobuf.Duration workflow_execution_timeout = 6 [(gogoproto.stdduration) = true];
     // Timeout of a single workflow run
-    int32 workflow_run_timeout_seconds = 7;
+    google.protobuf.Duration workflow_run_timeout = 7 [(gogoproto.stdduration) = true];
     // Timeout of a single workflow task
-    int32 workflow_task_timeout_seconds = 8;
+    google.protobuf.Duration workflow_task_timeout = 8 [(gogoproto.stdduration) = true];
     string identity = 9;
     string request_id = 10;
     temporal.api.enums.v1.WorkflowIdReusePolicy workflow_id_reuse_policy = 11;


### PR DESCRIPTION
- Move all Times/Durations to use correct `google.protobuf` WKTs
- Use gogo extension for Go Time/Duration generation in Golang
  - Add gogo.proto dependencies file until we can fetch this at build time
- Rename various fields to support lint rules