### PR TITLE
Add property/mutable state updating events

### DIFF
--- a/temporal/api/enums/v1/event_type.proto
+++ b/temporal/api/enums/v1/event_type.proto
@@ -157,4 +157,8 @@ enum EventType {
     EVENT_TYPE_WORKFLOW_UPDATE_ACCEPTED = 42;
     // Workflow update has been completed
     EVENT_TYPE_WORKFLOW_UPDATE_COMPLETED = 43;
+    // Some property or properties of the workflow as a whole have changed
+    EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED = 41;
+    // Some property or properties of an already-scheduled activity have changed
+    EVENT_TYPE_ACTIVITY_PROPERTIES_MODIFIED = 42;
 }

--- a/temporal/api/enums/v1/event_type.proto
+++ b/temporal/api/enums/v1/event_type.proto
@@ -158,7 +158,7 @@ enum EventType {
     // Workflow update has been completed
     EVENT_TYPE_WORKFLOW_UPDATE_COMPLETED = 43;
     // Some property or properties of the workflow as a whole have changed
-    EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED = 41;
+    EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED = 44;
     // Some property or properties of an already-scheduled activity have changed
-    EVENT_TYPE_ACTIVITY_PROPERTIES_MODIFIED = 42;
+    EVENT_TYPE_ACTIVITY_PROPERTIES_MODIFIED = 45;
 }

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -656,6 +656,28 @@ message UpdateWorkflowCompletedEventAttributes {
     }
 }
 
