### PR TITLE
Add NewerBuildExistsFailure

### DIFF
--- a/temporal/api/errordetails/v1/message.proto
+++ b/temporal/api/errordetails/v1/message.proto
@@ -106,3 +106,8 @@ message SystemWorkflowFailure {
 
 message WorkflowNotReadyFailure {
 }
+
+message NewerBuildExistsFailure {
+    // Build ID of the newer compatible build that will receive tasks.
+    string latest_build_id = 1;
+}


### PR DESCRIPTION
**What changed?**
Add error details for NewerBuildExistsFailure.

**Why?**
This error (with OutOfRange code) will be returned to pollers which will not receive any tasks because they've been superseded by a newer build.