### PR TITLE
Add supports_schedules flag

### DIFF
--- a/temporal/api/namespace/v1/message.proto
+++ b/temporal/api/namespace/v1/message.proto
@@ -47,6 +47,10 @@ message NamespaceInfo {
     // A key-value map for any customized purpose.
     map<string, string> data = 5;
     string id = 6;
+
+    // Whether scheduled workflows are supported on this namespace. This is only needed
+    // temporarily while the feature is experimental, so we can give it a high tag.
+    bool supports_schedules = 100;
 }
 
 message NamespaceConfig {


### PR DESCRIPTION
**What changed?**
Adds a bool field in NamespaceInfo for whether the new scheduled workflow feature is supported on the namespace.

**Why?**
This is intended for the web UI to use to control whether to display schedule-related elements.

