### PR TITLE
Restore buf compatibility checking

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -3,10 +3,6 @@ breaking:
   ignore:
     - temporal/api/schedule/v1
     - temporal/api/update/v1
-    - temporal/api/command/v1
-    - temporal/api/enums/v1
-    - temporal/api/history/v1
-    - temporal/api/workflowservice/v1
   use:
     - PACKAGE
 lint:


### PR DESCRIPTION
Leave the update pkg unchecked as it is still evolving.

<!-- Describe what has changed in this PR -->
**What changed?**
Restores protobuf compatiibility checking temporarily suspended for a breaking change to a non-official API

<!-- Tell your future self why have you made these changes -->
**Why?**
Compatibility good

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
No
