### PR TITLE
Add reason field for workflow cancellation

### DIFF
--- a/temporal/api/command/v1/message.proto
+++ b/temporal/api/command/v1/message.proto
@@ -127,6 +127,8 @@ message RequestCancelExternalWorkflowExecutionCommandAttributes {
     // command. The request will be rejected if it is set to true and the target workflow is *not*
     // a child of the requesting workflow.
     bool child_workflow_only = 5;
+    // Reason for requesting the cancellation
+    string reason = 6;
 }
 
 message SignalExternalWorkflowExecutionCommandAttributes {

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -344,7 +344,8 @@ message TimerCanceledEventAttributes {
 
 message WorkflowExecutionCancelRequestedEventAttributes {
     // User provided reason for requesting cancellation
-    string cause = 1;
+    // TODO: shall we create a new field with name "reason" and deprecate this one? 
+    string cause = 1; 
     // TODO: Is this the ID of the event in the workflow which initiated this cancel, if there was one?
     int64 external_initiated_event_id = 2;
     temporal.api.common.v1.WorkflowExecution external_workflow_execution = 3;
@@ -401,6 +402,8 @@ message RequestCancelExternalWorkflowExecutionInitiatedEventAttributes {
     // Workers are expected to set this to true if the workflow they are requesting to cancel is
     // a child of the workflow which issued the request
     bool child_workflow_only = 5;
+    // Reason for requesting the cancellation
+    string reason = 6;
 }
 
 message RequestCancelExternalWorkflowExecutionFailedEventAttributes {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -510,6 +510,8 @@ message RequestCancelWorkflowExecutionRequest {
     // `workflow_execution`), or specified (if it is) workflow execution is not part of the same
     // execution chain as this id.
     string first_execution_run_id = 5;
+    // Reason for requesting the cancellation
+    string reason = 6;
 }
 
 message RequestCancelWorkflowExecutionResponse {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add reason field for request cancel workflow API
- Add reason field for request cancel workflow command
- Add reason field to `RequestCancelExternalWorkflowExecutionInitiatedEventAttributes`
- `WorkflowExecutionCancelRequestedEventAttributes` already contains a `cause` field

- NOTE: 
- SDK need to populate the "reason" field in request cancel workflow command.
- [When seeing a `WorkflowExecutionCancelRequestedEvent`](https://github.com/temporalio/sdk-go/blob/master/internal/internal_event_handlers.go#L856), SDK should create a [CancelledError](https://github.com/temporalio/sdk-go/blob/master/internal/error.go#L143) using the reason in the history event. Currently I think it's using [`ErrCanceled`](https://github.com/temporalio/sdk-go/blob/master/internal/context.go#L196), which is created [without any details](https://github.com/temporalio/sdk-go/blob/master/internal/context.go#L176), and the [details field in workflow execution cancelled event](https://github.com/temporalio/sdk-go/blob/master/internal/internal_task_handlers.go#L1463) is empty.

<!-- Tell your future self why have you made these changes -->
**Why?**
- https://github.com/temporalio/temporal/issues/2426

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

