### PR TITLE
Add namespace_id field to events with namespace field

### DIFF
--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -96,6 +96,8 @@ message WorkflowExecutionStartedEventAttributes {
     // It should be used together with parent_initiated_event_id to identify
     // a child initiated event for global namespace
     int64 parent_initiated_event_version = 26;
+    // If this workflow is a child, the namespace our parent lives in
+    string parent_workflow_namespace_id = 27;
 }
 
 message WorkflowExecutionCompletedEventAttributes {
@@ -420,6 +422,8 @@ message RequestCancelExternalWorkflowExecutionInitiatedEventAttributes {
     bool child_workflow_only = 5;
     // Reason for requesting the cancellation
     string reason = 6;
+    // The namespace the workflow to be cancelled lives in
+    string namespace_id = 7;
 }
 
 message RequestCancelExternalWorkflowExecutionFailedEventAttributes {
@@ -434,6 +438,8 @@ message RequestCancelExternalWorkflowExecutionFailedEventAttributes {
     int64 initiated_event_id = 5;
     // Deprecated
     string control = 6;
+    // namespace of the workflow which failed to cancel
+    string namespace_id = 7;
 }
 
 message ExternalWorkflowExecutionCancelRequestedEventAttributes {
@@ -443,6 +449,8 @@ message ExternalWorkflowExecutionCancelRequestedEventAttributes {
     // namespace of the to-be-cancelled workflow
     string namespace = 2;
     temporal.api.common.v1.WorkflowExecution workflow_execution = 3;
+    // namespace of the to-be-cancelled workflow
+    string namespace_id = 4;
 }
 
 message SignalExternalWorkflowExecutionInitiatedEventAttributes {
@@ -461,6 +469,8 @@ message SignalExternalWorkflowExecutionInitiatedEventAttributes {
     // a child of the workflow which issued the request
     bool child_workflow_only = 7;
     temporal.api.common.v1.Header header = 8;
+    // namespace of the to-be-signalled workflow
+    string namespace_id = 9;
 }
 
 message SignalExternalWorkflowExecutionFailedEventAttributes {
@@ -472,6 +482,7 @@ message SignalExternalWorkflowExecutionFailedEventAttributes {
     int64 initiated_event_id = 5;
     // Deprecated
     string control = 6;
+    string namespace_id = 7;
 }
 
 message ExternalWorkflowExecutionSignaledEventAttributes {
@@ -482,6 +493,8 @@ message ExternalWorkflowExecutionSignaledEventAttributes {
     temporal.api.common.v1.WorkflowExecution workflow_execution = 3;
     // Deprecated
     string control = 4;
+    // namespace of the workflow which was signaled
+    string namespace_id = 5;
 }
 
 message UpsertWorkflowSearchAttributesEventAttributes {
@@ -517,6 +530,8 @@ message StartChildWorkflowExecutionInitiatedEventAttributes {
     temporal.api.common.v1.Header header = 15;
     temporal.api.common.v1.Memo memo = 16;
     temporal.api.common.v1.SearchAttributes search_attributes = 17;
+    // Namespace of the child workflow
+    string namespace_id = 18;
 }
 
 message StartChildWorkflowExecutionFailedEventAttributes {
@@ -531,6 +546,8 @@ message StartChildWorkflowExecutionFailedEventAttributes {
     int64 initiated_event_id = 6;
     // The `WORKFLOW_TASK_COMPLETED` event which this command was reported with
     int64 workflow_task_completed_event_id = 7;
+    // Namespace of the child workflow
+    string namespace_id = 8;
 }
 
 message ChildWorkflowExecutionStartedEventAttributes {
@@ -541,6 +558,8 @@ message ChildWorkflowExecutionStartedEventAttributes {
     temporal.api.common.v1.WorkflowExecution workflow_execution = 3;
     temporal.api.common.v1.WorkflowType workflow_type = 4;
     temporal.api.common.v1.Header header = 5;
+    // Namespace of the child workflow
+    string namespace_id = 6;
 }
 
 message ChildWorkflowExecutionCompletedEventAttributes {
@@ -553,6 +572,8 @@ message ChildWorkflowExecutionCompletedEventAttributes {
     int64 initiated_event_id = 5;
     // Id of the `CHILD_WORKFLOW_EXECUTION_STARTED` event which this event corresponds to
     int64 started_event_id = 6;
+    // Namespace of the child workflow
+    string namespace_id = 7;
 }
 
 message ChildWorkflowExecutionFailedEventAttributes {
@@ -566,6 +587,8 @@ message ChildWorkflowExecutionFailedEventAttributes {
     // Id of the `CHILD_WORKFLOW_EXECUTION_STARTED` event which this event corresponds to
     int64 started_event_id = 6;
     temporal.api.enums.v1.RetryState retry_state = 7;
+    // Namespace of the child workflow
+    string namespace_id = 8;
 }
 
 message ChildWorkflowExecutionCanceledEventAttributes {
@@ -578,6 +601,8 @@ message ChildWorkflowExecutionCanceledEventAttributes {
     int64 initiated_event_id = 5;
     // Id of the `CHILD_WORKFLOW_EXECUTION_STARTED` event which this event corresponds to
     int64 started_event_id = 6;
+    // Namespace of the child workflow
+    string namespace_id = 7;
 }
 
 message ChildWorkflowExecutionTimedOutEventAttributes {
@@ -590,6 +615,8 @@ message ChildWorkflowExecutionTimedOutEventAttributes {
     // Id of the `CHILD_WORKFLOW_EXECUTION_STARTED` event which this event corresponds to
     int64 started_event_id = 5;
     temporal.api.enums.v1.RetryState retry_state = 6;
+    // Namespace of the child workflow
+    string namespace_id = 7;
 }
 
 message ChildWorkflowExecutionTerminatedEventAttributes {
@@ -601,6 +628,8 @@ message ChildWorkflowExecutionTerminatedEventAttributes {
     int64 initiated_event_id = 4;
     // Id of the `CHILD_WORKFLOW_EXECUTION_STARTED` event which this event corresponds to
     int64 started_event_id = 5;
+    // Namespace of the child workflow
+    string namespace_id = 6;
 }
 
 // History events are the method by which Temporal SDKs advance (or recreate) workflow state.

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -47,8 +47,10 @@ import "temporal/api/taskqueue/v1/message.proto";
 // Always the first event in workflow history
 message WorkflowExecutionStartedEventAttributes {
     temporal.api.common.v1.WorkflowType workflow_type = 1;
-    // If this workflow is a child, the namespace our parent lives in
+    // If this workflow is a child, the namespace our parent lives in.
+    // SDKs and UI tools should use `parent_workflow_namespace` field but server must use `parent_workflow_namespace_id` only.
     string parent_workflow_namespace = 2;
+    string parent_workflow_namespace_id = 27;
     // Contains information about parent workflow execution that initiated the child workflow these attributes belong to.
     // If the workflow these attributes belong to is not a child workflow of any other execution, this field will not be populated.
     temporal.api.common.v1.WorkflowExecution parent_workflow_execution = 3;
@@ -96,8 +98,6 @@ message WorkflowExecutionStartedEventAttributes {
     // It should be used together with parent_initiated_event_id to identify
     // a child initiated event for global namespace
     int64 parent_initiated_event_version = 26;
-    // If this workflow is a child, the namespace our parent lives in
-    string parent_workflow_namespace_id = 27;
 }
 
 message WorkflowExecutionCompletedEventAttributes {
@@ -412,8 +412,10 @@ message WorkflowExecutionTerminatedEventAttributes {
 message RequestCancelExternalWorkflowExecutionInitiatedEventAttributes {
     // The `WORKFLOW_TASK_COMPLETED` event which this command was reported with
     int64 workflow_task_completed_event_id = 1;
-    // The namespace the workflow to be cancelled lives in
+    // The namespace the workflow to be cancelled lives in.
+    // SDKs and UI tools should use `namespace` field but server must use `namespace_id` only.
     string namespace = 2;
+    string namespace_id = 7;
     temporal.api.common.v1.WorkflowExecution workflow_execution = 3;
     // Deprecated
     string control = 4;
@@ -422,42 +424,42 @@ message RequestCancelExternalWorkflowExecutionInitiatedEventAttributes {
     bool child_workflow_only = 5;
     // Reason for requesting the cancellation
     string reason = 6;
-    // The namespace the workflow to be cancelled lives in
-    string namespace_id = 7;
 }
 
 message RequestCancelExternalWorkflowExecutionFailedEventAttributes {
     temporal.api.enums.v1.CancelExternalWorkflowExecutionFailedCause cause = 1;
     // The `WORKFLOW_TASK_COMPLETED` event which this command was reported with
     int64 workflow_task_completed_event_id = 2;
-    // namespace of the workflow which failed to cancel
+    // Namespace of the workflow which failed to cancel.
+    // SDKs and UI tools should use `namespace` field but server must use `namespace_id` only.
     string namespace = 3;
+    string namespace_id = 7;
     temporal.api.common.v1.WorkflowExecution workflow_execution = 4;
     // id of the `REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED` event this failure
     // corresponds to
     int64 initiated_event_id = 5;
     // Deprecated
     string control = 6;
-    // namespace of the workflow which failed to cancel
-    string namespace_id = 7;
 }
 
 message ExternalWorkflowExecutionCancelRequestedEventAttributes {
     // id of the `REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED` event this event corresponds
     // to
     int64 initiated_event_id = 1;
-    // namespace of the to-be-cancelled workflow
+    // Namespace of the to-be-cancelled workflow.
+    // SDKs and UI tools should use `namespace` field but server must use `namespace_id` only.
     string namespace = 2;
-    temporal.api.common.v1.WorkflowExecution workflow_execution = 3;
-    // namespace of the to-be-cancelled workflow
     string namespace_id = 4;
+    temporal.api.common.v1.WorkflowExecution workflow_execution = 3;
 }
 
 message SignalExternalWorkflowExecutionInitiatedEventAttributes {
     // The `WORKFLOW_TASK_COMPLETED` event which this command was reported with
     int64 workflow_task_completed_event_id = 1;
-    // namespace of the to-be-signalled workflow
+    // Namespace of the to-be-signalled workflow.
+    // SDKs and UI tools should use `namespace` field but server must use `namespace_id` only.
     string namespace = 2;
+    string namespace_id = 9;
     temporal.api.common.v1.WorkflowExecution workflow_execution = 3;
     // name/type of the signal to fire in the external workflow
     string signal_name = 4;
@@ -469,32 +471,32 @@ message SignalExternalWorkflowExecutionInitiatedEventAttributes {
     // a child of the workflow which issued the request
     bool child_workflow_only = 7;
     temporal.api.common.v1.Header header = 8;
-    // namespace of the to-be-signalled workflow
-    string namespace_id = 9;
 }
 
 message SignalExternalWorkflowExecutionFailedEventAttributes {
     temporal.api.enums.v1.SignalExternalWorkflowExecutionFailedCause cause = 1;
     // The `WORKFLOW_TASK_COMPLETED` event which this command was reported with
     int64 workflow_task_completed_event_id = 2;
+    // Namespace of the workflow which failed the signal.
+    // SDKs and UI tools should use `namespace` field but server must use `namespace_id` only.
     string namespace = 3;
+    string namespace_id = 7;
     temporal.api.common.v1.WorkflowExecution workflow_execution = 4;
     int64 initiated_event_id = 5;
     // Deprecated
     string control = 6;
-    string namespace_id = 7;
 }
 
 message ExternalWorkflowExecutionSignaledEventAttributes {
     // id of the `SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED` event this event corresponds to
     int64 initiated_event_id = 1;
-    // namespace of the workflow which was signaled
+    // Namespace of the workflow which was signaled.
+    // SDKs and UI tools should use `namespace` field but server must use `namespace_id` only.
     string namespace = 2;
+    string namespace_id = 5;
     temporal.api.common.v1.WorkflowExecution workflow_execution = 3;
     // Deprecated
     string control = 4;
-    // namespace of the workflow which was signaled
-    string namespace_id = 5;
 }
 
 message UpsertWorkflowSearchAttributesEventAttributes {
@@ -504,8 +506,10 @@ message UpsertWorkflowSearchAttributesEventAttributes {
 }
 
 message StartChildWorkflowExecutionInitiatedEventAttributes {
-    // Namespace of the child workflow
+    // Namespace of the child workflow.
+    // SDKs and UI tools should use `namespace` field but server must use `namespace_id` only.
     string namespace = 1;
+    string namespace_id = 18;
     string workflow_id = 2;
     temporal.api.common.v1.WorkflowType workflow_type = 3;
     temporal.api.taskqueue.v1.TaskQueue task_queue = 4;
@@ -530,13 +534,13 @@ message StartChildWorkflowExecutionInitiatedEventAttributes {
     temporal.api.common.v1.Header header = 15;
     temporal.api.common.v1.Memo memo = 16;
     temporal.api.common.v1.SearchAttributes search_attributes = 17;
-    // Namespace of the child workflow
-    string namespace_id = 18;
 }
 
 message StartChildWorkflowExecutionFailedEventAttributes {
-    // Namespace of the child workflow
+    // Namespace of the child workflow.
+    // SDKs and UI tools should use `namespace` field but server must use `namespace_id` only.
     string namespace = 1;
+    string namespace_id = 8;
     string workflow_id = 2;
     temporal.api.common.v1.WorkflowType workflow_type = 3;
     temporal.api.enums.v1.StartChildWorkflowExecutionFailedCause cause = 4;
@@ -546,40 +550,40 @@ message StartChildWorkflowExecutionFailedEventAttributes {
     int64 initiated_event_id = 6;
     // The `WORKFLOW_TASK_COMPLETED` event which this command was reported with
     int64 workflow_task_completed_event_id = 7;
-    // Namespace of the child workflow
-    string namespace_id = 8;
 }
 
 message ChildWorkflowExecutionStartedEventAttributes {
-    // Namespace of the child workflow
+    // Namespace of the child workflow.
+    // SDKs and UI tools should use `namespace` field but server must use `namespace_id` only.
     string namespace = 1;
+    string namespace_id = 6;
     // Id of the `START_CHILD_WORKFLOW_EXECUTION_INITIATED` event which this event corresponds to
     int64 initiated_event_id = 2;
     temporal.api.common.v1.WorkflowExecution workflow_execution = 3;
     temporal.api.common.v1.WorkflowType workflow_type = 4;
     temporal.api.common.v1.Header header = 5;
-    // Namespace of the child workflow
-    string namespace_id = 6;
 }
 
 message ChildWorkflowExecutionCompletedEventAttributes {
     temporal.api.common.v1.Payloads result = 1;
-    // Namespace of the child workflow
+    // Namespace of the child workflow.
+    // SDKs and UI tools should use `namespace` field but server must use `namespace_id` only.
     string namespace = 2;
+    string namespace_id = 7;
     temporal.api.common.v1.WorkflowExecution workflow_execution = 3;
     temporal.api.common.v1.WorkflowType workflow_type = 4;
     // Id of the `START_CHILD_WORKFLOW_EXECUTION_INITIATED` event which this event corresponds to
     int64 initiated_event_id = 5;
     // Id of the `CHILD_WORKFLOW_EXECUTION_STARTED` event which this event corresponds to
     int64 started_event_id = 6;
-    // Namespace of the child workflow
-    string namespace_id = 7;
 }
 
 message ChildWorkflowExecutionFailedEventAttributes {
     temporal.api.failure.v1.Failure failure = 1;
-    // Namespace of the child workflow
+    // Namespace of the child workflow.
+    // SDKs and UI tools should use `namespace` field but server must use `namespace_id` only.
     string namespace = 2;
+    string namespace_id = 8;
     temporal.api.common.v1.WorkflowExecution workflow_execution = 3;
     temporal.api.common.v1.WorkflowType workflow_type = 4;
     // Id of the `START_CHILD_WORKFLOW_EXECUTION_INITIATED` event which this event corresponds to
@@ -587,27 +591,27 @@ message ChildWorkflowExecutionFailedEventAttributes {
     // Id of the `CHILD_WORKFLOW_EXECUTION_STARTED` event which this event corresponds to
     int64 started_event_id = 6;
     temporal.api.enums.v1.RetryState retry_state = 7;
-    // Namespace of the child workflow
-    string namespace_id = 8;
 }
 
 message ChildWorkflowExecutionCanceledEventAttributes {
     temporal.api.common.v1.Payloads details = 1;
-    // Namespace of the child workflow
+    // Namespace of the child workflow.
+    // SDKs and UI tools should use `namespace` field but server must use `namespace_id` only.
     string namespace = 2;
+    string namespace_id = 7;
     temporal.api.common.v1.WorkflowExecution workflow_execution = 3;
     temporal.api.common.v1.WorkflowType workflow_type = 4;
     // Id of the `START_CHILD_WORKFLOW_EXECUTION_INITIATED` event which this event corresponds to
     int64 initiated_event_id = 5;
     // Id of the `CHILD_WORKFLOW_EXECUTION_STARTED` event which this event corresponds to
     int64 started_event_id = 6;
-    // Namespace of the child workflow
-    string namespace_id = 7;
 }
 
 message ChildWorkflowExecutionTimedOutEventAttributes {
-    // Namespace of the child workflow
+    // Namespace of the child workflow.
+    // SDKs and UI tools should use `namespace` field but server must use `namespace_id` only.
     string namespace = 1;
+    string namespace_id = 7;
     temporal.api.common.v1.WorkflowExecution workflow_execution = 2;
     temporal.api.common.v1.WorkflowType workflow_type = 3;
     // Id of the `START_CHILD_WORKFLOW_EXECUTION_INITIATED` event which this event corresponds to
@@ -615,21 +619,19 @@ message ChildWorkflowExecutionTimedOutEventAttributes {
     // Id of the `CHILD_WORKFLOW_EXECUTION_STARTED` event which this event corresponds to
     int64 started_event_id = 5;
     temporal.api.enums.v1.RetryState retry_state = 6;
-    // Namespace of the child workflow
-    string namespace_id = 7;
 }
 
 message ChildWorkflowExecutionTerminatedEventAttributes {
-    // Namespace of the child workflow
+    // Namespace of the child workflow.
+    // SDKs and UI tools should use `namespace` field but server must use `namespace_id` only.
     string namespace = 1;
+    string namespace_id = 6;
     temporal.api.common.v1.WorkflowExecution workflow_execution = 2;
     temporal.api.common.v1.WorkflowType workflow_type = 3;
     // Id of the `START_CHILD_WORKFLOW_EXECUTION_INITIATED` event which this event corresponds to
     int64 initiated_event_id = 4;
     // Id of the `CHILD_WORKFLOW_EXECUTION_STARTED` event which this event corresponds to
     int64 started_event_id = 5;
-    // Namespace of the child workflow
-    string namespace_id = 6;
 }
 
 // History events are the method by which Temporal SDKs advance (or recreate) workflow state.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add `namespace_id` field to events with `namespace` field.

<!-- Tell your future self why have you made these changes -->
**Why?**
Having namespace name is useful for SDKs and UI. But internal server logic also requires namespace information for some events. For example when child workflow is started, target namespace is read from event attributes. Using namespace name is not reliable because namespace might be renamed (during delete process, for example) and won't be found. Replication stack also might re-apply events and for renamed namespace it won't be possible.

`namespace_id` is actually needed only for 4 events:
* `StartChildWorkflowExecutionInitiated`
* `RequestCancelExternalWorkflowExecutionInitiated`
* `SignalExternalWorkflowExecutionInitiated`
* `WorkflowExecutionStarted`

but to keep parity, I decided to add it to all events.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
In corresponding server PR: https://github.com/temporalio/temporal/pull/2903.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
History size will slightly increase.
