### PR TITLE
Update API cleanups

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -2,6 +2,11 @@ version: v1
 breaking:
   ignore:
     - temporal/api/schedule/v1
+    - temporal/api/update/v1
+    - temporal/api/command/v1
+    - temporal/api/enums/v1
+    - temporal/api/history/v1
+    - temporal/api/workflowservice/v1
   use:
     - PACKAGE
 lint:

--- a/temporal/api/command/v1/message.proto
+++ b/temporal/api/command/v1/message.proto
@@ -215,22 +215,20 @@ message StartChildWorkflowExecutionCommandAttributes {
 }
 
 message AcceptWorkflowUpdateCommandAttributes {
-    // An opaque token that can be used to retrieve the update result via
-    // polling if it is not returned as part of the gRPC response
-    bytes update_token = 1;
+    // A unique identifier for an update within a given workflow context
+    string update_id = 1;
 }
 
 message CompleteWorkflowUpdateCommandAttributes {
-    // An opaque token that can be used to retrieve the update result via
-    // polling if it is not returned as part of the gRPC response
-    bytes update_token = 1;
+    // A unique identifier for an update within a given workflow context
+    string update_id = 1;
 
     // Whether the server should attempt to bypass making this update rejection
     // durable in history. This field is only consulted when the result field
     // indicates failure. Leaving this field in its default state (i.e.
     // UPDATE_WORKFLOW_REJECTION_DURABILITY_PREFERENCE_UNSPECIFIED) will result
     // in making the rejection durable.
-    temporal.api.enums.v1.UpdateWorkflowRejectionDurabilityPreference durability_preference = 2;
+    temporal.api.enums.v1.WorkflowUpdateDurabilityPreference durability_preference = 2;
 
     // The success or failure output of the update
     oneof result {

--- a/temporal/api/enums/v1/update.proto
+++ b/temporal/api/enums/v1/update.proto
@@ -31,21 +31,21 @@ option java_outer_classname = "UpdateProto";
 option ruby_package = "Temporal::Api::Enums::V1";
 option csharp_namespace = "Temporal.Api.Enums.V1";
 
-enum UpdateWorkflowResultAccessStyle {
-    UPDATE_WORKFLOW_RESULT_ACCESS_STYLE_UNSPECIFIED = 0;
+enum WorkflowUpdateResultAccessStyle {
+    WORKFLOW_UPDATE_RESULT_ACCESS_STYLE_UNSPECIFIED = 0;
 
     // Indicates that the update response _must_ be included as part of the gRPC
     // response body
-    UPDATE_WORKFLOW_RESULT_ACCESS_STYLE_REQUIRE_INLINE = 1;
+    WORKFLOW_UPDATE_RESULT_ACCESS_STYLE_REQUIRE_INLINE = 1;
 }
 
-enum UpdateWorkflowRejectionDurabilityPreference {
+enum WorkflowUpdateDurabilityPreference {
     // The workflow expresses no preference as to the durability of the
-    // rejection.
-    UPDATE_WORKFLOW_REJECTION_DURABILITY_PREFERENCE_UNSPECIFIED = 0;
+    // the associated update.
+    WORKFLOW_UPDATE_DURABILITY_PREFERENCE_UNSPECIFIED = 0;
 
     // Used by a workflow to indicate that no workflow state mutation occurred
     // while processing the update and that it wishes that the update not be
     // made durable (and thus not take up space in workflow history).
-    UPDATE_WORKFLOW_REJECTION_DURABILITY_PREFERENCE_BYPASS = 1;
+    WORKFLOW_UPDATE_DURABILITY_PREFERENCE_BYPASS = 1;
 }

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -635,20 +635,20 @@ message ChildWorkflowExecutionTerminatedEventAttributes {
     int64 started_event_id = 5;
 }
 
-message UpdateWorkflowRequestedEventAttributes {
+message WorkflowUpdateRequestedEventAttributes {
     temporal.api.common.v1.Header header = 1;
     string request_id = 2;
     string update_id = 3;
     temporal.api.update.v1.WorkflowUpdate update = 4;
 }
 
-message UpdateWorkflowAcceptedEventAttributes {
+message WorkflowUpdateAcceptedEventAttributes {
     temporal.api.common.v1.Header header = 1;
     string update_id = 2;
 }
 
-message UpdateWorkflowCompletedEventAttributes {
-    temporal.api.common.v1.Header header = 1;
+message WorkflowUpdateCompletedEventAttributes {
+    temporal.api.common.v1.Header system_header = 1;
     string update_id = 3;
     oneof result {
         temporal.api.common.v1.Payloads success = 4;
@@ -738,9 +738,9 @@ message HistoryEvent {
         SignalExternalWorkflowExecutionFailedEventAttributes signal_external_workflow_execution_failed_event_attributes = 43;
         ExternalWorkflowExecutionSignaledEventAttributes external_workflow_execution_signaled_event_attributes = 44;
         UpsertWorkflowSearchAttributesEventAttributes upsert_workflow_search_attributes_event_attributes = 45;
-        UpdateWorkflowRequestedEventAttributes update_workflow_requested_event_attributes = 46;
-        UpdateWorkflowAcceptedEventAttributes update_workflow_accepted_event_attributes = 47;
-        UpdateWorkflowCompletedEventAttributes update_workflow_completed_event_attributes = 48;
+        WorkflowUpdateRequestedEventAttributes workflow_update_requested_event_attributes = 46;
+        WorkflowUpdateAcceptedEventAttributes workflow_update_accepted_event_attributes = 47;
+        WorkflowUpdateCompletedEventAttributes workflow_update_completed_event_attributes = 48;
         WorkflowPropertiesModifiedExternallyEventAttributes workflow_properties_modified_externally_event_attributes = 49;
         ActivityPropertiesModifiedExternallyEventAttributes activity_properties_modified_externally_event_attributes = 50;
     }

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1009,7 +1009,7 @@ message UpdateWorkflowRequest {
     // The manner in which the update result will be accessed.
     // This field requires a non-default value; the default value of the enum
     // will result in an error.
-    temporal.api.enums.v1.UpdateWorkflowResultAccessStyle result_access_style = 2;
+    temporal.api.enums.v1.WorkflowUpdateResultAccessStyle result_access_style = 2;
 
     // The namespace name of the target workflow
     string namespace = 3;


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Implementing this API has show us some fixups that need to occur

- Use update_id rather than update_token in commands
- Consistenly use WorkflowUpdate rather than UpdateWorkflow for events,
  commands, and enums
- remove "Rejection" from WorkflowUpdateRejectionDurabilityPreference so
  that the enum can be used in more places

<!-- Tell your future self why have you made these changes -->
**Why?**
Naming predictability and reuse

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
Very. But to an API that has not been released or implemented yet so doesn't matter.
