### PR TITLE
Revert "Add pollers to workflow service's ListTaskQueuePartitionsRequest"

### DIFF
--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -574,7 +574,6 @@ message GetClusterInfoResponse {
 message ListTaskQueuePartitionsRequest {
     string namespace = 1;
     temporal.api.taskqueue.v1.TaskQueue task_queue = 2;
-    repeated temporal.api.taskqueue.v1.PollerInfo pollers = 3;
 }
 
 message ListTaskQueuePartitionsResponse {


### PR DESCRIPTION
Reverts temporalio/api#83

new plan, we won't be checking for # of pollers when listing partitions, so reverting this change.