### PR TITLE
Add failure Payloads

### DIFF
--- a/temporal/api/failure/v1/message.proto
+++ b/temporal/api/failure/v1/message.proto
@@ -90,14 +90,14 @@ message Failure {
     // message.
     //
     // SDK authors: 
-    // - The SDK should provide an overridable default `encodeFailureAttributes` and `decodeFailureAttributes`
-    //   implementation, those methods may mutate the original failure.
-    // - The default implementation uses a JSON object to represent `{ message, stack_trace }`.
-    //   - The original message is overridden with "Encoded failure" to indicate that more information could be
-    //     extracted
+    // - The SDK should provide a default `encodeFailureAttributes` and `decodeFailureAttributes` implementation that:
+    //   - Uses a JSON object to represent `{ message, stack_trace }`.
+    //   - Overwrites the original message with "Encoded failure" to indicate that more information could be extracted.
+    //   - Overwrites the original stack_trace with an empty string.
     //   - The resulting JSON object is converted to Payload using the default PayloadConverter and should be processed
     //     by the user-provided PayloadCodec
     //
+    // - If there's demand, we could allow overriding the default SDK implementation to encode other opaque Failure attributes.
     // (-- api-linter: core::0203::optional=disabled --)
     temporal.api.common.v1.Payload encoded_attributes = 20;
     Failure cause = 4;

--- a/temporal/api/failure/v1/message.proto
+++ b/temporal/api/failure/v1/message.proto
@@ -80,8 +80,18 @@ message ChildWorkflowExecutionFailureInfo {
 
 message Failure {
     string message = 1;
+    // The source this Failure originated in, e.g. TypeScriptSDK / JavaSDK
+    // In some SDKs this is used to rehydrate the stack trace into an exception object.
     string source = 2;
     string stack_trace = 3;
+    // Alternative way to supply `message` and `stack_trace`, used for encryption of errors originating in user code
+    // which might contain sensitive information. Mutually exclusive with `message` and `stack_trace`.
+    // SDK authors: 
+    // * Use one Payload for `message` and one for `stack_trace`
+    // * If only the one Payload is provided, it is assumed to be the message
+    // * Both Payloads are optional and if omitted the rehydrated error will assume an empty string for both
+    // * These strings MUST be created with the default PayloadConverter and MAY be processed by a PayloadCodec
+    temporal.api.common.v1.Payloads attributes = 20;
     Failure cause = 4;
     oneof failure_info {
         ApplicationFailureInfo application_failure_info = 5;

--- a/temporal/api/failure/v1/message.proto
+++ b/temporal/api/failure/v1/message.proto
@@ -87,10 +87,12 @@ message Failure {
     // Alternative way to supply `message` and `stack_trace`, used for encryption of errors originating in user code
     // which might contain sensitive information. Mutually exclusive with `message` and `stack_trace`.
     // SDK authors: 
-    // * Use one Payload for `message` and one for `stack_trace`
-    // * If only the one Payload is provided, it is assumed to be the message
-    // * Both Payloads are optional and if omitted the rehydrated error will assume an empty string for both
-    // * These strings MUST be created with the default PayloadConverter and MAY be processed by a PayloadCodec
+    // - Use one Payload for `message` and one for `stack_trace`
+    // - If only the one Payload is provided, it is assumed to be the message
+    // - Both Payloads are optional and if omitted the rehydrated error will assume an empty string for both
+    // - These strings MUST be created with the default PayloadConverter and MAY be processed by a PayloadCodec
+    //
+    // (-- api-linter: core::0203::optional=disabled --)
     temporal.api.common.v1.Payloads attributes = 20;
     Failure cause = 4;
     oneof failure_info {

--- a/temporal/api/failure/v1/message.proto
+++ b/temporal/api/failure/v1/message.proto
@@ -96,7 +96,7 @@ message Failure {
     //   - The original message is overridden with "Encoded failure" to indicate that more information could be
     //     extracted
     //   - The resulting JSON object is converted to Payload using the default PayloadConverter and should be processed
-    //     by the user provided PayloadCodec
+    //     by the user-provided PayloadCodec
     //
     // (-- api-linter: core::0203::optional=disabled --)
     temporal.api.common.v1.Payload encoded_attributes = 20;

--- a/temporal/api/failure/v1/message.proto
+++ b/temporal/api/failure/v1/message.proto
@@ -84,16 +84,22 @@ message Failure {
     // In some SDKs this is used to rehydrate the stack trace into an exception object.
     string source = 2;
     string stack_trace = 3;
-    // Alternative way to supply `message` and `stack_trace`, used for encryption of errors originating in user code
-    // which might contain sensitive information. Mutually exclusive with `message` and `stack_trace`.
+    // Alternative way to supply `message` and `stack_trace` and possibly other attributes, used for encryption of
+    // errors originating in user code which might contain sensitive information.
+    // The `encoded_attributes` Payload could represent any serializable object, e.g. JSON object or a `Failure` proto
+    // message.
+    //
     // SDK authors: 
-    // - Use one Payload for `message` and one for `stack_trace`
-    // - If only the one Payload is provided, it is assumed to be the message
-    // - Both Payloads are optional and if omitted the rehydrated error will assume an empty string for both
-    // - These strings MUST be created with the default PayloadConverter and MAY be processed by a PayloadCodec
+    // - The SDK should provide an overridable default `encodeFailureAttributes` and `decodeFailureAttributes`
+    //   implementation, those methods may mutate the original failure.
+    // - The default implementation uses a JSON object to represent `{ message, stack_trace }`.
+    //   - The original message is overridden with "Encoded failure" to indicate that more information could be
+    //     extracted
+    //   - The resulting JSON object is converted to Payload using the default PayloadConverter and should be processed
+    //     by the user provided PayloadCodec
     //
     // (-- api-linter: core::0203::optional=disabled --)
-    temporal.api.common.v1.Payloads attributes = 20;
+    temporal.api.common.v1.Payload encoded_attributes = 20;
     Failure cause = 4;
     oneof failure_info {
         ApplicationFailureInfo application_failure_info = 5;

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -804,7 +804,7 @@ message GetSystemInfoResponse {
         bool supports_schedules = 4;
 
         // True if server uses protos that include temporal.api.failure.v1.Failure.encoded_attributes
-        bool encoded_failure_attributes = 3;
+        bool encoded_failure_attributes = 5;
     }
 }
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -802,6 +802,9 @@ message GetSystemInfoResponse {
 
         // Supports scheduled workflow features.
         bool supports_schedules = 4;
+
+        // True if server uses protos that include temporal.api.failure.v1.Failure.encoded_attributes
+        bool encoded_failure_attributes = 3;
     }
 }
 


### PR DESCRIPTION
During SDK team standup, we'd discussed the need to allow opting into encrypting error messages and stack traces originating in user code.

This change is the first required block to allow this functionality.
Server should not use the new field, it should only be used by failures originating in the SDK.

Once the server repo is updated with these new protos, we should add a new server capability so clients can know they can start encrypting errors.