### PR TITLE
Add SDK-specific data to WFT Completions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 # Syntax is here:
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-* @temporalio/server @temporalio/sdk
+*                       @temporalio/server @temporalio/sdk
+api/temporal/api/sdk/*  @temporalio/sdk

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -195,6 +195,9 @@ message WorkflowTaskCompletedEventAttributes {
     // ID of the worker who picked up this workflow task, or missing if worker
     // is not using versioning.
     temporal.api.taskqueue.v1.VersionId worker_versioning_id = 5;
+    // See `RespondWorkflowTaskCompletedRequest::metadata`. This field contains either all or
+    // some subset of the information from the WFT completion request.
+    map<string, temporal.api.common.v1.Payload> metadata = 6;
 }
 
 message WorkflowTaskTimedOutEventAttributes {

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -44,7 +44,7 @@ import "temporal/api/failure/v1/message.proto";
 import "temporal/api/taskqueue/v1/message.proto";
 import "temporal/api/update/v1/message.proto";
 import "temporal/api/workflow/v1/message.proto";
-import "temporal/api/sdk/v1/wft_complete_metadata.proto";
+import "temporal/api/sdk/v1/task_complete_metadata.proto";
 
 // Always the first event in workflow history
 message WorkflowExecutionStartedEventAttributes {
@@ -198,7 +198,7 @@ message WorkflowTaskCompletedEventAttributes {
     temporal.api.taskqueue.v1.VersionId worker_versioning_id = 5;
     // Data the SDK wishes to record for itself, but server need not interpret, and does not
     // directly impact workflow state.
-    temporal.api.sdk.v1.WFTCompleteMetadata sdk_data = 6;
+    temporal.api.sdk.v1.WorkflowTaskCompletedMetadata sdk_metadata = 6;
 }
 
 message WorkflowTaskTimedOutEventAttributes {

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -44,6 +44,7 @@ import "temporal/api/failure/v1/message.proto";
 import "temporal/api/taskqueue/v1/message.proto";
 import "temporal/api/update/v1/message.proto";
 import "temporal/api/workflow/v1/message.proto";
+import "temporal/api/sdk/v1/wft_complete_metadata.proto";
 
 // Always the first event in workflow history
 message WorkflowExecutionStartedEventAttributes {
@@ -195,9 +196,9 @@ message WorkflowTaskCompletedEventAttributes {
     // ID of the worker who picked up this workflow task, or missing if worker
     // is not using versioning.
     temporal.api.taskqueue.v1.VersionId worker_versioning_id = 5;
-    // See `RespondWorkflowTaskCompletedRequest::metadata`. This field contains either all or
-    // some subset of the information from the WFT completion request.
-    map<string, temporal.api.common.v1.Payload> metadata = 6;
+    // Data the SDK wishes to record for itself, but server need not interpret, and does not
+    // directly impact workflow state.
+    temporal.api.sdk.v1.WFTCompleteMetadata sdk_data = 6;
 }
 
 message WorkflowTaskTimedOutEventAttributes {

--- a/temporal/api/sdk/v1/task_complete_metadata.proto
+++ b/temporal/api/sdk/v1/task_complete_metadata.proto
@@ -1,3 +1,25 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 syntax = "proto3";
 
 package temporal.api.sdk.v1;
@@ -10,37 +32,32 @@ option ruby_package = "Temporalio::Api::Sdk::V1";
 option csharp_namespace = "Temporalio.Api.Sdk.V1";
 
 message WorkflowTaskCompletedMetadata {
-  // Internal patches used by an SDK. SDKs must comply with the following behavior:
+  // Internal flags used by the core SDK. SDKs using flags must comply with the following behavior:
   //
   // During replay:
-  // * If a patch is not recognized (value is too high or not defined), it must fail the workflow
+  // * If a flag is not recognized (value is too high or not defined), it must fail the workflow
   //   task.
-  // * If a patch is recognized, it is stored in a set of used patches for the run. Code checks for
-  //   that patch during and after this WFT are allowed to assume that the patch is present.
-  // * If a code check for a patch does not find the patch in the set of used patches, it must take
-  //   the branch corresponding to the absence of that patch.
+  // * If a flag is recognized, it is stored in a set of used flags for the run. Code checks for
+  //   that flag during and after this WFT are allowed to assume that the flag is present.
+  // * If a code check for a flag does not find the flag in the set of used flags, it must take
+  //   the branch corresponding to the absence of that flag.
   //
   // During non-replay execution of new WFTs:
-  // * The SDK is free to use all patches it knows about. It must record any newly-used (IE: not
-  //   previously recorded) patches when completing the WFT.
+  // * The SDK is free to use all flags it knows about. It must record any newly-used (IE: not
+  //   previously recorded) flags when completing the WFT.
   //
-  // SDKs which are too old to even know about this message at all are considered to produce
+  // SDKs which are too old to even know about this field at all are considered to produce
   // undefined behavior if they replay workflows which used this mechanism.
-  InternalPatches internal_patches = 1;
-}
-
-message InternalPatches {
-  // Patches used by Core. Non-Core-using languages may error if they see anything in this field.
   //
   // (-- api-linter: core::0141::forbidden-types=disabled
   //     aip.dev/not-precedent: These really shouldn't have negative values. --)
-  repeated uint32 core_used_patches = 1;
+  repeated uint32 core_used_flags = 1;
 
-  // Patches used by the SDK lang. No attempt is made to distinguish between different SDK languages
+  // Flags used by the SDK lang. No attempt is made to distinguish between different SDK languages
   // here as processing a workflow with a different language than the one which authored it is
-  // already undefined behavior.
+  // already undefined behavior. See `core_used_patches` for more.
   //
   // (-- api-linter: core::0141::forbidden-types=disabled
   //     aip.dev/not-precedent: These really shouldn't have negative values. --)
-  repeated uint32 lang_used_patches = 2;
+  repeated uint32 lang_used_flags = 2;
 }

--- a/temporal/api/sdk/v1/task_complete_metadata.proto
+++ b/temporal/api/sdk/v1/task_complete_metadata.proto
@@ -5,11 +5,11 @@ package temporal.api.sdk.v1;
 option go_package = "go.temporal.io/api/sdk/v1;sdk";
 option java_package = "io.temporal.api.sdk.v1";
 option java_multiple_files = true;
-option java_outer_classname = "WftCompleteMetadataProto";
+option java_outer_classname = "TaskCompleteMetadataProto";
 option ruby_package = "Temporalio::Api::Sdk::V1";
 option csharp_namespace = "Temporalio.Api.Sdk.V1";
 
-message WFTCompleteMetadata {
+message WorkflowTaskCompletedMetadata {
   // Internal patches used by an SDK. SDKs must comply with the following behavior:
   //
   // During replay:

--- a/temporal/api/sdk/v1/wft_complete_metadata.proto
+++ b/temporal/api/sdk/v1/wft_complete_metadata.proto
@@ -1,0 +1,46 @@
+syntax = "proto3";
+
+package temporal.api.sdk.v1;
+
+option go_package = "go.temporal.io/api/sdk/v1;sdk";
+option java_package = "io.temporal.api.sdk.v1";
+option java_multiple_files = true;
+option java_outer_classname = "WftCompleteMetadataProto";
+option ruby_package = "Temporalio::Api::Sdk::V1";
+option csharp_namespace = "Temporalio.Api.Sdk.V1";
+
+message WFTCompleteMetadata {
+  // Internal patches used by an SDK. SDKs must comply with the following behavior:
+  //
+  // During replay:
+  // * If a patch is not recognized (value is too high or not defined), it must fail the workflow
+  //   task.
+  // * If a patch is recognized, it is stored in a set of used patches for the run. Code checks for
+  //   that patch during and after this WFT are allowed to assume that the patch is present.
+  // * If a code check for a patch does not find the patch in the set of used patches, it must take
+  //   the branch corresponding to the absence of that patch.
+  //
+  // During non-replay execution of new WFTs:
+  // * The SDK is free to use all patches it knows about. It must record any newly-used (IE: not
+  //   previously recorded) patches when completing the WFT.
+  //
+  // SDKs which are too old to even know about this message at all are considered to produce
+  // undefined behavior if they replay workflows which used this mechanism.
+  InternalPatches internal_patches = 1;
+}
+
+message InternalPatches {
+  // Patches used by Core. Non-Core-using languages may error if they see anything in this field.
+  //
+  // (-- api-linter: core::0141::forbidden-types=disabled
+  //     aip.dev/not-precedent: These really shouldn't have negative values. --)
+  repeated uint32 core_used_patches = 1;
+
+  // Patches used by the SDK lang. No attempt is made to distinguish between different SDK languages
+  // here as processing a workflow with a different language than the one which authored it is
+  // already undefined behavior.
+  //
+  // (-- api-linter: core::0141::forbidden-types=disabled
+  //     aip.dev/not-precedent: These really shouldn't have negative values. --)
+  repeated uint32 lang_used_patches = 2;
+}

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -54,6 +54,7 @@ import "temporal/api/taskqueue/v1/message.proto";
 import "temporal/api/update/v1/message.proto";
 import "temporal/api/version/v1/message.proto";
 import "temporal/api/batch/v1/message.proto";
+import "temporal/api/sdk/v1/wft_complete_metadata.proto";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
@@ -310,10 +311,9 @@ message RespondWorkflowTaskCompletedRequest {
     temporal.api.taskqueue.v1.VersionId worker_versioning_id = 10;
     // Protocol messages piggybacking on a WFT as a transport
     repeated temporal.api.protocol.v1.Message messages = 11;
-    // Additional metadata which is not directly relevant to the reconstruction of workflow state.
-    // It may be used by SDKs to make notes to themselves, or to provide dynamic information to
-    // the server which is not explicitly defined in this response message.
-    map<string, temporal.api.common.v1.Payload> metadata = 12;
+    // Data the SDK wishes to record for itself, but server need not interpret, and does not
+    // directly impact workflow state.
+    temporal.api.sdk.v1.WFTCompleteMetadata sdk_data = 12;
 }
 
 message RespondWorkflowTaskCompletedResponse {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -310,6 +310,10 @@ message RespondWorkflowTaskCompletedRequest {
     temporal.api.taskqueue.v1.VersionId worker_versioning_id = 10;
     // Protocol messages piggybacking on a WFT as a transport
     repeated temporal.api.protocol.v1.Message messages = 11;
+    // Additional metadata which is not directly relevant to the reconstruction of workflow state.
+    // It may be used by SDKs to make notes to themselves, or to provide dynamic information to
+    // the server which is not explicitly defined in this response message.
+    map<string, temporal.api.common.v1.Payload> metadata = 12;
 }
 
 message RespondWorkflowTaskCompletedResponse {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -54,7 +54,7 @@ import "temporal/api/taskqueue/v1/message.proto";
 import "temporal/api/update/v1/message.proto";
 import "temporal/api/version/v1/message.proto";
 import "temporal/api/batch/v1/message.proto";
-import "temporal/api/sdk/v1/wft_complete_metadata.proto";
+import "temporal/api/sdk/v1/task_complete_metadata.proto";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
@@ -313,7 +313,7 @@ message RespondWorkflowTaskCompletedRequest {
     repeated temporal.api.protocol.v1.Message messages = 11;
     // Data the SDK wishes to record for itself, but server need not interpret, and does not
     // directly impact workflow state.
-    temporal.api.sdk.v1.WFTCompleteMetadata sdk_data = 12;
+    temporal.api.sdk.v1.WorkflowTaskCompletedMetadata sdk_metadata = 12;
 }
 
 message RespondWorkflowTaskCompletedResponse {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added an sdk-specific field which server need not inspect to WFT completions and events.

<!-- Tell your future self why have you made these changes -->
**Why?**
We felt that the generality of the approach in https://github.com/temporalio/proposals/pull/73/files wasn't exactly necessary (see last comment I've left there).

This accomplishes our current specific need in a more wire-efficient and type safe way.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
No
