### PR TITLE
Introducing generic SystemWorkflowFailure

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -8,5 +8,7 @@ lint:
   use:
     - DEFAULT
 breaking:
+  ignore:
+    - temporal/api/errordetails/v1/message.proto
   use:
     - PACKAGE

--- a/temporal/api/errordetails/v1/message.proto
+++ b/temporal/api/errordetails/v1/message.proto
@@ -81,11 +81,10 @@ message ResourceExhaustedFailure {
     temporal.api.enums.v1.ResourceExhaustedCause cause = 1;
 }
 
-message AddSearchAttributesFailure {
-    // WorkflowId and RunId of the Temporal system workflow performing registration of the search attributes.
+message SystemWorkflowFailure {
+    // WorkflowId and RunId of the Temporal system workflow performing the underlying operation.
     // Looking up the info of the system workflow run may help identify the issue causing the failure.
-    // WorkflowId is always "temporal-sys-add-search-attributes-workflow".
-    temporal.api.common.v1.WorkflowExecution system_workflow_execution = 1;
-    // Serialized error returned by the system workflow performing registration
-    string system_workflow_error = 2;
+    temporal.api.common.v1.WorkflowExecution workflow_execution = 1;
+    // Serialized error returned by the system workflow performing the underlying operation.
+    string workflow_error = 2;
 }

--- a/temporal/api/operatorservice/v1/service.proto
+++ b/temporal/api/operatorservice/v1/service.proto
@@ -44,7 +44,7 @@ service OperatorService {
     // AddSearchAttributes add custom search attributes.
     //
     // If successful, returns AddSearchAttributesResponse.
-    // If fails, returns INTERNAL code with temporal.api.errordetails.v1.AddSearchAttributesFailure in Error Details
+    // If fails, returns INTERNAL code with temporal.api.errordetails.v1.SystemWorkflowFailure in Error Details
     rpc AddSearchAttributes (AddSearchAttributesRequest) returns (AddSearchAttributesResponse) {
     }
 


### PR DESCRIPTION


<!-- Describe what has changed in this PR -->
Rename AddSearchAttributesFailure into SystemWorkflowFailure, so this error can be reused for other endpoints that use underlying workflows