### PR TITLE
Fix doc for RequestCancelWorkflowExecution

### DIFF
--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -215,9 +215,9 @@ service WorkflowService {
     // RequestCancelWorkflowExecution is called by workers when they want to request cancellation of
     // a workflow execution.
     //
-    // This result in a new `WORKFLOW_EXECUTION_CANCEL_REQUESTED` event being written to the
-    // workflow history and a new workflow task created for the workflow. It returns success if requested
-    // workflow already closed. It fails with 'NotFound' if the requested workflow doesn't exist.
+    // This results in a new `WORKFLOW_EXECUTION_CANCEL_REQUESTED` event being written to the
+    // workflow history and a new workflow task created for the workflow. It returns success if the requested
+    // workflow is already closed. It fails with 'NotFound' if the requested workflow doesn't exist.
     rpc RequestCancelWorkflowExecution (RequestCancelWorkflowExecutionRequest) returns (RequestCancelWorkflowExecutionResponse) {
     }
 

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -216,8 +216,8 @@ service WorkflowService {
     // a workflow execution.
     //
     // This result in a new `WORKFLOW_EXECUTION_CANCEL_REQUESTED` event being written to the
-    // workflow history and a new workflow task created for the workflow. Fails with `NotFound` if
-    // the workflow is already completed or doesn't exist.
+    // workflow history and a new workflow task created for the workflow. It returns success if requested
+    // workflow already closed. It fails with 'NotFound' if the requested workflow doesn't exist.
     rpc RequestCancelWorkflowExecution (RequestCancelWorkflowExecutionRequest) returns (RequestCancelWorkflowExecutionResponse) {
     }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update doc for RequestCancelWorkflowExecution to reflect actual behavior. The behavior is expected.

<!-- Tell your future self why have you made these changes -->
**Why?**
RequestCancelWorkflow should not return error when target workflow already closed.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

