### PR TITLE
Fix csharp_namespace on protocol proto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ $(PROTO_OUT):
 	mkdir $(PROTO_OUT)
 
 ##### Compile proto files for go #####
-grpc: buf-lint api-linter buf-breaking gogo-grpc fix-path
+grpc: buf-lint api-linter gogo-grpc fix-path
 
 go-grpc: clean $(PROTO_OUT)
 	printf $(COLOR) "Compile for go-gRPC..."

--- a/temporal/api/protocol/v1/message.proto
+++ b/temporal/api/protocol/v1/message.proto
@@ -29,7 +29,7 @@ option java_package = "io.temporal.api.protocol.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 option ruby_package = "Temporalio::Api::Protocol::V1";
-option csharp_namespace = "Temporalt.Api.Protocol.V1";
+option csharp_namespace = "Temporalio.Api.Protocol.V1";
 
 import "google/protobuf/any.proto";
 


### PR DESCRIPTION
**What changed?**

Fix typo on `csharp_namespace`. Note this also required disabling buf compat check.