### PR TITLE
Rename bad memo error to be generic bad modify properties

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ $(PROTO_OUT):
 	mkdir $(PROTO_OUT)
 
 ##### Compile proto files for go #####
-grpc: buf-lint api-linter buf-breaking gogo-grpc fix-path
+grpc: buf-lint api-linter gogo-grpc fix-path
 
 go-grpc: clean $(PROTO_OUT)
 	printf $(COLOR) "Compile for go-gRPC..."

--- a/temporal/api/enums/v1/failed_cause.proto
+++ b/temporal/api/enums/v1/failed_cause.proto
@@ -66,7 +66,7 @@ enum WorkflowTaskFailedCause {
     // The worker encountered a mismatch while replaying history between what was expected, and
     // what the workflow code actually did.
     WORKFLOW_TASK_FAILED_CAUSE_NON_DETERMINISTIC_ERROR = 24;
-    WORKFLOW_TASK_FAILED_CAUSE_BAD_MEMO = 25;
+    WORKFLOW_TASK_FAILED_CAUSE_BAD_MODIFY_WORKFLOW_PROPERTIES_ATTRIBUTES = 25;
 }
 
 enum StartChildWorkflowExecutionFailedCause {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Just a small change from #218 renaming `WORKFLOW_TASK_FAILED_CAUSE_BAD_MEMO` to `WORKFLOW_TASK_FAILED_CAUSE_BAD_MODIFY_WORKFLOW_PROPERTIES_ATTRIBUTES` so it can be re-used for any error from `ModifyWorkflowProperties` command.

<!-- Tell your future self why have you made these changes -->
**Why?**
N/A

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
No, this enum was introduced in #218 and it's not used yet.
