### PR TITLE
Worker versioning related updates

### DIFF
--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -129,10 +129,6 @@ message WorkerVersionStamp {
     // Set if the worker used a dynamically loadable bundle to process
     // the task. The bundle could be a WASM blob, JS bundle, etc.
     string bundle_id = 2;
-
-    // If set, the worker is opting in to worker versioning. Otherwise, the version stamp is used as a marker for
-    // workflow reset points and the BuildId search attibute.
-    bool uses_versioning = 3;
 }
 
 // Identifies the version(s) that a worker is compatible with when polling or identifying itself

--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -129,6 +129,10 @@ message WorkerVersionStamp {
     // Set if the worker used a dynamically loadable bundle to process
     // the task. The bundle could be a WASM blob, JS bundle, etc.
     string bundle_id = 2;
+
+    // If set, the worker is opting in to worker versioning. Otherwise, the version stamp is used as a marker for
+    // workflow reset points and the BuildId search attibute.
+    bool uses_versioning = 3;
 }
 
 // Identifies the version(s) that a worker is compatible with when polling or identifying itself

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -88,11 +88,10 @@ message StickyExecutionAttributes {
 }
 
 // Used by the worker versioning APIs, represents an ordering of one or more versions which are
-// considered to be compatible with each other. Currently the versions are always worker build ids.
+// considered to be compatible with each other. Currently the versions are always worker build IDs.
 message CompatibleVersionSet {
-    // A unique identifier for this version set. Users don't need to understand or care about this
-    // value, but it has value for debugging purposes.
-    string version_set_id = 1;
-    // All the compatible versions, ordered from oldest to newest
-    repeated string build_ids = 2;
+    // All the compatible versions, in insertion order.
+    // The last element is considered the set "default" and may not be the last inserted item in case of promoting an
+    // older build ID to be the set default.
+    repeated string build_ids = 1;
 }

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -87,11 +87,9 @@ message StickyExecutionAttributes {
     google.protobuf.Duration schedule_to_start_timeout = 2 [(gogoproto.stdduration) = true];
 }
 
-// Used by the worker versioning APIs, represents an ordering of one or more versions which are
+// Used by the worker versioning APIs, represents an unordered set of one or more versions which are
 // considered to be compatible with each other. Currently the versions are always worker build IDs.
 message CompatibleVersionSet {
-    // All the compatible versions, in insertion order.
-    // The last element is considered the set "default" and may not be the last inserted item in case of promoting an
-    // older build ID to be the set default.
+    // All the compatible versions, unordered, except for the last element, which is considered the set "default".
     repeated string build_ids = 1;
 }

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -327,6 +327,11 @@ message RespondWorkflowTaskCompletedRequest {
     temporal.api.sdk.v1.WorkflowTaskCompletedMetadata sdk_metadata = 12;
     // Local usage data collected for metering
     temporal.api.common.v1.MeteringMetadata metering_metadata = 13;
+
+    // If set, the worker is opting in to worker versioning. Otherwise, worker_version_stamp is used as a marker for
+    // workflow reset points and the BuildId search attibute.
+    // This flag must only be set if worker_version_stamp is provided.
+    bool use_versioning = 14;
 }
 
 message RespondWorkflowTaskCompletedResponse {


### PR DESCRIPTION
Decided not to expose (the yet unused) `CompatibleVersionSet.version_set_id`, the set will have multiple IDs internally.

The affected projects have been updated:
- [x] [Server PR](https://github.com/temporalio/temporal/pull/4170)
- [x] [Go SDK PR](https://github.com/temporalio/sdk-go/pull/1089)

Also added a `use_versioning` flag to `RespondWorkflowTaskCompletedRequest` to differentiate between the version stamp being used for versioning (matching) purposes or just as a marker.