### PR TITLE
Add new_execution_run_id to some workflow completion events

### DIFF
--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -57,6 +57,7 @@ message WorkflowExecutionStartedEventAttributes {
     google.protobuf.Duration workflow_run_timeout = 8 [(gogoproto.stdduration) = true];
     // Timeout of a single workflow task.
     google.protobuf.Duration workflow_task_timeout = 9 [(gogoproto.stdduration) = true];
+    // Run id of previous ContinueAsNew or retry or cron execution.
     string continued_execution_run_id = 10;
     temporal.api.enums.v1.ContinueAsNewInitiator initiator = 11;
     temporal.api.failure.v1.Failure continued_failure = 12;
@@ -82,16 +83,22 @@ message WorkflowExecutionStartedEventAttributes {
 message WorkflowExecutionCompletedEventAttributes {
     temporal.api.common.v1.Payloads result = 1;
     int64 workflow_task_completed_event_id = 2;
+    // If another run is started by cron, this contains the new run id.
+    string new_execution_run_id = 3;
 }
 
 message WorkflowExecutionFailedEventAttributes {
     temporal.api.failure.v1.Failure failure = 1;
     temporal.api.enums.v1.RetryState retry_state = 2;
     int64 workflow_task_completed_event_id = 3;
+    // If another run is started by cron or retry, this contains the new run id.
+    string new_execution_run_id = 4;
 }
 
 message WorkflowExecutionTimedOutEventAttributes {
     temporal.api.enums.v1.RetryState retry_state = 1;
+    // If another run is started by cron or retry, this contains the new run id.
+    string new_execution_run_id = 2;
 }
 
 message WorkflowExecutionContinuedAsNewEventAttributes {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Adding a field for completed/failed/timed-out workflow completion events to link to a next execution, in the case of retry or cron. (Currently canceled or terminated workflows can't have a next execution in that way, but if that changes we can add it there also.)

<!-- Tell your future self why have you made these changes -->
**Why?**

1. We want to be able to link to a potential next execution of retried or cron workflows once they're no longer using the continue-as-new event.
2. We need to know whether there is a next execution to tell whether to notify a parent workflow.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

