### PR TITLE
Operator Service with Search Attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.idea
 /.gen
+/.vscode

--- a/api-linter.yaml
+++ b/api-linter.yaml
@@ -11,6 +11,7 @@
 
 - included_paths:
     - '**/workflowservice/v1/request_response.proto'
+    - '**/operatorservice/v1/request_response.proto'
   disabled_rules:
     - 'core::0122::name-suffix'
     - 'core::0131::request-name-required'
@@ -27,6 +28,7 @@
 
 - included_paths:
     - '**/workflowservice/v1/service.proto'
+    - '**/operatorservice/v1/service.proto'
   disabled_rules:
     - 'core::0127::http-annotation'
     - 'core::0131::method-signature'

--- a/temporal/api/errordetails/v1/message.proto
+++ b/temporal/api/errordetails/v1/message.proto
@@ -22,7 +22,8 @@
 
 syntax = "proto3";
 
-// These error details extend failures defined in https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto
+// These error details are supplied in google.rpc.Status#details as described in "Google APIs, Error Model" (https://cloud.google.com/apis/design/errors#error_model)
+// and extend standard Error Details defined in https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto
 
 package temporal.api.errordetails.v1;
 
@@ -33,6 +34,7 @@ option java_outer_classname = "MessageProto";
 option ruby_package = "Temporal::Api::ErrorDetails::V1";
 option csharp_namespace = "Temporal.Api.ErrorDetails.V1";
 
