### PR TITLE
Remove namespace field from ScheduleActivityTaskCommandAttributes message

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -10,5 +10,6 @@ lint:
 breaking:
   ignore:
     - temporal/api/command/v1
+    - temporal/api/history/v1
   use:
     - PACKAGE

--- a/buf.yaml
+++ b/buf.yaml
@@ -9,5 +9,6 @@ lint:
     - DEFAULT
 breaking:
   ignore:
+    - temporal/api/command/v1
   use:
     - PACKAGE

--- a/temporal/api/command/v1/message.proto
+++ b/temporal/api/command/v1/message.proto
@@ -44,6 +44,7 @@ import "temporal/api/taskqueue/v1/message.proto";
 message ScheduleActivityTaskCommandAttributes {
     string activity_id = 1;
     temporal.api.common.v1.ActivityType activity_type = 2;
+    // This used to be a `namespace` field which allowed to schedule activity in another namespace.
     reserved 3;
     temporal.api.taskqueue.v1.TaskQueue task_queue = 4;
     temporal.api.common.v1.Header header = 5;

--- a/temporal/api/command/v1/message.proto
+++ b/temporal/api/command/v1/message.proto
@@ -44,7 +44,7 @@ import "temporal/api/taskqueue/v1/message.proto";
 message ScheduleActivityTaskCommandAttributes {
     string activity_id = 1;
     temporal.api.common.v1.ActivityType activity_type = 2;
-    string namespace = 3;
+    reserved 3;
     temporal.api.taskqueue.v1.TaskQueue task_queue = 4;
     temporal.api.common.v1.Header header = 5;
     temporal.api.common.v1.Payloads input = 6;

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -208,7 +208,8 @@ message ActivityTaskScheduledEventAttributes {
     // The worker/user assigned identifier for the activity
     string activity_id = 1;
     temporal.api.common.v1.ActivityType activity_type = 2;
-    string namespace = 3;
+    // This used to be a `namespace` field which allowed to schedule activity in another namespace.
+    reserved 3;
     temporal.api.taskqueue.v1.TaskQueue task_queue = 4;
     temporal.api.common.v1.Header header = 5;
     temporal.api.common.v1.Payloads input = 6;


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove `namespace` field from `ScheduleActivityTaskCommandAttributes` message.

<!-- Tell your future self why have you made these changes -->
**Why?**
To remove ability of cross namespace activities calls. Initial motivation behind cross namespace activities was to allow different teams to own their own namespaces with activities and other teams to build workflows that use these activities in form of "library". Unfortunately, we found out that "cross namespace activity" is a wrong abstraction to achieve this goal. It adds complexity which is not well covered with test and not actually used (all official SDKs doesn't even expose it). For example, who should control activity heartbeat timeout?

And by the way, we are working on designing new feature/abstraction which will enable this functionality.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Low risk: `namespace` field is not exposed for the most SDKs but there might be some unofficial SDK which will lose ability to start activity in another namespace.
