### PR TITLE
Differentiate schedule_to_start/close timeouts

### DIFF
--- a/temporal/api/command/v1/message.proto
+++ b/temporal/api/command/v1/message.proto
@@ -49,12 +49,12 @@ message ScheduleActivityTaskCommandAttributes {
     temporal.api.common.v1.Header header = 5;
     temporal.api.common.v1.Payloads input = 6;
     // Indicates how long the caller is willing to wait for activity completion. The "schedule" time
-    // is when the activity is initially scheduled—not when the most recent retry is scheduled.
+    // is when the activity is initially scheduled, not when the most recent retry is scheduled.
     // Limits how long retries will be attempted. Either this or `start_to_close_timeout` must be
     // specified. When not specified, defaults to the workflow execution timeout.
     //
-    // (-- api-linter: core::0140::prepositions=disabled aip.dev/not-precedent: "to" is used to
-    //     indicate interval. --)
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: "to" is used to indicate interval. --)
     google.protobuf.Duration schedule_to_close_timeout = 7 [(gogoproto.stdduration) = true];
     // Limits the time an activity task can stay in a task queue before a worker picks it up. The
     // "schedule" time is when the most recent retry is scheduled. This timeout should usually not
@@ -64,8 +64,8 @@ message ScheduleActivityTaskCommandAttributes {
     // specified. More info:
     // https://docs.temporal.io/docs/content/what-is-a-schedule-to-start-timeout/
     //
-    // (-- api-linter: core::0140::prepositions=disabled aip.dev/not-precedent: "to" is used to
-    //     indicate interval. --)
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: "to" is used to indicate interval. --)
     google.protobuf.Duration schedule_to_start_timeout = 8 [(gogoproto.stdduration) = true];
     // Maximum time an activity is allowed to execute after being picked up by a worker. This
     // timeout is always retryable. Either this or `schedule_to_close_timeout` must be specified.

--- a/temporal/api/command/v1/message.proto
+++ b/temporal/api/command/v1/message.proto
@@ -48,20 +48,24 @@ message ScheduleActivityTaskCommandAttributes {
     temporal.api.taskqueue.v1.TaskQueue task_queue = 4;
     temporal.api.common.v1.Header header = 5;
     temporal.api.common.v1.Payloads input = 6;
-    // Indicates how long the caller is willing to wait for activity completion. Limits how long
-    // retries will be attempted. Either this or `start_to_close_timeout` must be specified. When
-    // not specified, defaults to the workflow execution timeout.
+    // Indicates how long the caller is willing to wait for activity completion. The "schedule" time
+    // is when the activity is initially scheduled—not when the most recent retry is scheduled.
+    // Limits how long retries will be attempted. Either this or `start_to_close_timeout` must be
+    // specified. When not specified, defaults to the workflow execution timeout.
     //
-    // (-- api-linter: core::0140::prepositions=disabled
-    //     aip.dev/not-precedent: "to" is used to indicate interval. --)
+    // (-- api-linter: core::0140::prepositions=disabled aip.dev/not-precedent: "to" is used to
+    //     indicate interval. --)
     google.protobuf.Duration schedule_to_close_timeout = 7 [(gogoproto.stdduration) = true];
-    // Limits the time an activity task can stay in a task queue before a worker picks it up. This
-    // timeout is always non retryable, as all a retry would achieve is to put it back into the same
-    // queue. Defaults to `schedule_to_close_timeout` or workflow execution timeout if that is not
-    // specified.
+    // Limits the time an activity task can stay in a task queue before a worker picks it up. The
+    // "schedule" time is when the most recent retry is scheduled. This timeout should usually not
+    // be set: it's useful in specific scenarios like worker-specific task queues. This timeout is
+    // always non retryable, as all a retry would achieve is to put it back into the same queue.
+    // Defaults to `schedule_to_close_timeout` or workflow execution timeout if that is not
+    // specified. More info:
+    // https://docs.temporal.io/docs/content/what-is-a-schedule-to-start-timeout/
     //
-    // (-- api-linter: core::0140::prepositions=disabled
-    //     aip.dev/not-precedent: "to" is used to indicate interval. --)
+    // (-- api-linter: core::0140::prepositions=disabled aip.dev/not-precedent: "to" is used to
+    //     indicate interval. --)
     google.protobuf.Duration schedule_to_start_timeout = 8 [(gogoproto.stdduration) = true];
     // Maximum time an activity is allowed to execute after being picked up by a worker. This
     // timeout is always retryable. Either this or `schedule_to_close_timeout` must be specified.


### PR DESCRIPTION
Updated comments to define "schedule" time