+import "temporal/api/common/v1/message.proto";
 import "temporal/api/enums/v1/failed_cause.proto";
 
 message NotFoundFailure {
@@ -77,4 +79,13 @@ message PermissionDeniedFailure {
 
 message ResourceExhaustedFailure {
     temporal.api.enums.v1.ResourceExhaustedCause cause = 1;
+}
+
+message AddSearchAttributesFailure {
+    // WorkflowId and RunId of the Temporal system workflow performing registration of the search attributes.
+    // Looking up the info of the system workflow run may help identify the issue causing the failure.
+    // WorkflowId is always "temporal-sys-add-search-attributes-workflow".
+    temporal.api.common.v1.WorkflowExecution system_workflow_execution = 1;
+    // Serialized error returned by the system workflow performing registration
+    string system_workflow_error = 2;
 }

--- a/temporal/api/operatorservice/v1/request_response.proto
+++ b/temporal/api/operatorservice/v1/request_response.proto
@@ -1,0 +1,64 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+syntax = "proto3";
+
+package temporal.api.operatorservice.v1;
+
+option go_package = "go.temporal.io/api/operatorservice/v1;operatorservice";
+option java_package = "io.temporal.api.operatorservice.v1";
+option java_multiple_files = true;
+option java_outer_classname = "RequestResponseProto";
+option ruby_package = "Temporal::Api::OperatorService::V1";
+option csharp_namespace = "Temporal.Api.OperatorService.V1";
+
+import "temporal/api/enums/v1/common.proto";
+
+// (-- Search Attribute --)
+
+message AddSearchAttributesRequest {
+    // Mapping between search attribute name and its IndexedValueType.
+    map<string, temporal.api.enums.v1.IndexedValueType> search_attributes = 1;
+}
+
+message AddSearchAttributesResponse {
+}
+
+message RemoveSearchAttributesRequest {
+    // Search attribute names to delete.
+    repeated string search_attributes = 1;
+}
+
+message RemoveSearchAttributesResponse {
+}
+
+message ListSearchAttributesRequest {
+}
+
+message ListSearchAttributesResponse {
+    // Mapping between custom (user-registered) search attribute name to its IndexedValueType.
+    map<string, temporal.api.enums.v1.IndexedValueType> custom_attributes = 1;
+    // Mapping between system (predefined) search attribute name to its IndexedValueType.
+    map<string, temporal.api.enums.v1.IndexedValueType> system_attributes = 2;
+    // Mapping from the attribute name to the visibility storage native type
+    map<string, string> storage_schema = 3;
+}

--- a/temporal/api/operatorservice/v1/service.proto
+++ b/temporal/api/operatorservice/v1/service.proto
@@ -1,0 +1,58 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+syntax = "proto3";
+
+package temporal.api.operatorservice.v1;
+
+option go_package = "go.temporal.io/api/operatorservice/v1;operatorservice";
+option java_package = "io.temporal.api.operatorservice.v1";
+option java_multiple_files = true;
+option java_outer_classname = "ServiceProto";
+option ruby_package = "Temporal::Api::OperatorService::V1";
+option csharp_namespace = "Temporal.Api.OperatorService.V1";
+
+
+import "temporal/api/operatorservice/v1/request_response.proto";
+
+// OperatorService API defines how Temporal SDKs and other clients interact with the Temporal server
+// to perform administrative functions like registering a search attribute or a namespace.
+// APIs in this file could be not compatible with Temporal Cloud, hence it's usage in SDKs should be limited by
+// designated APIs that clearly state that they shouldn't be used by the main Application (Workflows & Activities) framework.
+service OperatorService {
+    // (-- Search Attribute --)
+
+    // AddSearchAttributes add custom search attributes.
+    //
+    // If successful, returns AddSearchAttributesResponse.
+    // If fails, returns INTERNAL code with temporal.api.errordetails.v1.AddSearchAttributesFailure in Error Details
+    rpc AddSearchAttributes (AddSearchAttributesRequest) returns (AddSearchAttributesResponse) {
+    }
+
+    // RemoveSearchAttributes removes custom search attributes.
+    rpc RemoveSearchAttributes (RemoveSearchAttributesRequest) returns (RemoveSearchAttributesResponse) {
+    }
+
+    // GetSearchAttributes returns comprehensive information about search attributes.
+    rpc ListSearchAttributes (ListSearchAttributesRequest) returns (ListSearchAttributesResponse) {
+    }
+}


### PR DESCRIPTION
Creating an Operator API by moving Search Attribute endpoints from the Internal Server API and polishing it for 

OperatorService API defines how Temporal SDKs and other clients interact with the Temporal server
to perform administrative functions like registering a search attribute or a namespace.
APIs in this file could be not compatible with Temporal Cloud, hence its usage in SDKs should be limited by
designated APIs that clearly state that they shouldn't be used by the main Application (Workflows & Activities) framework.

This change should be safe for deployment as it doesn't change any of the existing APIs.

### Note for reviewers
This is the original SearchAttributes API that was polished to become public in this PR:
```
// AddSearchAttributes add custom search attributes and returns comprehensive information about them.
rpc AddSearchAttributes (AddSearchAttributesRequest) returns (AddSearchAttributesResponse) {}

// RemoveSearchAttributes removes custom search attributes and returns comprehensive information about them.
rpc RemoveSearchAttributes (RemoveSearchAttributesRequest) returns (RemoveSearchAttributesResponse) {}

// GetSearchAttributes returns comprehensive information about search attributes.
rpc GetSearchAttributes (GetSearchAttributesRequest) returns (GetSearchAttributesResponse) {}

message AddSearchAttributesRequest {
    map<string, temporal.api.enums.v1.IndexedValueType> search_attributes = 1;
    string index_name = 2;
    bool skip_schema_update = 3;
}

message AddSearchAttributesResponse {}

message RemoveSearchAttributesRequest {
    repeated string search_attributes = 1;
    string index_name = 2;
}

message RemoveSearchAttributesResponse {}

message GetSearchAttributesRequest {
    string index_name = 1;
}

message GetSearchAttributesResponse {
    map<string, temporal.api.enums.v1.IndexedValueType> custom_attributes = 1;
    map<string, temporal.api.enums.v1.IndexedValueType> system_attributes = 2;
    map<string, string> mapping = 3;
    // State of the workflow that adds search attributes to the system.
    temporal.api.workflow.v1.WorkflowExecutionInfo add_workflow_execution_info = 4;
}
```