### PR TITLE
Move DeleteWorkflowExecution to workflow service

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -4,6 +4,8 @@ breaking:
     # TODO: remove these after pr 229
     - temporal/api/taskqueue/v1
     - temporal/api/workflowservice/v1
+    # TODO (alex): remove these after pr 233
+    - temporal/api/operatorservice/v1
   use:
     - PACKAGE
 lint:

--- a/temporal/api/operatorservice/v1/request_response.proto
+++ b/temporal/api/operatorservice/v1/request_response.proto
@@ -36,7 +36,6 @@ import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";
 
 import "temporal/api/cluster/v1/message.proto";
-import "temporal/api/common/v1/message.proto";
 import "temporal/api/enums/v1/cluster.proto";
 import "temporal/api/enums/v1/common.proto";
 import "temporal/api/version/v1/message.proto";
@@ -82,19 +81,6 @@ message DeleteNamespaceRequest {
 message DeleteNamespaceResponse {
     // Temporary namespace name that is used during reclaim resources step.
     string deleted_namespace = 1;
-}
-
-// (-- api-linter: core::0135::request-unknown-fields=disabled
-//     aip.dev/not-precedent: DeleteNamespace RPC doesn't follow Google API format. --)
-// (-- api-linter: core::0135::request-name-required=disabled
-//     aip.dev/not-precedent: DeleteNamespace RPC doesn't follow Google API format. --)
-message DeleteWorkflowExecutionRequest {
-    string namespace = 1;
-    // Workflow Execution to delete. If run_id is not specified, the latest one is used.
-    temporal.api.common.v1.WorkflowExecution workflow_execution = 2;
-}
-
-message DeleteWorkflowExecutionResponse {
 }
 
 message AddOrUpdateRemoteClusterRequest {

--- a/temporal/api/operatorservice/v1/service.proto
+++ b/temporal/api/operatorservice/v1/service.proto
@@ -66,17 +66,6 @@ service OperatorService {
     rpc DeleteNamespace (DeleteNamespaceRequest) returns (DeleteNamespaceResponse) {
     }
 
-    // DeleteWorkflowExecution asynchronously deletes a specific Workflow Execution (when
-    // WorkflowExecution.run_id is provided) or the latest Workflow Execution (when
-    // WorkflowExecution.run_id is not provided). If the Workflow Execution is Running, it will be
-    // terminated before deletion.
-    // (-- api-linter: core::0135::method-signature=disabled
-    //     aip.dev/not-precedent: DeleteNamespace RPC doesn't follow Google API format. --)
-    // (-- api-linter: core::0135::response-message-name=disabled
-    //     aip.dev/not-precedent: DeleteNamespace RPC doesn't follow Google API format. --)
-    rpc DeleteWorkflowExecution (DeleteWorkflowExecutionRequest) returns (DeleteWorkflowExecutionResponse) {
-    }
-
     // AddOrUpdateRemoteCluster adds or updates remote cluster.
     rpc AddOrUpdateRemoteCluster(AddOrUpdateRemoteClusterRequest) returns (AddOrUpdateRemoteClusterResponse) {
     }

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -635,6 +635,19 @@ message TerminateWorkflowExecutionRequest {
 message TerminateWorkflowExecutionResponse {
 }
 
+// (-- api-linter: core::0135::request-unknown-fields=disabled
+//     aip.dev/not-precedent: DeleteNamespace RPC doesn't follow Google API format. --)
+// (-- api-linter: core::0135::request-name-required=disabled
+//     aip.dev/not-precedent: DeleteNamespace RPC doesn't follow Google API format. --)
+message DeleteWorkflowExecutionRequest {
+    string namespace = 1;
+    // Workflow Execution to delete. If run_id is not specified, the latest one is used.
+    temporal.api.common.v1.WorkflowExecution workflow_execution = 2;
+}
+
+message DeleteWorkflowExecutionResponse {
+}
+
 message ListOpenWorkflowExecutionsRequest {
     string namespace = 1;
     int32 maximum_page_size = 2;

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -256,6 +256,17 @@ service WorkflowService {
     rpc TerminateWorkflowExecution (TerminateWorkflowExecutionRequest) returns (TerminateWorkflowExecutionResponse) {
     }
 
+    // DeleteWorkflowExecution asynchronously deletes a specific Workflow Execution (when
+    // WorkflowExecution.run_id is provided) or the latest Workflow Execution (when
+    // WorkflowExecution.run_id is not provided). If the Workflow Execution is Running, it will be
+    // terminated before deletion.
+    // (-- api-linter: core::0135::method-signature=disabled
+    //     aip.dev/not-precedent: DeleteNamespace RPC doesn't follow Google API format. --)
+    // (-- api-linter: core::0135::response-message-name=disabled
+    //     aip.dev/not-precedent: DeleteNamespace RPC doesn't follow Google API format. --)
+    rpc DeleteWorkflowExecution (DeleteWorkflowExecutionRequest) returns (DeleteWorkflowExecutionResponse) {
+    }
+
     // ListOpenWorkflowExecutions is a visibility API to list the open executions in a specific namespace.
     rpc ListOpenWorkflowExecutions (ListOpenWorkflowExecutionsRequest) returns (ListOpenWorkflowExecutionsResponse) {
     }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Move `DeleteWorkflowExecution` to workflow service.

<!-- Tell your future self why have you made these changes -->
**Why?**
After number of discussions we came up to conclusion that all workflow execution APIs must be in `workflowservice`.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
Yes, but `DeleteWorkflowExecution` is accesible only using `tctl v2` which is in beta.