### PR TITLE
Add NamespaceInvalidStateFailure and NamespaceNotFoundFailure

### DIFF
--- a/temporal/api/errordetails/v1/message.proto
+++ b/temporal/api/errordetails/v1/message.proto
@@ -63,6 +63,9 @@ message NamespaceNotFoundFailure {
     string namespace = 1;
 }
 
+message NamespaceAlreadyExistsFailure {
+}
+
 message ClientVersionNotSupportedFailure {
     string client_version = 1;
     string client_name = 2;
@@ -72,9 +75,6 @@ message ClientVersionNotSupportedFailure {
 message ServerVersionNotSupportedFailure {
     string server_version = 1;
     string client_supported_server_versions = 2;
-}
-
-message NamespaceAlreadyExistsFailure {
 }
 
 message CancellationAlreadyRequestedFailure {

--- a/temporal/api/errordetails/v1/message.proto
+++ b/temporal/api/errordetails/v1/message.proto
@@ -53,6 +53,16 @@ message NamespaceNotActiveFailure {
     string active_cluster = 3;
 }
 
+message NamespaceInvalidStateFailure {
+    string namespace = 1;
+    string state = 2;
+    repeated string allowed_states = 3;
+}
+
+message NamespaceNotFoundFailure {
+    string namespace = 1;
+}
+
 message ClientVersionNotSupportedFailure {
     string client_version = 1;
     string client_name = 2;

--- a/temporal/api/errordetails/v1/message.proto
+++ b/temporal/api/errordetails/v1/message.proto
@@ -35,7 +35,9 @@ option ruby_package = "Temporal::Api::ErrorDetails::V1";
 option csharp_namespace = "Temporal.Api.ErrorDetails.V1";
 
 import "temporal/api/common/v1/message.proto";
+
 import "temporal/api/enums/v1/failed_cause.proto";
+import "temporal/api/enums/v1/namespace.proto";
 
 message NotFoundFailure {
     string current_cluster = 1;
@@ -55,8 +57,11 @@ message NamespaceNotActiveFailure {
 
 message NamespaceInvalidStateFailure {
     string namespace = 1;
-    string state = 2;
-    repeated string allowed_states = 3;
+    // Current state of the requested namespace.
+    temporal.api.enums.v1.NamespaceState state = 2;
+    // Allowed namespace states for requested operation.
+    // For example NAMESPACE_STATE_DELETED is forbidden for most operations but allowed for DescribeNamespace.
+    repeated temporal.api.enums.v1.NamespaceState allowed_states = 3;
 }
 
 message NamespaceNotFoundFailure {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add `NamespaceInvalidStateFailure` and `NamespaceNotFoundFailure`.

<!-- Tell your future self why have you made these changes -->
**Why?**
If namespace is in deleted state, namespace validator on server returns `InvalidArgument` error for any request to this namespace and if namespace is not found it returns `NotFound` error. Go SDK reacts on these errors differently. If poller gets `InvalidArgument` it exits the process [immediately](https://github.com/temporalio/sdk-go/blob/cb9c7de44f8774ab6681f4469ecbed8243d082dd/internal/internal_worker_base.go#L320) (not only worker) but `NotFound` error are considered to be [retryable](https://github.com/temporalio/sdk-go/blob/cb9c7de44f8774ab6681f4469ecbed8243d082dd/internal/internal_worker_base.go#L367). Therefore, worker behaviour in case of deleted namespace is unpredictable and depends on namespace registry refresh and SDK poll interval: it will either kill the process or keeps retrying forever.

Adding 2 new failures will allow to differentiate namespace related errors and handle them accordingly.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.
