### PR TITLE
Fix ResetReapplyType comments

### DIFF
--- a/temporal/api/enums/v1/reset.proto
+++ b/temporal/api/enums/v1/reset.proto
@@ -31,7 +31,9 @@ option java_outer_classname = "ResetProto";
 option ruby_package = "Temporal::Api::Enums::V1";
 option csharp_namespace = "Temporal.Api.Enums.V1";
 
-// TODO: What is this?
+// Reset reapplay(replay) options
+// * RESET_REAPPLY_TYPE_SIGNAL (default) - Signals are reapplied when workflow is reset
+// * RESET_REAPPLY_TYPE_NONE - nothing is reapplied
 enum ResetReapplyType {
     RESET_REAPPLY_TYPE_UNSPECIFIED = 0;
     RESET_REAPPLY_TYPE_SIGNAL = 1;

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -587,7 +587,7 @@ message ResetWorkflowExecutionRequest {
     int64 workflow_task_finish_event_id = 4;
     // Used to de-dupe reset requests
     string request_id = 5;
-    // Should be removed. Appears unused.
+    // Reset reapplay(replay) options.
     temporal.api.enums.v1.ResetReapplyType reset_reapply_type = 6;
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?** 

Some of the comments related to `ResetReapplyType`.
Fixed comments on `ResetReapplyType`.
1. Wrote most sensible description I could come up to `enum ResetReapplyType`
1. `// Should be removed. Appears unused.` was also misleading. Because it is clearly being used by [temporal](https://github.com/temporalio/temporal) and [tctl](https://github.com/temporalio/tctl)


<!-- Tell your future self why have you made these changes -->
**Why?** It was little misleading


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?** It is just a comment fix


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks** None

