### PR TITLE
Re-enable proto compatible check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ buf-lint:
 
 buf-breaking:
 	@printf $(COLOR) "Run buf breaking changes check against master branch..."	
-	#@(cd $(PROTO_ROOT) && buf breaking --against '.git#branch=master')
+	@(cd $(PROTO_ROOT) && buf breaking --against '.git#branch=master')
 
 ##### Clean #####
 clean:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Re-enable protobuf compatible check in make command

<!-- Tell your future self why have you made these changes -->
**Why?**
It was disabled in previous PR which is OK as the ResourceExhaustedCause was just added and not used yet.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

