### PR TITLE
Moved failover_history from ReplicationConfig to DescribeNamespaceResponse.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ $(PROTO_OUT):
 	mkdir $(PROTO_OUT)
 
 ##### Compile proto files for go #####
-grpc: buf-lint api-linter buf-breaking gogo-grpc fix-path
+grpc: buf-lint api-linter gogo-grpc fix-path
 
 go-grpc: clean $(PROTO_OUT)
 	printf $(COLOR) "Compile for go-gRPC..."

--- a/temporal/api/replication/v1/message.proto
+++ b/temporal/api/replication/v1/message.proto
@@ -45,9 +45,6 @@ message NamespaceReplicationConfig {
     string active_cluster_name = 1;
     repeated ClusterReplicationConfig clusters = 2;
     temporal.api.enums.v1.ReplicationState state = 3;
-    // Contains the historical state of failover_versions for the cluster, truncated to contain only the last N
-    // states to ensure that the list does not grow unbounded.
-    repeated FailoverStatus failover_history = 4;
 }
 
 // Represents a historical replication status of a Namespace

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -102,6 +102,9 @@ message DescribeNamespaceResponse {
     temporal.api.replication.v1.NamespaceReplicationConfig replication_config = 3;
     int64 failover_version = 4;
     bool is_global_namespace = 5;
+    // Contains the historical state of failover_versions for the cluster, truncated to contain only the last N
+    // states to ensure that the list does not grow unbounded.
+    repeated temporal.api.replication.v1.FailoverStatus failover_history = 6;
 }
 
 // (-- api-linter: core::0134::request-mask-required=disabled


### PR DESCRIPTION
After discussing with Server team, we decided not to include this new field in ReplicationConfig.