### PR TITLE
Add continued_failure and last_completion_result to StartWorkflowExecution

### DIFF
--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -174,7 +174,10 @@ message StartWorkflowExecutionRequest {
     // The returned task will be marked as started and is expected to be completed by the specified
     // `workflow_task_timeout`.
     bool request_eager_execution = 17;
-    // These two fields are intended for internal use only.
+    // These values will be available as ContinuedFailure and LastCompletionResult in the
+    // WorkflowExecutionStarted event and through SDKs. The are currently only used by the
+    // server itself (for the schedules feature) and are not intended to be exposed in
+    // StartWorkflowExecution.
     temporal.api.failure.v1.Failure continued_failure = 18;
     temporal.api.common.v1.Payloads last_completion_result = 19;
 }

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -174,6 +174,9 @@ message StartWorkflowExecutionRequest {
     // The returned task will be marked as started and is expected to be completed by the specified
     // `workflow_task_timeout`.
     bool request_eager_execution = 17;
+    // These two fields are intended for internal use only.
+    temporal.api.failure.v1.Failure continued_failure = 18;
+    temporal.api.common.v1.Payloads last_completion_result = 19;
 }
 
 message StartWorkflowExecutionResponse {


### PR DESCRIPTION
**What changed?**
Allow these two fields to be set on new workflows at the frontend api level.

**Why?**
For the schedule feature, we need to be able to set these, but also want the rpc to go through the frontend. They don't have to be exposed anywhere else.

**Breaking changes**
No