### PR TITLE
Add more docs to SearchAttribute APIs about the return codes

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -9,6 +9,5 @@ lint:
     - DEFAULT
 breaking:
   ignore:
-    - temporal/api/errordetails/v1/message.proto
   use:
     - PACKAGE

--- a/temporal/api/operatorservice/v1/service.proto
+++ b/temporal/api/operatorservice/v1/service.proto
@@ -43,12 +43,14 @@ service OperatorService {
 
     // AddSearchAttributes add custom search attributes.
     //
-    // If successful, returns AddSearchAttributesResponse.
-    // If fails, returns INTERNAL code with temporal.api.errordetails.v1.SystemWorkflowFailure in Error Details
+    // Returns ALREADY_EXISTS status code if a Search Attribute with any of the specified names already exists
+    // Returns INTERNAL status code with temporal.api.errordetails.v1.SystemWorkflowFailure in Error Details if registration process fails,
     rpc AddSearchAttributes (AddSearchAttributesRequest) returns (AddSearchAttributesResponse) {
     }
 
     // RemoveSearchAttributes removes custom search attributes.
+    //
+    // Returns NOT_FOUND status code if a Search Attribute with any of the specified names is not registered
     rpc RemoveSearchAttributes (RemoveSearchAttributesRequest) returns (RemoveSearchAttributesResponse) {
     }
 


### PR DESCRIPTION
**What changed?**
Added clarification about the error codes returned from Seach Attributes endpoints if the attribute already exists or it doesn't exist.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None. These endpoints are not released yet.
