### PR TITLE
Add worker build id fields to poll requests

### DIFF
--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -75,6 +75,9 @@ message PollerInfo {
     google.protobuf.Timestamp last_access_time = 1 [(gogoproto.stdtime) = true];
     string identity = 2;
     double rate_per_second = 3;
+    // If a worker has specified an ID for use with the worker versioning feature while polling,
+    // that id must appear here.
+    string worker_versioning_build_id = 4;
 }
 
 message StickyExecutionAttributes {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -219,7 +219,13 @@ message PollWorkflowTaskQueueRequest {
     // The identity of the worker/client who is polling this task queue
     string identity = 3;
     // Each worker process should provide an ID unique to the specific set of code it is running
+    // "checksum" in this field name isn't very accurate, it should be though of as an id.
     string binary_checksum = 4;
+    // If set, the worker is opting in to build-id based versioning and wishes to only
+    // receive tasks that are considered compatible with the version provided in the string.
+    // Doing so only makes sense in conjunction with the `UpdateWorkerBuildIdOrdering` API.
+    // When set, `binary_checksum` and this field should typically have the same value.
+    string worker_build_id = 5;
 }
 
 message PollWorkflowTaskQueueResponse {
@@ -318,6 +324,10 @@ message PollActivityTaskQueueRequest {
     // The identity of the worker/client
     string identity = 3;
     temporal.api.taskqueue.v1.TaskQueueMetadata task_queue_metadata = 4;
+    // If set, the worker is opting in to build-id based versioning and wishes to only
+    // receive tasks that are considered compatible with the version provided in the string.
+    // Doing so only makes sense in conjunction with the `UpdateWorkerBuildIdOrdering` API.
+    string worker_build_id = 5;
 }
 
 message PollActivityTaskQueueResponse {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -224,8 +224,9 @@ message PollWorkflowTaskQueueRequest {
     // If set, the worker is opting in to build-id based versioning and wishes to only
     // receive tasks that are considered compatible with the version provided in the string.
     // Doing so only makes sense in conjunction with the `UpdateWorkerBuildIdOrdering` API.
-    // When set, `binary_checksum` and this field should typically have the same value.
-    string worker_build_id = 5;
+    // When set, and `binary_checksum` is not, this value should also be considered as the
+    // `binary_checksum`.
+    string worker_versioning_build_id = 5;
 }
 
 message PollWorkflowTaskQueueResponse {
@@ -327,7 +328,7 @@ message PollActivityTaskQueueRequest {
     // If set, the worker is opting in to build-id based versioning and wishes to only
     // receive tasks that are considered compatible with the version provided in the string.
     // Doing so only makes sense in conjunction with the `UpdateWorkerBuildIdOrdering` API.
-    string worker_build_id = 5;
+    string worker_versioning_build_id = 5;
 }
 
 message PollActivityTaskQueueResponse {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added worker build id field to poll requests.

I've used the id field consistency's sake so workflow and activity polls look similar. Alternatively, the workflow poll could be a boolean flag and lean on binary checksum, but this seems more obvious at the cost of duping a small amount of data in the poll request.

Open to other ideas too.

<!-- Tell your future self why have you made these changes -->
**Why?**
We need to know if a worker is opting in to the new versioning features when it polls. It does so by specifying its build id. 

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
No
