### PR TITLE
Add parent initiated event version to WorkflowExecutionStartedEvent

### DIFF
--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -50,7 +50,7 @@ message WorkflowExecutionStartedEventAttributes {
     // If this workflow is a child, the namespace our parent lives in
     string parent_workflow_namespace = 2;
     temporal.api.common.v1.WorkflowExecution parent_workflow_execution = 3;
-    // TODO: What is this? ID of the event that requested this workflow execution if we are a child?
+    // EventID of the child execution initiated event in parent workflow 
     int64 parent_initiated_event_id = 4;
     temporal.api.taskqueue.v1.TaskQueue task_queue = 5;
     // SDK will deserialize this and provide it as arguments to the workflow function
@@ -88,6 +88,10 @@ message WorkflowExecutionStartedEventAttributes {
     temporal.api.common.v1.SearchAttributes search_attributes = 23;
     temporal.api.workflow.v1.ResetPoints prev_auto_reset_points = 24;
     temporal.api.common.v1.Header header = 25;
+    // Version of the child execution initiated event in parent workflow
+    // It should be used together with parent_initiated_event_id to identify
+    // a child initiated event for global namespace
+    int64 parent_initiated_event_version = 26;
 }
 
 message WorkflowExecutionCompletedEventAttributes {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add parent initiated event version to WorkflowExecutionStartedEvent
- Have to add the info to history event so that replication stack can replicate the information to standby cluster.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Existing parent initiated eventID alone can't not identify the child initiated event in parent workflow for global namespace. We need event version as well to uniquely identify it.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
