### PR TITLE
Add AliasSearchAttributes endpoint to operator service

### DIFF
--- a/temporal/api/namespace/v1/message.proto
+++ b/temporal/api/namespace/v1/message.proto
@@ -62,6 +62,7 @@ message NamespaceConfig {
     // If unspecified (ARCHIVAL_STATE_UNSPECIFIED) then default server configuration is used.
     temporal.api.enums.v1.ArchivalState visibility_archival_state = 5;
     string visibility_archival_uri = 6;
+    map<string, string> custom_search_attributes_alias = 7;
 }
 
 message BadBinaries {

--- a/temporal/api/operatorservice/v1/request_response.proto
+++ b/temporal/api/operatorservice/v1/request_response.proto
@@ -38,6 +38,7 @@ import "temporal/api/enums/v1/common.proto";
 message AddSearchAttributesRequest {
     // Mapping between search attribute name and its IndexedValueType.
     map<string, temporal.api.enums.v1.IndexedValueType> search_attributes = 1;
+    string namespace = 2;
 }
 
 message AddSearchAttributesResponse {
@@ -46,12 +47,14 @@ message AddSearchAttributesResponse {
 message RemoveSearchAttributesRequest {
     // Search attribute names to delete.
     repeated string search_attributes = 1;
+    string namespace = 2;
 }
 
 message RemoveSearchAttributesResponse {
 }
 
 message ListSearchAttributesRequest {
+    string namespace = 1;
 }
 
 message ListSearchAttributesResponse {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding `AliasSearchAttributes` endpoint to operator service

<!-- Tell your future self why have you made these changes -->
**Why?**
Adding command to `tctl` to alias custom search attributes.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
No.
