### PR TITLE
Add history size and continue-as-new suggestion

### DIFF
--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -163,6 +163,13 @@ message WorkflowTaskStartedEventAttributes {
     string identity = 2;
     // TODO: ? Appears unused?
     string request_id = 3;
+    // True if this workflow should continue-as-new soon because its history size (in
+    // either events or bytes) is getting large.
+    bool suggest_continue_as_new = 4;
+    // Total history size in bytes, which the workflow might use to decide when to
+    // continue-as-new regardless of the suggestion. Note that history size in events is
+    // just the event id of this event, so we don't include it explicitly here.
+    int64 history_size_bytes = 5;
 }
 
 message WorkflowTaskCompletedEventAttributes {

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -172,10 +172,10 @@ message WorkflowTaskStartedEventAttributes {
     // TODO: ? Appears unused?
     string request_id = 3;
     // True if this workflow should continue-as-new soon because its history size (in
-    // either events or bytes) is getting large.
+    // either event count or bytes) is getting large.
     bool suggest_continue_as_new = 4;
     // Total history size in bytes, which the workflow might use to decide when to
-    // continue-as-new regardless of the suggestion. Note that history size in events is
+    // continue-as-new regardless of the suggestion. Note that history event count is
     // just the event id of this event, so we don't include it explicitly here.
     int64 history_size_bytes = 5;
 }


### PR DESCRIPTION
**What changed?**
Adding two fields to WorkflowTaskStartedEventAttributes that can be exposed by SDKs, to allow long-running workflows to make better choices about when to continue-as-new.

**Why?**
Long-running workflows eventually need to call continue-as-new to limit history size (both in event count and in bytes), otherwise they will be automatically terminated by the server. Currently there's no guidance provided to workflows about when to do this. Even knowing that they should do it after 10,000 events, that information isn't exposed to workflow code.

The server has history size thresholds (soft and hard limits) in dynamic config and can use those to figure out a suggestion that will be applicable for many cases. In other cases, the workflow code might want to know the exact history size (in events or bytes) and make its own determinate. This adds two fields for the suggestion and the raw history size in bytes. (The history size in events is just the event id of this event.)

See https://github.com/temporalio/temporal/issues/1114 and https://github.com/temporalio/temporal/issues/2726
