### PR TITLE
Adding csharp_namespace for future dotnet package

### DIFF
--- a/temporal/api/command/v1/message.proto
+++ b/temporal/api/command/v1/message.proto
@@ -29,6 +29,7 @@ option java_package = "io.temporal.api.command.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 option ruby_package = "Temporal::Api::Command::V1";
+option csharp_namespace = "Temporal.Api.Command.V1";
 
 import "google/protobuf/duration.proto";
 

--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -29,6 +29,7 @@ option java_package = "io.temporal.api.common.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 option ruby_package = "Temporal::Api::Common::V1";
+option csharp_namespace = "Temporal.Api.Common.V1";
 
 import "google/protobuf/duration.proto";
 

--- a/temporal/api/enums/v1/command_type.proto
+++ b/temporal/api/enums/v1/command_type.proto
@@ -29,6 +29,7 @@ option java_package = "io.temporal.api.enums.v1";
 option java_multiple_files = true;
 option java_outer_classname = "CommandTypeProto";
 option ruby_package = "Temporal::Api::Enums::V1";
+option csharp_namespace = "Temporal.Api.Enums.V1";
 
 // Whenever this list of command types is changed do change the function shouldBufferEvent in mutableStateBuilder.go to make sure to do the correct event ordering.
 enum CommandType {

--- a/temporal/api/enums/v1/common.proto
+++ b/temporal/api/enums/v1/common.proto
@@ -29,6 +29,7 @@ option java_package = "io.temporal.api.enums.v1";
 option java_multiple_files = true;
 option java_outer_classname = "CommonProto";
 option ruby_package = "Temporal::Api::Enums::V1";
+option csharp_namespace = "Temporal.Api.Enums.V1";
 
 enum EncodingType {
     ENCODING_TYPE_UNSPECIFIED = 0;

--- a/temporal/api/enums/v1/event_type.proto
+++ b/temporal/api/enums/v1/event_type.proto
@@ -29,6 +29,7 @@ option java_package = "io.temporal.api.enums.v1";
 option java_multiple_files = true;
 option java_outer_classname = "EventTypeProto";
 option ruby_package = "Temporal::Api::Enums::V1";
+option csharp_namespace = "Temporal.Api.Enums.V1";
 
 // Whenever this list of events is changed do change the function shouldBufferEvent in mutableStateBuilder.go to make sure to do the correct event ordering.
 enum EventType {

--- a/temporal/api/enums/v1/failed_cause.proto
+++ b/temporal/api/enums/v1/failed_cause.proto
@@ -29,6 +29,7 @@ option java_package = "io.temporal.api.enums.v1";
 option java_multiple_files = true;
 option java_outer_classname = "FailedCauseProto";
 option ruby_package = "Temporal::Api::Enums::V1";
+option csharp_namespace = "Temporal.Api.Enums.V1";
 
 enum WorkflowTaskFailedCause {
     WORKFLOW_TASK_FAILED_CAUSE_UNSPECIFIED = 0;

--- a/temporal/api/enums/v1/namespace.proto
+++ b/temporal/api/enums/v1/namespace.proto
@@ -29,6 +29,7 @@ option java_package = "io.temporal.api.enums.v1";
 option java_multiple_files = true;
 option java_outer_classname = "NamespaceProto";
 option ruby_package = "Temporal::Api::Enums::V1";
+option csharp_namespace = "Temporal.Api.Enums.V1";
 
 enum NamespaceState {
     NAMESPACE_STATE_UNSPECIFIED = 0;

--- a/temporal/api/enums/v1/query.proto
+++ b/temporal/api/enums/v1/query.proto
@@ -29,6 +29,7 @@ option java_package = "io.temporal.api.enums.v1";
 option java_multiple_files = true;
 option java_outer_classname = "QueryProto";
 option ruby_package = "Temporal::Api::Enums::V1";
+option csharp_namespace = "Temporal.Api.Enums.V1";
 
 enum QueryResultType {
     QUERY_RESULT_TYPE_UNSPECIFIED = 0;

--- a/temporal/api/enums/v1/task_queue.proto
+++ b/temporal/api/enums/v1/task_queue.proto
@@ -29,6 +29,7 @@ option java_package = "io.temporal.api.enums.v1";
 option java_multiple_files = true;
 option java_outer_classname = "TaskQueueProto";
 option ruby_package = "Temporal::Api::Enums::V1";
+option csharp_namespace = "Temporal.Api.Enums.V1";
 
 enum TaskQueueKind {
     TASK_QUEUE_KIND_UNSPECIFIED = 0;

--- a/temporal/api/enums/v1/workflow.proto
+++ b/temporal/api/enums/v1/workflow.proto
@@ -29,6 +29,7 @@ option java_package = "io.temporal.api.enums.v1";
 option java_multiple_files = true;
 option java_outer_classname = "WorkflowProto";
 option ruby_package = "Temporal::Api::Enums::V1";
+option csharp_namespace = "Temporal.Api.Enums.V1";
 
 enum WorkflowIdReusePolicy {
     WORKFLOW_ID_REUSE_POLICY_UNSPECIFIED = 0;

--- a/temporal/api/errordetails/v1/message.proto
+++ b/temporal/api/errordetails/v1/message.proto
@@ -31,6 +31,7 @@ option java_package = "io.temporal.api.errordetails.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 option ruby_package = "Temporal::Api::ErrorDetails::V1";
+option csharp_namespace = "Temporal.Api.ErrorDetails.V1";
 
 message NotFoundFailure {
     string current_cluster = 1;

--- a/temporal/api/failure/v1/message.proto
+++ b/temporal/api/failure/v1/message.proto
@@ -29,6 +29,7 @@ option java_package = "io.temporal.api.failure.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 option ruby_package = "Temporal::Api::Failure::V1";
+option csharp_namespace = "Temporal.Api.Failure.V1";
 
 import "temporal/api/common/v1/message.proto";
 import "temporal/api/enums/v1/workflow.proto";

--- a/temporal/api/filter/v1/message.proto
+++ b/temporal/api/filter/v1/message.proto
@@ -29,6 +29,7 @@ option java_package = "io.temporal.api.filter.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 option ruby_package = "Temporal::Api::Filter::V1";
+option csharp_namespace = "Temporal.Api.Filter.V1";
 
 import "google/protobuf/timestamp.proto";
 

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -29,6 +29,7 @@ option java_package = "io.temporal.api.history.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 option ruby_package = "Temporal::Api::History::V1";
+option csharp_namespace = "Temporal.Api.History.V1";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";

--- a/temporal/api/namespace/v1/message.proto
+++ b/temporal/api/namespace/v1/message.proto
@@ -29,6 +29,7 @@ option java_package = "io.temporal.api.namespace.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 option ruby_package = "Temporal::Api::Namespace::V1";
+option csharp_namespace = "Temporal.Api.Namespace.V1";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";

--- a/temporal/api/query/v1/message.proto
+++ b/temporal/api/query/v1/message.proto
@@ -29,6 +29,7 @@ option java_package = "io.temporal.api.query.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 option ruby_package = "Temporal::Api::Query::V1";
+option csharp_namespace = "Temporal.Api.Query.V1";
 
 import "temporal/api/enums/v1/query.proto";
 import "temporal/api/enums/v1/workflow.proto";

--- a/temporal/api/replication/v1/message.proto
+++ b/temporal/api/replication/v1/message.proto
@@ -29,6 +29,7 @@ option java_package = "io.temporal.api.replication.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 option ruby_package = "Temporal::Api::Replication::V1";
+option csharp_namespace = "Temporal.Api.Replication.V1";
 
 message ClusterReplicationConfig {
     string cluster_name = 1;

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -29,6 +29,7 @@ option java_package = "io.temporal.api.taskqueue.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 option ruby_package = "Temporal::Api::TaskQueue::V1";
+option csharp_namespace = "Temporal.Api.TaskQueue.V1";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";

--- a/temporal/api/version/v1/message.proto
+++ b/temporal/api/version/v1/message.proto
@@ -29,6 +29,7 @@ option java_package = "io.temporal.api.version.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 option ruby_package = "Temporal::Api::Version::V1";
+option csharp_namespace = "Temporal.Api.Version.V1";
 
 import "google/protobuf/timestamp.proto";
 import "dependencies/gogoproto/gogo.proto";

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -29,6 +29,7 @@ option java_package = "io.temporal.api.workflow.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 option ruby_package = "Temporal::Api::Workflow::V1";
+option csharp_namespace = "Temporal.Api.Workflow.V1";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -29,6 +29,7 @@ option java_package = "io.temporal.api.workflowservice.v1";
 option java_multiple_files = true;
 option java_outer_classname = "RequestResponseProto";
 option ruby_package = "Temporal::Api::WorkflowService::V1";
+option csharp_namespace = "Temporal.Api.WorkflowService.V1";
 
 import "temporal/api/enums/v1/workflow.proto";
 import "temporal/api/enums/v1/namespace.proto";

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -29,6 +29,7 @@ option java_package = "io.temporal.api.workflowservice.v1";
 option java_multiple_files = true;
 option java_outer_classname = "ServiceProto";
 option ruby_package = "Temporal::Api::WorkflowService::V1";
+option csharp_namespace = "Temporal.Api.WorkflowService.V1";
 
 
 import "temporal/api/workflowservice/v1/request_response.proto";


### PR DESCRIPTION
To build in your `.csproj` be sure to:
 1. submodule in this repository
 2. add references to all the appropriate `.proto` files.

Example of `ItemGroup` in your `.csproj` file when temporal API is submoduled into `./lib/api`
```xml
  <ItemGroup>
    <Protobuf
            Include="../lib/api/dependencies/**/*.proto"
            ProtoRoot="../lib/api"
            Link="proto\%(RecursiveDir)"
            GrpcServices="Client" />
    <Protobuf
            Include="../lib/api/temporal/api/*/v1/*.proto"
            ProtoRoot="../lib/api"
            Link="proto\%(RecursiveDir)"
            GrpcServices="Client" />
  </ItemGroup>
```