### PR TITLE
Document WorkflowExecutionStartedEventAttributes.first_workflow_task_backoff

### DIFF
--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -81,7 +81,8 @@ message WorkflowExecutionStartedEventAttributes {
     google.protobuf.Timestamp workflow_execution_expiration_time = 19 [(gogoproto.stdtime) = true];
     // If this workflow runs on a cron schedule, it will appear here
     string cron_schedule = 20;
-    // TODO: What is this? Appears unused.
+    // For a cron workflow, this contains the amount of time between when this iteration of
+    // the cron workflow was scheduled and when it should run next per its cron_schedule.
     google.protobuf.Duration first_workflow_task_backoff = 21 [(gogoproto.stdduration) = true];
     temporal.api.common.v1.Memo memo = 22;
     temporal.api.common.v1.SearchAttributes search_attributes = 23;


### PR DESCRIPTION
**What changed?**
This commit adds documentation for a field that stripe uses. I found the TODO when I was writing a design doc and wanted to indicate that it's not unused.

**Why?**
Fewer TODOs are better!

**How did you test it?**
I didn't - it's a comment.

**Potential risks**
Maybe there's a linter that has opinions about what's in my comment and I'll find out when CI runs?
