### PR TITLE
Add metadata_only to workflow listing queries

### DIFF
--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -57,6 +57,8 @@ message SearchAttributes {
 
 message Memo {
     map<string, Payload> fields = 1;
+    // Memo is present in visibility database, but was not returned in this response.
+    bool is_omitted = 2;
 }
 
 message Header {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -440,6 +440,7 @@ message ListOpenWorkflowExecutionsRequest {
         temporal.api.filter.v1.WorkflowExecutionFilter execution_filter = 5;
         temporal.api.filter.v1.WorkflowTypeFilter type_filter = 6;
     }
+    bool omit_memo = 7;
 }
 
 message ListOpenWorkflowExecutionsResponse {
@@ -457,6 +458,7 @@ message ListClosedWorkflowExecutionsRequest {
         temporal.api.filter.v1.WorkflowTypeFilter type_filter = 6;
         temporal.api.filter.v1.StatusFilter status_filter = 7;
     }
+    bool omit_memo = 8;
 }
 
 message ListClosedWorkflowExecutionsResponse {
@@ -469,6 +471,7 @@ message ListWorkflowExecutionsRequest {
     int32 page_size = 2;
     bytes next_page_token = 3;
     string query = 4;
+    bool omit_memo = 5;
 }
 
 message ListWorkflowExecutionsResponse {
@@ -481,6 +484,7 @@ message ListArchivedWorkflowExecutionsRequest {
     int32 page_size = 2;
     bytes next_page_token = 3;
     string query = 4;
+    bool omit_memo = 5;
 }
 
 message ListArchivedWorkflowExecutionsResponse {
@@ -493,6 +497,7 @@ message ScanWorkflowExecutionsRequest {
     int32 page_size = 2;
     bytes next_page_token = 3;
     string query = 4;
+    bool omit_memo = 5;
 }
 
 message ScanWorkflowExecutionsResponse {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Adding a `metadata_only` field to list workflows without fetching the `memo` fields, which can be very large.

<!-- Tell your future self why have you made these changes -->
**Why?**

To speed up workflow queries.
