### PR TITLE
Add details field to RespondActivityTaskFailed(ById)

### DIFF
--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -433,6 +433,8 @@ message RespondActivityTaskFailedRequest {
     // The identity of the worker/client
     string identity = 3;
     string namespace = 4;
+    // Additional details to be stored as last activity heartbeat
+    temporal.api.common.v1.Payloads last_heartbeat_details = 5;
 }
 
 message RespondActivityTaskFailedResponse {
@@ -451,6 +453,8 @@ message RespondActivityTaskFailedByIdRequest {
     temporal.api.failure.v1.Failure failure = 5;
     // The identity of the worker/client
     string identity = 6;
+    // Additional details to be stored as last activity heartbeat
+    temporal.api.common.v1.Payloads last_heartbeat_details = 7;
 }
 
 message RespondActivityTaskFailedByIdResponse {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Addition of details field to RespondActivityTaskFailed(ById)Request

<!-- Tell your future self why have you made these changes -->
**Why?**
To Allow for attaching the last heartbeat details during failed notification.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
