### PR TITLE
Add namespace_division field

### DIFF
--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -98,6 +98,8 @@ message WorkflowExecutionStartedEventAttributes {
     // It should be used together with parent_initiated_event_id to identify
     // a child initiated event for global namespace
     int64 parent_initiated_event_version = 26;
+    // The namespace division this workflow exists in
+    string namespace_division = 28;
 }
 
 message WorkflowExecutionCompletedEventAttributes {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -137,6 +137,8 @@ message DeprecateNamespaceResponse {
 
 message StartWorkflowExecutionRequest {
     string namespace = 1;
+    // The namespace division to create this workflow in
+    string namespace_division = 17;
     string workflow_id = 2;
     temporal.api.common.v1.WorkflowType workflow_type = 3;
     temporal.api.taskqueue.v1.TaskQueue task_queue = 4;
@@ -542,6 +544,8 @@ message SignalWorkflowExecutionResponse {
 
 message SignalWithStartWorkflowExecutionRequest {
     string namespace = 1;
+    // The namespace division to create this workflow in
+    string namespace_division = 20;
     string workflow_id = 2;
     temporal.api.common.v1.WorkflowType workflow_type = 3;
     // The task queue to start this workflow on, if it will be started


### PR DESCRIPTION
**What changed?**
Add the first set of fields needed for namespace divisions.

**Why?**
Namespace divisions are initially a visibility concept that will let the server keep certain internal workflows separate from user workflows in the same namespace. It will be used for the new scheduler and batch operation workflows, and won't be available to users yet. All workflows will have a namespace division, a string, which will be the empty string by default. Visibility queries will be limited to a single division at a time. Eventually we may extend other namespace features to namespace divisions, such as resource limits and other dynamic config.
