### PR TITLE
Add persistence store info to GetClusterInfoResponse

### DIFF
--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -588,6 +588,8 @@ message GetClusterInfoResponse {
     temporal.api.version.v1.VersionInfo version_info = 4;
     string cluster_name = 5;
     int32 history_shard_count = 6;
+    string persistence_store = 7;
+    string visibility_store = 8;
 }
 
 message ListTaskQueuePartitionsRequest {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add 2 new fields to GetClusterInfoResponse to expose the persistence store info.

<!-- Tell your future self why have you made these changes -->
**Why?**
WebUI could adjust the available functionality based on what backend is using. For example enable some features if visibility store is Elasticsearch.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

