### PR TITLE
Record intent to use versioning in WorkerVersionStamp

### DIFF
--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -206,6 +206,12 @@ message WorkflowTaskCompletedEventAttributes {
     // Data the SDK wishes to record for itself, but server need not interpret, and does not
     // directly impact workflow state.
     temporal.api.sdk.v1.WorkflowTaskCompletedMetadata sdk_metadata = 6;
+
+    // If set, the worker that completed this task opted in to worker versioning. Otherwise, worker_version_stamp is
+    // used as a marker for workflow reset points and the BuildId search attibute.
+    // This flag must only be set if worker_version_stamp is provided.
+    bool use_versioning = 7;
+
     // Local usage data sent during workflow task completion and recorded here for posterity
     temporal.api.common.v1.MeteringMetadata metering_metadata = 13;
 }


### PR DESCRIPTION
We need to store this intent to distinguish between a when a version is used as a binary checksum replacement or for task dispatching.