### PR TITLE
Add field for nonfirst LA attempts count

### DIFF
--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -110,3 +110,14 @@ message RetryPolicy {
     // this is not a substring match, the error *type* (not message) must match exactly.
     repeated string non_retryable_error_types = 5;
 }
+
+// Metadata relevant for metering purposes
+message MeteringMetadata {
+    // Count of local activities which have begun an execution attempt during this workflow task,
+    // and whose first attempt occurred in some previous task. This is used for metering
+    // purposes, and does not affect workflow state.
+    //
+    // (-- api-linter: core::0141::forbidden-types=disabled
+    //     aip.dev/not-precedent: Negative values make no sense to represent. --)
+    uint32 nonfirst_local_activity_execution_attempts = 13;
+}

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -199,13 +199,8 @@ message WorkflowTaskCompletedEventAttributes {
     // Data the SDK wishes to record for itself, but server need not interpret, and does not
     // directly impact workflow state.
     temporal.api.sdk.v1.WorkflowTaskCompletedMetadata sdk_metadata = 6;
-    // Count of local activities which have begun an execution attempt during this workflow task,
-    // and whose first attempt occurred in some previous task. This is used for metering
-    // purposes, and does not affect workflow state.
-    //
-    // (-- api-linter: core::0141::forbidden-types=disabled
-    //     aip.dev/not-precedent: Negative values make no sense to represent. --)
-    uint32 nonfirst_local_activity_execution_attempts = 7;
+    // Local usage data sent during workflow task completion and recorded here for posterity
+    temporal.api.common.v1.MeteringMetadata metering_metadata = 13;
 }
 
 message WorkflowTaskTimedOutEventAttributes {

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -199,6 +199,13 @@ message WorkflowTaskCompletedEventAttributes {
     // Data the SDK wishes to record for itself, but server need not interpret, and does not
     // directly impact workflow state.
     temporal.api.sdk.v1.WorkflowTaskCompletedMetadata sdk_metadata = 6;
+    // Count of local activities which have begun an execution attempt during this workflow task,
+    // and whose first attempt occurred in some previous task. This is used for metering
+    // purposes, and does not affect workflow state.
+    //
+    // (-- api-linter: core::0141::forbidden-types=disabled
+    //     aip.dev/not-precedent: Negative values make no sense to represent. --)
+    uint32 nonfirst_local_activity_execution_attempts = 7;
 }
 
 message WorkflowTaskTimedOutEventAttributes {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -320,13 +320,8 @@ message RespondWorkflowTaskCompletedRequest {
     // Data the SDK wishes to record for itself, but server need not interpret, and does not
     // directly impact workflow state.
     temporal.api.sdk.v1.WorkflowTaskCompletedMetadata sdk_metadata = 12;
-    // Count of local activities which have begun an execution attempt during this workflow task,
-    // and whose first attempt occurred in some previous task. This is used for metering
-    // purposes, and does not affect workflow state.
-    //
-    // (-- api-linter: core::0141::forbidden-types=disabled
-    //     aip.dev/not-precedent: Negative values make no sense to represent. --)
-    uint32 nonfirst_local_activity_execution_attempts = 13;
+    // Local usage data collected for metering
+    temporal.api.common.v1.MeteringMetadata metering_metadata = 13;
 }
 
 message RespondWorkflowTaskCompletedResponse {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -320,6 +320,13 @@ message RespondWorkflowTaskCompletedRequest {
     // Data the SDK wishes to record for itself, but server need not interpret, and does not
     // directly impact workflow state.
     temporal.api.sdk.v1.WorkflowTaskCompletedMetadata sdk_metadata = 12;
+    // Count of local activities which have begun an execution attempt during this workflow task,
+    // and whose first attempt occurred in some previous task. This is used for metering
+    // purposes, and does not affect workflow state.
+    //
+    // (-- api-linter: core::0141::forbidden-types=disabled
+    //     aip.dev/not-precedent: Negative values make no sense to represent. --)
+    uint32 nonfirst_local_activity_execution_attempts = 13;
 }
 
 message RespondWorkflowTaskCompletedResponse {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Pursuant to our discussions and conclusions around how we will charge for Local Activities in cloud, I've added the field that contains the information we need to perform those charges accurately.

The field is *not* added to the completed event, because metering does not need it to be there to work properly, and it has no value from a replay perspective.

For discussion:
* Should we embed this field inside a new message? That was my initial inclination, for future proofing purposes, but it's not clear exactly what that name would be. `MeteringMetadata`? Does it seem likely we'll need more info at some point? Arguably not, since we don't even really want to use this as a long term solution anyway.

<!-- Tell your future self why have you made these changes -->
**Why?**
Needed for accurate metring

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
No