+message WorkflowPropertiesModifiedEventAttributes {
+    // If set to a nonempty string, future workflow tasks for this workflow shall be dispatched on
+    // the provided queue.
+    string new_task_queue = 1;
+    // If set, update the workflow task timeout to this value.
+    google.protobuf.Duration new_workflow_task_timeout = 2 [(gogoproto.stdduration) = true];
+    // If set, update the workflow run timeout to this value.
+    google.protobuf.Duration new_workflow_run_timeout = 3 [(gogoproto.stdduration) = true];
+    // If set, update the workflow execution timeout to this value.
+    google.protobuf.Duration new_workflow_execution_timeout = 4 [(gogoproto.stdduration) = true];
+}
+
+message ActivityPropertiesModifiedEventAttributes {
+    // The id of the `ACTIVITY_TASK_SCHEDULED` event this modification corresponds to.
+    int64 scheduled_event_id = 1;
+    // The id of the `ACTIVITY_TASK_STARTED` event this modification corresponds to.
+    int64 started_event_id = 2;
+    // If set, update the retry policy of the activity, replacing it with the specified one.
+    // The number of attempts at the activity is preserved.
+    temporal.api.common.v1.RetryPolicy new_retry_policy = 3;
+}
+
 // History events are the method by which Temporal SDKs advance (or recreate) workflow state.
 // See the `EventType` enum for more info about what each event is for.
 message HistoryEvent {
@@ -667,6 +689,11 @@ message HistoryEvent {
     int64 version = 4;
     // TODO: What is this? Appears unused by SDKs
     int64 task_id = 5;
+    // Set to true when the SDK may ignore the event as it does not impact workflow state or
+    // information in any way that the SDK need be concerned with. If an SDK encounters an event
+    // type which it does not understand, it must error unless this is true. If it is true, it's
+    // acceptable for the event type and/or attributes to be uninterpretable.
+    bool sdk_may_ignore = 300;
     // The event details. The type must match that in `event_type`.
     oneof attributes {
         WorkflowExecutionStartedEventAttributes workflow_execution_started_event_attributes = 6;
@@ -712,6 +739,8 @@ message HistoryEvent {
         UpdateWorkflowRequestedEventAttributes update_workflow_requested_event_attributes = 46;
         UpdateWorkflowAcceptedEventAttributes update_workflow_accepted_event_attributes = 47;
         UpdateWorkflowCompletedEventAttributes update_workflow_completed_event_attributes = 48;
+        WorkflowPropertiesModifiedEventAttributes workflow_properties_modified_event_attributes = 46;
+        ActivityPropertiesModifiedEventAttributes activity_properties_modified_event_attributes = 47;
     }
 }
 

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -662,20 +662,18 @@ message WorkflowPropertiesModifiedEventAttributes {
     string new_task_queue = 1;
     // If set, update the workflow task timeout to this value.
     google.protobuf.Duration new_workflow_task_timeout = 2 [(gogoproto.stdduration) = true];
-    // If set, update the workflow run timeout to this value.
+    // If set, update the workflow run timeout to this value. May be set to 0 for no timeout.
     google.protobuf.Duration new_workflow_run_timeout = 3 [(gogoproto.stdduration) = true];
-    // If set, update the workflow execution timeout to this value.
+    // If set, update the workflow execution timeout to this value. May be set to 0 for no timeout.
     google.protobuf.Duration new_workflow_execution_timeout = 4 [(gogoproto.stdduration) = true];
 }
 
 message ActivityPropertiesModifiedEventAttributes {
     // The id of the `ACTIVITY_TASK_SCHEDULED` event this modification corresponds to.
     int64 scheduled_event_id = 1;
-    // The id of the `ACTIVITY_TASK_STARTED` event this modification corresponds to.
-    int64 started_event_id = 2;
     // If set, update the retry policy of the activity, replacing it with the specified one.
     // The number of attempts at the activity is preserved.
-    temporal.api.common.v1.RetryPolicy new_retry_policy = 3;
+    temporal.api.common.v1.RetryPolicy new_retry_policy = 2;
 }
 
 // History events are the method by which Temporal SDKs advance (or recreate) workflow state.

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -691,7 +691,7 @@ message HistoryEvent {
     // information in any way that the SDK need be concerned with. If an SDK encounters an event
     // type which it does not understand, it must error unless this is true. If it is true, it's
     // acceptable for the event type and/or attributes to be uninterpretable.
-    bool sdk_may_ignore = 300;
+    bool worker_may_ignore = 300;
     // The event details. The type must match that in `event_type`.
     oneof attributes {
         WorkflowExecutionStartedEventAttributes workflow_execution_started_event_attributes = 6;

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -666,7 +666,9 @@ message WorkflowPropertiesModifiedEventAttributes {
     google.protobuf.Duration new_workflow_run_timeout = 3 [(gogoproto.stdduration) = true];
     // If set, update the workflow execution timeout to this value. May be set to 0 for no timeout.
     google.protobuf.Duration new_workflow_execution_timeout = 4 [(gogoproto.stdduration) = true];
-    // If set, update the workflow memo to the provided value.
+    // If set, update the workflow memo with the provided values. The values will be merged with
+    // the existing memo. If the user wants to delete values, a default/empty Payload should be
+    // used as the value for the key being deleted.
     temporal.api.common.v1.Memo memo = 5;
 }
 

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -739,8 +739,8 @@ message HistoryEvent {
         UpdateWorkflowRequestedEventAttributes update_workflow_requested_event_attributes = 46;
         UpdateWorkflowAcceptedEventAttributes update_workflow_accepted_event_attributes = 47;
         UpdateWorkflowCompletedEventAttributes update_workflow_completed_event_attributes = 48;
-        WorkflowPropertiesModifiedEventAttributes workflow_properties_modified_event_attributes = 46;
-        ActivityPropertiesModifiedEventAttributes activity_properties_modified_event_attributes = 47;
+        WorkflowPropertiesModifiedEventAttributes workflow_properties_modified_event_attributes = 49;
+        ActivityPropertiesModifiedEventAttributes activity_properties_modified_event_attributes = 50;
     }
 }
 

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -666,6 +666,8 @@ message WorkflowPropertiesModifiedEventAttributes {
     google.protobuf.Duration new_workflow_run_timeout = 3 [(gogoproto.stdduration) = true];
     // If set, update the workflow execution timeout to this value. May be set to 0 for no timeout.
     google.protobuf.Duration new_workflow_execution_timeout = 4 [(gogoproto.stdduration) = true];
+    // If set, update the workflow memo to the provided value.
+    temporal.api.common.v1.Memo memo = 5;
 }
 
 message ActivityPropertiesModifiedEventAttributes {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added new events that we want to use to make changes to mutable state

Also introduces a new top-level field to history event which indicates that the SDK may ignore an event. This is immediately useful for the `ActivityPropertiesModifiedEvent`, and also gives us a non-breaking upgrade path for any such events in the future which will function with SDKs that do not know how to interpret the new event, but do know it is safe to ignore.

<!-- Tell your future self why have you made these changes -->
**Why?**
Support new features

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
:|

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
SDKs who are not updated to include these new protos and the corresponding logic *will* break if they encounter histories containing these events.
