### PR TITLE
Add command and event enums to modify workflow properties

### DIFF
--- a/temporal/api/command/v1/message.proto
+++ b/temporal/api/command/v1/message.proto
@@ -156,7 +156,8 @@ message UpsertWorkflowSearchAttributesCommandAttributes {
 }
 
 message ModifyWorkflowPropertiesCommandAttributes {
-    temporal.api.common.v1.Memo memo = 1;
+    // If set, replace workflow memo with provided value.
+    temporal.api.common.v1.Memo new_memo = 1;
 }
 
 message RecordMarkerCommandAttributes {

--- a/temporal/api/command/v1/message.proto
+++ b/temporal/api/command/v1/message.proto
@@ -155,6 +155,10 @@ message UpsertWorkflowSearchAttributesCommandAttributes {
     temporal.api.common.v1.SearchAttributes search_attributes = 1;
 }
 
+message ModifyWorkflowPropertiesCommandAttributes {
+    temporal.api.common.v1.Memo memo = 1;
+}
+
 message RecordMarkerCommandAttributes {
     string marker_name = 1;
     map<string, temporal.api.common.v1.Payloads> details = 2;
@@ -255,5 +259,6 @@ message Command {
         UpsertWorkflowSearchAttributesCommandAttributes upsert_workflow_search_attributes_command_attributes = 14;
         AcceptWorkflowUpdateCommandAttributes accept_workflow_update_command_attributes = 15;
         CompleteWorkflowUpdateCommandAttributes complete_workflow_update_command_attributes = 16;
+        ModifyWorkflowPropertiesCommandAttributes modify_workflow_properties_command_attributes = 17;
     }
 }

--- a/temporal/api/command/v1/message.proto
+++ b/temporal/api/command/v1/message.proto
@@ -156,8 +156,10 @@ message UpsertWorkflowSearchAttributesCommandAttributes {
 }
 
 message ModifyWorkflowPropertiesCommandAttributes {
-    // If set, replace workflow memo with provided value.
-    temporal.api.common.v1.Memo new_memo = 1;
+    // If set, update the workflow memo with the provided values. The values will be merged with
+    // the existing memo. If the user wants to delete values, a default/empty Payload should be
+    // used as the value for the key being deleted.
+    temporal.api.common.v1.Memo upserted_memo = 1;
 }
 
 message RecordMarkerCommandAttributes {

--- a/temporal/api/enums/v1/command_type.proto
+++ b/temporal/api/enums/v1/command_type.proto
@@ -47,11 +47,10 @@ enum CommandType {
     COMMAND_TYPE_START_CHILD_WORKFLOW_EXECUTION = 11;
     COMMAND_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION = 12;
     COMMAND_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES = 13;
-
     // Indicates that an update has been accepted for processing workflow code
     COMMAND_TYPE_ACCEPT_WORKFLOW_UPDATE = 14;
-
     // Indicates that an update has completed and carries either the success or
     // failure outcome of said update.
     COMMAND_TYPE_COMPLETE_WORKFLOW_UPDATE = 15;
+    COMMAND_TYPE_MODIFY_WORKFLOW_PROPERTIES = 16;
 }

--- a/temporal/api/enums/v1/event_type.proto
+++ b/temporal/api/enums/v1/event_type.proto
@@ -165,4 +165,6 @@ enum EventType {
     // The distinction of external vs. command-based modification is important so the SDK can
     // maintain determinism when using the command-based approach.
     EVENT_TYPE_ACTIVITY_PROPERTIES_MODIFIED_EXTERNALLY = 45;
+    // Workflow properties modified by user workflow code
+    EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED = 46;
 }

--- a/temporal/api/enums/v1/failed_cause.proto
+++ b/temporal/api/enums/v1/failed_cause.proto
@@ -66,6 +66,7 @@ enum WorkflowTaskFailedCause {
     // The worker encountered a mismatch while replaying history between what was expected, and
     // what the workflow code actually did.
     WORKFLOW_TASK_FAILED_CAUSE_NON_DETERMINISTIC_ERROR = 24;
+    WORKFLOW_TASK_FAILED_CAUSE_BAD_MEMO = 25;
 }
 
 enum StartChildWorkflowExecutionFailedCause {

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -509,7 +509,8 @@ message UpsertWorkflowSearchAttributesEventAttributes {
 message WorkflowPropertiesModifiedEventAttributes {
     // The `WORKFLOW_TASK_COMPLETED` event which this command was reported with
     int64 workflow_task_completed_event_id = 1;
-    temporal.api.common.v1.Memo memo = 2;
+    // If set, replace workflow memo with provided value.
+    temporal.api.common.v1.Memo new_memo = 2;
 }
 
 message StartChildWorkflowExecutionInitiatedEventAttributes {

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -506,6 +506,12 @@ message UpsertWorkflowSearchAttributesEventAttributes {
     temporal.api.common.v1.SearchAttributes search_attributes = 2;
 }
 
+message WorkflowPropertiesModifiedEventAttributes {
+    // The `WORKFLOW_TASK_COMPLETED` event which this command was reported with
+    int64 workflow_task_completed_event_id = 1;
+    temporal.api.common.v1.Memo memo = 2;
+}
+
 message StartChildWorkflowExecutionInitiatedEventAttributes {
     // Namespace of the child workflow.
     // SDKs and UI tools should use `namespace` field but server must use `namespace_id` only.
@@ -743,6 +749,7 @@ message HistoryEvent {
         WorkflowUpdateCompletedEventAttributes workflow_update_completed_event_attributes = 48;
         WorkflowPropertiesModifiedExternallyEventAttributes workflow_properties_modified_externally_event_attributes = 49;
         ActivityPropertiesModifiedExternallyEventAttributes activity_properties_modified_externally_event_attributes = 50;
+        WorkflowPropertiesModifiedEventAttributes workflow_properties_modified_event_attributes = 51;
     }
 }
 

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -509,8 +509,10 @@ message UpsertWorkflowSearchAttributesEventAttributes {
 message WorkflowPropertiesModifiedEventAttributes {
     // The `WORKFLOW_TASK_COMPLETED` event which this command was reported with
     int64 workflow_task_completed_event_id = 1;
-    // If set, replace workflow memo with provided value.
-    temporal.api.common.v1.Memo new_memo = 2;
+    // If set, update the workflow memo with the provided values. The values will be merged with
+    // the existing memo. If the user wants to delete values, a default/empty Payload should be
+    // used as the value for the key being deleted.
+    temporal.api.common.v1.Memo upserted_memo = 2;
 }
 
 message StartChildWorkflowExecutionInitiatedEventAttributes {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding a command and an event for modifying workflow properties from user workflow code.
It's named generically so it can be re-used for modifying any workflow property, and for now, it only supports modifying memo.

<!-- Tell your future self why have you made these changes -->
**Why?**
Adding a feature to upsert memo.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
No.
