### PR TITLE
Specify that Datetime values should be ISO strings

### DIFF
--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -56,6 +56,7 @@ message Payload {
 }
 
 // A user-defined set of *indexed* fields that are used/exposed when listing/searching workflows.
+// Datetime fields are represented as ISO strings.
 // The payload is not serialized in a user-defined way.
 message SearchAttributes {
     map<string, Payload> indexed_fields = 1;

--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -56,7 +56,7 @@ message Payload {
 }
 
 // A user-defined set of *indexed* fields that are used/exposed when listing/searching workflows.
-// Datetime fields are represented as ISO strings.
+// Datetime fields are represented as RFC 3339 strings.
 // The payload is not serialized in a user-defined way.
 message SearchAttributes {
     map<string, Payload> indexed_fields = 1;


### PR DESCRIPTION
Fixes https://github.com/temporalio/api/issues/154

(I think Datetime representation is the only ambiguity—the rest isn't needed, since precise field type info is only needed in `AddSearchAttributesRequest`)