### PR TITLE
Remove unnecessary namespace fields from Batch API

### DIFF
--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1084,7 +1084,7 @@ message UpdateWorkflowResponse {
 }
 
 message StartBatchOperationRequest {
-    // Namespace that contains the batch operation
+    // Namespace of the Workflow Executions to operate on
     string namespace = 1;
     // Visibility query defines the the group of workflow to do batch operation
     string visibility_query = 2;
@@ -1101,11 +1101,11 @@ message StartBatchOperationRequest {
 }
 
 message StartBatchOperationResponse {
+    // Batch job id
+    string job_id = 1;
 }
 
 message StopBatchOperationRequest {
-    // Namespace that contains the batch operation
-    string namespace = 1;
     // Batch job id
     string job_id = 2;
     // Reason to stop a batch operation
@@ -1118,8 +1118,6 @@ message StopBatchOperationResponse {
 }
 
 message DescribeBatchOperationRequest {
-    // Namespace that contains the batch operation
-    string namespace = 1;
     // Batch job id
     string job_id = 2;
 }
@@ -1148,8 +1146,6 @@ message DescribeBatchOperationResponse {
 }
 
 message ListBatchOperationsRequest {
-    // Namespace that contains the batch operation
-    string namespace = 1;
     // List page size
     int32 page_size = 2;
     // Next page token


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

- These namespaces are not used since
- Added Job ID to start batch operation response

<!-- Tell your future self why have you made these changes -->
**Why?**

- Batch jobs run in Temporal System Local namespace and not in the namespace from requests
- returning Job ID can help with making the Job ID in request optional instead of required 

This came up after working on https://github.com/temporalio/temporal/pull/3428

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**

