### PR TITLE
Add first_execution_run_id to missing requests and responses

### DIFF
--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -519,6 +519,10 @@ message SignalWorkflowExecutionRequest {
     // Headers that are passed with the signal to the processing workflow.
     // These can include things like auth or tracing tokens.
     temporal.api.common.v1.Header header = 8;
+    // If set, this call will error if the most recent (if no run id is set on
+    // `workflow_execution`), or specified (if it is) workflow execution is not part of the same
+    // execution chain as this id.
+    string first_execution_run_id = 9;
 }
 
 message SignalWorkflowExecutionResponse {
@@ -560,6 +564,10 @@ message SignalWithStartWorkflowExecutionRequest {
 
 message SignalWithStartWorkflowExecutionResponse {
     string run_id = 1;
+    // The first run_id of the current execution chain.
+    // This can be used in calls to signal, query, terminate, and cancel this Workflow to ensure
+    // that those requests only affect this execution chain.
+    string first_execution_run_id = 2;
 }
 
 message ResetWorkflowExecutionRequest {
@@ -708,6 +716,10 @@ message QueryWorkflowRequest {
     // QueryRejectCondition can used to reject the query if workflow state does not satisfy condition.
     // Default: QUERY_REJECT_CONDITION_NONE.
     temporal.api.enums.v1.QueryRejectCondition query_reject_condition = 4;
+    // If set, this call will error if the most recent (if no run id is set on
+    // `workflow_execution`), or specified (if it is) workflow execution is not part of the same
+    // execution chain as this id.
+    string first_execution_run_id = 5;
 }
 
 message QueryWorkflowResponse {
@@ -718,6 +730,10 @@ message QueryWorkflowResponse {
 message DescribeWorkflowExecutionRequest {
     string namespace = 1;
     temporal.api.common.v1.WorkflowExecution execution = 2;
+    // If set, this call will error if the most recent (if no run id is set on
+    // `workflow_execution`), or specified (if it is) workflow execution is not part of the same
+    // execution chain as this id.
+    string first_execution_run_id = 3;
 }
 
 message DescribeWorkflowExecutionResponse {


### PR DESCRIPTION
As discussed on slack, we need `first_execution_run_id` in all of these requests to make them safer.
Also added this to `SignalWithStartWorkflowExecutionResponse` to make using stubs / handles created this way safer.