### PR TITLE
Add state transition count to DescribeWorkflowExecution API

### DIFF
--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -55,6 +55,7 @@ message WorkflowExecutionInfo {
     temporal.api.common.v1.SearchAttributes search_attributes = 11;
     ResetPoints auto_reset_points = 12;
     string task_queue = 13;
+    int64 state_transitions = 14;
 }
 
 message WorkflowExecutionConfig {

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -55,7 +55,7 @@ message WorkflowExecutionInfo {
     temporal.api.common.v1.SearchAttributes search_attributes = 11;
     ResetPoints auto_reset_points = 12;
     string task_queue = 13;
-    int64 state_transitions = 14;
+    int64 state_transition_count = 14;
 }
 
 message WorkflowExecutionConfig {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add `state_transition_count` specifying total number of state transient of a workflow to `WorkflowExecutionInfo` message which will expose it with `DescribeWorkflowExecution` API.

<!-- Tell your future self why have you made these changes -->
**Why?**
For users to track number of state transitions for workflow.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.
