### PR TITLE
Add namespace to RespondActivityTask* requests

### DIFF
--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -285,6 +285,7 @@ message RespondActivityTaskCompletedRequest {
     bytes task_token = 1;
     temporal.api.common.v1.Payloads result = 2;
     string identity = 3;
+    string namespace = 4;
 }
 
 message RespondActivityTaskCompletedResponse {
@@ -306,6 +307,7 @@ message RespondActivityTaskFailedRequest {
     bytes task_token = 1;
     temporal.api.failure.v1.Failure failure = 2;
     string identity = 3;
+    string namespace = 4;
 }
 
 message RespondActivityTaskFailedResponse {
@@ -327,6 +329,7 @@ message RespondActivityTaskCanceledRequest {
     bytes task_token = 1;
     temporal.api.common.v1.Payloads details = 2;
     string identity = 3;
+    string namespace = 4;
 }
 
 message RespondActivityTaskCanceledResponse {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -262,6 +262,7 @@ message RecordActivityTaskHeartbeatRequest {
     bytes task_token = 1;
     temporal.api.common.v1.Payloads details = 2;
     string identity = 3;
+    string namespace = 4;
 }
 
 message RecordActivityTaskHeartbeatResponse {


### PR DESCRIPTION
This is how client will pass the namespace it is configured for as part of those requests. Will help us detect mismatches between that namespace and one in the token.