### PR TITLE
Re-order import so @grpc/proto-loader works

### DIFF
--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -30,11 +30,6 @@ option java_multiple_files = true;
 option java_outer_classname = "RequestResponseProto";
 option ruby_package = "Temporal::Api::WorkflowService::V1";
 
-import "google/protobuf/duration.proto";
-import "google/protobuf/timestamp.proto";
-
-import "dependencies/gogoproto/gogo.proto";
-
 import "temporal/api/enums/v1/workflow.proto";
 import "temporal/api/enums/v1/namespace.proto";
 import "temporal/api/enums/v1/failed_cause.proto";
@@ -52,6 +47,11 @@ import "temporal/api/query/v1/message.proto";
 import "temporal/api/replication/v1/message.proto";
 import "temporal/api/taskqueue/v1/message.proto";
 import "temporal/api/version/v1/message.proto";
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+
+import "dependencies/gogoproto/gogo.proto";
 
 message RegisterNamespaceRequest {
     string namespace = 1;


### PR DESCRIPTION
In [this post](https://community.temporal.io/t/how-to-do-operations-tctl-can-do-from-any-programming-language/1256/4), @mfateev told me to use this project with Node grpc to call the service.
I followed [the tutorial](https://www.grpc.io/docs/languages/node/basics/) but found this strange problem.
I added this project using git submodule to a folder called `api` and used the following code to load package definition. It fails out of the box but works with the changes in the pull request, which did nothing but re-order the import

```javascript
const grpc = require('@grpc/grpc-js')
const protoLoader = require('@grpc/proto-loader');

const PROTO_PATH = './api/temporal/api/workflowservice/v1/service.proto'

const packageDefinition = protoLoader.loadSync(
    PROTO_PATH,
    {
        keepCase: true,
        longs: String,
        enums: String,
        defaults: true,
        oneofs: true,
        includeDirs: ['./api']
    }
)
const protoDescriptor = grpc.loadPackageDefinition(packageDefinition).temporal.api.workflowservice.v1
```