### PR TITLE
Expose ReplicateWorkflowExecution as public API

### DIFF
--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -773,3 +773,11 @@ message ListTaskQueuePartitionsResponse {
     repeated temporal.api.taskqueue.v1.TaskQueuePartitionMetadata activity_task_queue_partitions = 1;
     repeated temporal.api.taskqueue.v1.TaskQueuePartitionMetadata workflow_task_queue_partitions = 2;
 }
+
+message ReplicateWorkflowExecutionRequest {
+    string namespace = 1;
+    temporal.api.common.v1.WorkflowExecution execution = 2;
+}
+
+message ReplicateWorkflowExecutionResponse {
+}

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -318,4 +318,11 @@ service WorkflowService {
 
     rpc ListTaskQueuePartitions(ListTaskQueuePartitionsRequest) returns (ListTaskQueuePartitionsResponse) {
     }
+
+    // ReplicateWorkflowExecution generates a replication task for requested workflow execution that can be consumed
+    // by remote cluster that are configured for the namespace. This method can be used to force replicate a workflow
+    // execution that is missing in remote cluster for whatever reason.
+    rpc ReplicateWorkflowExecution(ReplicateWorkflowExecutionRequest) returns (ReplicateWorkflowExecutionResponse) {
+    }
+
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add `ReplicateWorkflowExecution` to force generate a replication task for requested workflow.

<!-- Tell your future self why have you made these changes -->
**Why?**
Make this API available through frontend. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
eye_ball

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No
