### PR TITLE
Add workflow_start_delay

### DIFF
--- a/temporal/api/enums/v1/workflow.proto
+++ b/temporal/api/enums/v1/workflow.proto
@@ -67,6 +67,8 @@ enum ContinueAsNewInitiator {
     CONTINUE_AS_NEW_INITIATOR_RETRY = 2;
     // The workflow continued as new because cron has triggered a new execution
     CONTINUE_AS_NEW_INITIATOR_CRON_SCHEDULE = 3;
+    // The workflow continued as new because the start was delayed
+    CONTINUE_AS_NEW_INITIATOR_DELAY_START = 4;
 }
 
 // (-- api-linter: core::0216::synonyms=disabled

--- a/temporal/api/enums/v1/workflow.proto
+++ b/temporal/api/enums/v1/workflow.proto
@@ -67,8 +67,6 @@ enum ContinueAsNewInitiator {
     CONTINUE_AS_NEW_INITIATOR_RETRY = 2;
     // The workflow continued as new because cron has triggered a new execution
     CONTINUE_AS_NEW_INITIATOR_CRON_SCHEDULE = 3;
-    // The workflow continued as new because the start was delayed
-    CONTINUE_AS_NEW_INITIATOR_DELAY_START = 4;
 }
 
 // (-- api-linter: core::0216::synonyms=disabled

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -180,6 +180,8 @@ message StartWorkflowExecutionRequest {
     // StartWorkflowExecution.
     temporal.api.failure.v1.Failure continued_failure = 18;
     temporal.api.common.v1.Payloads last_completion_result = 19;
+    // Time to wait before starting the first workflow run. Cannot be used with `cron_schedule`.
+    google.protobuf.Duration workflow_start_delay = 20 [(gogoproto.stdduration) = true];
 }
 
 message StartWorkflowExecutionResponse {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -631,8 +631,8 @@ message SignalWithStartWorkflowExecutionRequest {
     // Time to wait before dispatching the first workflow task. Cannot be used with `cron_schedule`.
     // Note that the signal will be delivered with the first workflow task. If the workflow gets
     // another SignalWithStartWorkflow before the delay, a workflow task will be dispatched immediately
-    // and the rest of the delay period will be ignored. Signal via SignalWorkflowExecution will
-    // not unblock the workflow.
+    // and the rest of the delay period will be ignored, even if that request also had a delay. Signal
+    // via SignalWorkflowExecution will not unblock the workflow.
     google.protobuf.Duration workflow_start_delay = 20 [(gogoproto.stdduration) = true];
 }
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -630,7 +630,9 @@ message SignalWithStartWorkflowExecutionRequest {
     temporal.api.common.v1.Header header = 19;
     // Time to wait before dispatching the first workflow task. Cannot be used with `cron_schedule`.
     // Note that the signal will be delivered with the first workflow task. If the workflow gets
-    // another signal before the delay, a workflow task will be dispatched immediately.
+    // another SignalWithStartWorkflow before the delay, a workflow task will be dispatched immediately
+    // and the rest of the delay period will be ignored. Signal via SignalWorkflowExecution will
+    // not unblock the workflow.
     google.protobuf.Duration workflow_start_delay = 20 [(gogoproto.stdduration) = true];
 }
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -626,6 +626,8 @@ message SignalWithStartWorkflowExecutionRequest {
     temporal.api.common.v1.Memo memo = 17;
     temporal.api.common.v1.SearchAttributes search_attributes = 18;
     temporal.api.common.v1.Header header = 19;
+    // Time to wait before starting the first workflow run.
+    google.protobuf.Duration workflow_start_delay = 20 [(gogoproto.stdduration) = true];
 }
 
 message SignalWithStartWorkflowExecutionResponse {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -626,7 +626,7 @@ message SignalWithStartWorkflowExecutionRequest {
     temporal.api.common.v1.Memo memo = 17;
     temporal.api.common.v1.SearchAttributes search_attributes = 18;
     temporal.api.common.v1.Header header = 19;
-    // Time to wait before starting the first workflow run.
+    // Time to wait before starting the first workflow run. Cannot be used with `cron_schedule`.
     google.protobuf.Duration workflow_start_delay = 20 [(gogoproto.stdduration) = true];
 }
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -180,7 +180,9 @@ message StartWorkflowExecutionRequest {
     // StartWorkflowExecution.
     temporal.api.failure.v1.Failure continued_failure = 18;
     temporal.api.common.v1.Payloads last_completion_result = 19;
-    // Time to wait before starting the first workflow run. Cannot be used with `cron_schedule`.
+    // Time to wait before dispatching the first workflow task. Cannot be used with `cron_schedule`.
+    // If the workflow gets a signal before the delay, a workflow task will be dispatched and the rest
+    // of the delay will be ignored.
     google.protobuf.Duration workflow_start_delay = 20 [(gogoproto.stdduration) = true];
 }
 
@@ -626,7 +628,9 @@ message SignalWithStartWorkflowExecutionRequest {
     temporal.api.common.v1.Memo memo = 17;
     temporal.api.common.v1.SearchAttributes search_attributes = 18;
     temporal.api.common.v1.Header header = 19;
-    // Time to wait before starting the first workflow run. Cannot be used with `cron_schedule`.
+    // Time to wait before dispatching the first workflow task. Cannot be used with `cron_schedule`.
+    // Note that the signal will be delivered with the first workflow task. If the workflow gets
+    // another signal before the delay, a workflow task will be dispatched immediately.
     google.protobuf.Duration workflow_start_delay = 20 [(gogoproto.stdduration) = true];
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added ability to specify a delay when starting a workflow. Cannot be used with workflows that have a `cron_schedule`

<!-- Tell your future self why have you made these changes -->
**Why?**
https://github.com/temporalio/temporal/issues/3378

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
None
