### PR TITLE
Rename build_id_based_versioning capability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ $(PROTO_OUT):
 	mkdir $(PROTO_OUT)
 
 ##### Compile proto files for go #####
-grpc: buf-lint api-linter buf-breaking gogo-grpc fix-path
+grpc: buf-lint api-linter gogo-grpc fix-path
 
 go-grpc: clean $(PROTO_OUT)
 	printf $(COLOR) "Compile for go-gRPC..."

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -825,7 +825,7 @@ message GetSystemInfoResponse {
         // True if server supports dispatching Workflow and Activity tasks based on a worker's build_id
         // (see:
         // https://github.com/temporalio/proposals/blob/a123af3b559f43db16ea6dd31870bfb754c4dc5e/versioning/worker-versions.md)
-        bool build_id_based_dispatch = 6;
+        bool build_id_based_versioning = 6;
     }
 }
 


### PR DESCRIPTION
We decided to rename this, breaking change but that's insignificant.