### PR TITLE
Add worker_versioning_id to more messages, use VersionId

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -1,9 +1,9 @@
 version: v1
 breaking:
   ignore:
-    - temporal/api/schedule/v1
-    - temporal/api/update/v1
-    - temporal/api/batch/v1
+    # TODO: remove these after pr 229
+    - temporal/api/taskqueue/v1
+    - temporal/api/workflowservice/v1
   use:
     - PACKAGE
 lint:

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -192,6 +192,9 @@ message WorkflowTaskCompletedEventAttributes {
     string identity = 3;
     // Binary ID of the worker who completed this task
     string binary_checksum = 4;
+    // ID of the worker who picked up this workflow task, or missing if worker
+    // is not using versioning.
+    temporal.api.taskqueue.v1.VersionId worker_versioning_id = 5;
 }
 
 message WorkflowTaskTimedOutEventAttributes {

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -77,7 +77,8 @@ message PollerInfo {
     double rate_per_second = 3;
     // If a worker has specified an ID for use with the worker versioning feature while polling,
     // that id must appear here.
-    string worker_versioning_build_id = 4;
+    string worker_versioning_build_id = 4 [deprecated=true]; // use VersionId field
+    VersionId worker_versioning_id = 5;
 }
 
 message StickyExecutionAttributes {
@@ -98,7 +99,7 @@ message VersionIdNode {
 }
 
 // Used by the worker versioning APIs, represents a specific version of something
-// Currently, that's just a whole-worker id. In the future, if we support 
+// Currently, that's just a whole-worker id. In the future, if we support
 // WASM workflow bundle based versioning, for example, then the inside of this
 // message may become a oneof of different version types.
 message VersionId {

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -77,8 +77,7 @@ message PollerInfo {
     double rate_per_second = 3;
     // If a worker has specified an ID for use with the worker versioning feature while polling,
     // that id must appear here.
-    string worker_versioning_build_id = 4 [deprecated=true]; // use VersionId field
-    VersionId worker_versioning_id = 5;
+    VersionId worker_versioning_id = 4;
 }
 
 message StickyExecutionAttributes {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -226,8 +226,7 @@ message PollWorkflowTaskQueueRequest {
     // Doing so only makes sense in conjunction with the `UpdateWorkerBuildIdOrdering` API.
     // When `worker_versioning_id` has a `worker_build_id`, and `binary_checksum` is not
     // set, that value should also be considered as the `binary_checksum`.
-    string worker_versioning_build_id = 5 [deprecated=true]; // use VersionId field
-    temporal.api.taskqueue.v1.VersionId worker_versioning_id = 6;
+    temporal.api.taskqueue.v1.VersionId worker_versioning_id = 5;
 }
 
 message PollWorkflowTaskQueueResponse {
@@ -334,8 +333,7 @@ message PollActivityTaskQueueRequest {
     // If set, the worker is opting in to build-id based versioning and wishes to only
     // receive tasks that are considered compatible with the version provided.
     // Doing so only makes sense in conjunction with the `UpdateWorkerBuildIdOrdering` API.
-    string worker_versioning_build_id = 5 [deprecated=true]; // use VersionId field
-    temporal.api.taskqueue.v1.VersionId worker_versioning_id = 6;
+    temporal.api.taskqueue.v1.VersionId worker_versioning_id = 5;
 }
 
 message PollActivityTaskQueueResponse {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -295,6 +295,8 @@ message RespondWorkflowTaskCompletedRequest {
     string namespace = 9;
     // If using versioning, worker should send the same id here that it used to
     // poll for the workflow task.
+    // When `worker_versioning_id` has a `worker_build_id`, and `binary_checksum` is not
+    // set, that value should also be considered as the `binary_checksum`.
     temporal.api.taskqueue.v1.VersionId worker_versioning_id = 10;
 }
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -222,11 +222,12 @@ message PollWorkflowTaskQueueRequest {
     // "checksum" in this field name isn't very accurate, it should be though of as an id.
     string binary_checksum = 4;
     // If set, the worker is opting in to build-id based versioning and wishes to only
-    // receive tasks that are considered compatible with the version provided in the string.
+    // receive tasks that are considered compatible with the version provided.
     // Doing so only makes sense in conjunction with the `UpdateWorkerBuildIdOrdering` API.
-    // When set, and `binary_checksum` is not, this value should also be considered as the
-    // `binary_checksum`.
-    string worker_versioning_build_id = 5;
+    // When `worker_versioning_id` has a `worker_build_id`, and `binary_checksum` is not
+    // set, that value should also be considered as the `binary_checksum`.
+    string worker_versioning_build_id = 5 [deprecated=true]; // use VersionId field
+    temporal.api.taskqueue.v1.VersionId worker_versioning_id = 6;
 }
 
 message PollWorkflowTaskQueueResponse {
@@ -292,6 +293,9 @@ message RespondWorkflowTaskCompletedRequest {
     // Responses to the `queries` field in the task being responded to
     map<string, temporal.api.query.v1.WorkflowQueryResult> query_results = 8;
     string namespace = 9;
+    // If using versioning, worker should send the same id here that it used to
+    // poll for the workflow task.
+    temporal.api.taskqueue.v1.VersionId worker_versioning_id = 10;
 }
 
 message RespondWorkflowTaskCompletedResponse {
@@ -326,9 +330,10 @@ message PollActivityTaskQueueRequest {
     string identity = 3;
     temporal.api.taskqueue.v1.TaskQueueMetadata task_queue_metadata = 4;
     // If set, the worker is opting in to build-id based versioning and wishes to only
-    // receive tasks that are considered compatible with the version provided in the string.
+    // receive tasks that are considered compatible with the version provided.
     // Doing so only makes sense in conjunction with the `UpdateWorkerBuildIdOrdering` API.
-    string worker_versioning_build_id = 5;
+    string worker_versioning_build_id = 5 [deprecated=true]; // use VersionId field
+    temporal.api.taskqueue.v1.VersionId worker_versioning_id = 6;
 }
 
 message PollActivityTaskQueueResponse {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add `worker_versioning_id` to `WorkflowTaskCompletedEventAttributes` and `RespondWorkflowTaskCompletedRequest`.
Also switch string fields that were added recently (unused) to use `VersionId`.

<!-- Tell your future self why have you made these changes -->
**Why?**
We need to record this in history to ensure consistency on replay and replication.
Use `VersionId` everywhere for consistency.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
Deprecate string build id fields and switch to a new field. These were not used yet.
