### PR TITLE
Rename "name" fields of namespace related request messages to "namespace"

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -8,4 +8,4 @@ lint:
     - DEFAULT
 breaking:
   use:
-    - PACKAGE
+    - WIRE

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -54,7 +54,7 @@ import "temporal/api/taskqueue/v1/message.proto";
 import "temporal/api/version/v1/message.proto";
 
 message RegisterNamespaceRequest {
-    string name = 1;
+    string namespace = 1;
     string description = 2;
     string owner_email = 3;
     google.protobuf.Duration workflow_execution_retention_period = 4 [(gogoproto.stdduration) = true];
@@ -86,7 +86,7 @@ message ListNamespacesResponse {
 }
 
 message DescribeNamespaceRequest {
-    string name = 1;
+    string namespace = 1;
     string id = 2;
 }
 
@@ -103,7 +103,7 @@ message DescribeNamespaceResponse {
 // (-- api-linter: core::0134::request-resource-required=disabled
 //     aip.dev/not-precedent: UpdateNamespace RPC doesn't follow Google API format. --)
 message UpdateNamespaceRequest {
-    string name = 1;
+    string namespace = 1;
     temporal.api.namespace.v1.UpdateNamespaceInfo update_info = 2;
     temporal.api.namespace.v1.NamespaceConfig config = 3;
     temporal.api.replication.v1.NamespaceReplicationConfig replication_config = 4;
@@ -120,7 +120,7 @@ message UpdateNamespaceResponse {
 }
 
 message DeprecateNamespaceRequest {
-    string name = 1;
+    string namespace = 1;
     string security_token = 2;
 }
 


### PR DESCRIPTION
To allow for unified access to namespace values of requests without first discriminating between namespace-related and workflow-related API calls.

This shouldn't break the wire protocol because the fields don't change their type or sequence number, only names.
