### PR TITLE
Add namespace field to more API calls

### DIFF
--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -206,6 +206,7 @@ message RespondWorkflowTaskCompletedRequest {
     bool force_create_new_workflow_task = 6;
     string binary_checksum = 7;
     map<string, temporal.api.query.v1.WorkflowQueryResult> query_results = 8;
+    string namespace = 9;
 }
 
 message RespondWorkflowTaskCompletedResponse {
@@ -218,6 +219,7 @@ message RespondWorkflowTaskFailedRequest {
     temporal.api.failure.v1.Failure failure = 3;
     string identity = 4;
     string binary_checksum = 5;
+    string namespace = 6;
 }
 
 message RespondWorkflowTaskFailedResponse {
@@ -518,6 +520,7 @@ message RespondQueryTaskCompletedRequest {
     temporal.api.common.v1.Payloads query_result = 3;
     string error_message = 4;
     reserved 5;
+    string namespace = 6;
 }
 
 message RespondQueryTaskCompletedResponse {


### PR DESCRIPTION
This is a follow-up to #101. 

RespondQueryTaskCompletedRequest
RespondWorkflowTaskCompletedRequest
RespondWorkflowTaskFailedRequest