### PR TITLE
Added FailoverStatus to the replication NamespaceReplicationConfig proto

### DIFF
--- a/temporal/api/replication/v1/message.proto
+++ b/temporal/api/replication/v1/message.proto
@@ -45,11 +45,14 @@ message NamespaceReplicationConfig {
     string active_cluster_name = 1;
     repeated ClusterReplicationConfig clusters = 2;
     temporal.api.enums.v1.ReplicationState state = 3;
+    // Contains the historical state of failover_versions for the cluster, truncated to contain only the last N
+    // states to ensure that the list does not grow unbounded.
     repeated FailoverStatus failover_history = 4;
 }
 
 // Represents a historical replication status of a Namespace
 message FailoverStatus {
+    // Timestamp when the Cluster switched to the following failover_version
     google.protobuf.Timestamp failover_time = 1 [(gogoproto.stdtime) = true];
     int64 failover_version = 2;
 }

--- a/temporal/api/replication/v1/message.proto
+++ b/temporal/api/replication/v1/message.proto
@@ -31,6 +31,10 @@ option java_outer_classname = "MessageProto";
 option ruby_package = "Temporal::Api::Replication::V1";
 option csharp_namespace = "Temporal.Api.Replication.V1";
 
+import "google/protobuf/timestamp.proto";
+
+import "dependencies/gogoproto/gogo.proto";
+
 import "temporal/api/enums/v1/namespace.proto";
 
 message ClusterReplicationConfig {
@@ -41,4 +45,11 @@ message NamespaceReplicationConfig {
     string active_cluster_name = 1;
     repeated ClusterReplicationConfig clusters = 2;
     temporal.api.enums.v1.ReplicationState state = 3;
+    repeated FailoverStatus failover_history = 4;
+}
+
+// Represents a historical replication status of a Namespace
+message FailoverStatus {
+    google.protobuf.Timestamp failover_time = 1 [(gogoproto.stdtime) = true];
+    int64 failover_version = 2;
 }


### PR DESCRIPTION
This is the first of a set of changes that will enable replicating the full NamespaceReplicationConfig