### PR TITLE
Add merged search attributes and memo maps to upsert history events

### DIFF
--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -507,6 +507,9 @@ message UpsertWorkflowSearchAttributesEventAttributes {
     // The `WORKFLOW_TASK_COMPLETED` event which this command was reported with
     int64 workflow_task_completed_event_id = 1;
     temporal.api.common.v1.SearchAttributes search_attributes = 2;
+    // `merged_search_attributes` contains the result of upserting
+    // search attributes if they are not the same
+    temporal.api.common.v1.SearchAttributes merged_search_attributes = 3;
 }
 
 message WorkflowPropertiesModifiedEventAttributes {
@@ -516,6 +519,9 @@ message WorkflowPropertiesModifiedEventAttributes {
     // the existing memo. If the user wants to delete values, a default/empty Payload should be
     // used as the value for the key being deleted.
     temporal.api.common.v1.Memo upserted_memo = 2;
+    // `merged_memo` contains the result of upserting memo
+    // if `upserted_memo` is not nil and they are not the same
+    temporal.api.common.v1.Memo merged_memo = 3;
 }
 
 message StartChildWorkflowExecutionInitiatedEventAttributes {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add fields to search attributes and memo upsert events to store the merged/final maps.

<!-- Tell your future self why have you made these changes -->
**Why?**
Adding those fields so they are stored in the history events and they can be removed from mutable state. More info: https://github.com/temporalio/temporal/pull/3471

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
No.
