### PR TITLE
Change go_package path in gogo.proto to original one

### DIFF
--- a/dependencies/gogoproto/gogo.proto
+++ b/dependencies/gogoproto/gogo.proto
@@ -31,7 +31,7 @@ package gogoproto;
 
 import "google/protobuf/descriptor.proto";
 
-option go_package = "go.temporal.io/api/dependencies/gogoproto;gogoproto";
+option go_package = "github.com/gogo/protobuf/gogoproto";
 
 extend google.protobuf.EnumOptions {
     optional bool goproto_enum_prefix = 62001;
@@ -138,5 +138,4 @@ extend google.protobuf.FieldOptions {
     optional bool stdtime = 65010;
     optional bool stdduration = 65011;
     optional bool wktpointer = 65012;
-
 }


### PR DESCRIPTION
Having custom go package name cause duplicate extension registration.
Closes https://github.com/temporalio/go-sdk/issues/236.