### PR TITLE
Add flags for using the default build id set

### DIFF
--- a/temporal/api/command/v1/message.proto
+++ b/temporal/api/command/v1/message.proto
@@ -88,7 +88,7 @@ message ScheduleActivityTaskCommandAttributes {
     // is the default behavior) and instead will use the current overall default for the queue.
     // If this command's `task_queue` field differs from the executing workflow's task queue, then
     // this flag has no effect.
-    bool use_default_build_id_set = 13;
+    bool use_latest_build_id = 13;
 }
 
 message RequestCancelActivityTaskCommandAttributes {
@@ -202,7 +202,7 @@ message ContinueAsNewWorkflowExecutionCommandAttributes {
     // is the default behavior) and instead will use the current overall default for the queue.
     // If this command's `task_queue` field differs from the executing workflow's task queue, then
     // this flag has no effect.
-    bool use_default_build_id_set = 15;
+    bool use_latest_build_id = 15;
 
     // `workflow_execution_timeout` is omitted as it shouldn't be overridden from within a workflow.
 }
@@ -235,7 +235,7 @@ message StartChildWorkflowExecutionCommandAttributes {
     // is the default behavior) and instead will use the current overall default for the queue.
     // If this command's `task_queue` field differs from the executing workflow's task queue, then
     // this flag has no effect.
-    bool use_default_build_id_set = 17;
+    bool use_latest_build_id = 17;
 }
 
 message ProtocolMessageCommandAttributes {

--- a/temporal/api/command/v1/message.proto
+++ b/temporal/api/command/v1/message.proto
@@ -83,6 +83,12 @@ message ScheduleActivityTaskCommandAttributes {
     // Request to start the activity directly bypassing matching service and worker polling
     // The slot for executing the activity should be reserved when setting this field to true.
     bool request_eager_execution = 12;
+    // If this is set and the workflow executing this command is on a task queue using build-id
+    // versioning, then the scheduled activity will not use the same compatible version set (which
+    // is the default behavior) and instead will use the current overall default for the queue.
+    // If this command's `task_queue` field differs from the executing workflow's task queue, then
+    // this flag has no effect.
+    bool use_default_build_id_set = 13;
 }
 
 message RequestCancelActivityTaskCommandAttributes {
@@ -191,6 +197,12 @@ message ContinueAsNewWorkflowExecutionCommandAttributes {
     temporal.api.common.v1.Header header = 12;
     temporal.api.common.v1.Memo memo = 13;
     temporal.api.common.v1.SearchAttributes search_attributes = 14;
+    // If this is set and the workflow executing this command is on a task queue using build-id
+    // versioning, then the continued workflow will not use the same compatible version set (which
+    // is the default behavior) and instead will use the current overall default for the queue.
+    // If this command's `task_queue` field differs from the executing workflow's task queue, then
+    // this flag has no effect.
+    bool use_default_build_id_set = 15;
 
     // `workflow_execution_timeout` is omitted as it shouldn't be overridden from within a workflow.
 }
@@ -218,6 +230,12 @@ message StartChildWorkflowExecutionCommandAttributes {
     temporal.api.common.v1.Header header = 14;
     temporal.api.common.v1.Memo memo = 15;
     temporal.api.common.v1.SearchAttributes search_attributes = 16;
+    // If this is set and the workflow executing this command is on a task queue using build-id
+    // versioning, then the child workflow will not use the same compatible version set (which
+    // is the default behavior) and instead will use the current overall default for the queue.
+    // If this command's `task_queue` field differs from the executing workflow's task queue, then
+    // this flag has no effect.
+    bool use_default_build_id_set = 17;
 }
 
 message ProtocolMessageCommandAttributes {

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -152,6 +152,12 @@ message WorkflowExecutionContinuedAsNewEventAttributes {
     temporal.api.common.v1.Header header = 12;
     temporal.api.common.v1.Memo memo = 13;
     temporal.api.common.v1.SearchAttributes search_attributes = 14;
+    // If this is set and the workflow executing this command is on a task queue using build-id
+    // versioning, then the scheduled activity will not use the same compatible version set (which
+    // is the default behavior) and instead will use the current overall default for the queue.
+    // If this command's `task_queue` field differs from the executing workflow's task queue, then
+    // this flag has no effect.
+    bool use_latest_build_id = 15;
 
     // workflow_execution_timeout is omitted as it shouldn't be overridden from within a workflow.
 }
@@ -270,6 +276,12 @@ message ActivityTaskScheduledEventAttributes {
     // configuration. Retries will happen up to `schedule_to_close_timeout`. To disable retries set
     // retry_policy.maximum_attempts to 1.
     temporal.api.common.v1.RetryPolicy retry_policy = 12;
+    // If this is set and the workflow executing this command is on a task queue using build-id
+    // versioning, then the scheduled activity will not use the same compatible version set (which
+    // is the default behavior) and instead will use the current overall default for the queue.
+    // If this command's `task_queue` field differs from the executing workflow's task queue, then
+    // this flag has no effect.
+    bool use_latest_build_id = 13;
 }
 
 message ActivityTaskStartedEventAttributes {
@@ -556,6 +568,12 @@ message StartChildWorkflowExecutionInitiatedEventAttributes {
     temporal.api.common.v1.Header header = 15;
     temporal.api.common.v1.Memo memo = 16;
     temporal.api.common.v1.SearchAttributes search_attributes = 17;
+    // If this is set and the workflow executing this command is on a task queue using build-id
+    // versioning, then the child workflow will not use the same compatible version set (which
+    // is the default behavior) and instead will use the current overall default for the queue.
+    // If this command's `task_queue` field differs from the executing workflow's task queue, then
+    // this flag has no effect.
+    bool use_latest_build_id = 19;
 }
 
 message StartChildWorkflowExecutionFailedEventAttributes {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add flags to activity/child/c-a-n to explicitly use the default version set rather than the compatible set when sticking to the same queue.

<!-- Tell your future self why have you made these changes -->
**Why?**
Flexibility with the versioning feature

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**

