### PR TITLE
Store more build ID and versioning information in history and reset points

### DIFF
--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -129,6 +129,10 @@ message WorkerVersionStamp {
     // Set if the worker used a dynamically loadable bundle to process
     // the task. The bundle could be a WASM blob, JS bundle, etc.
     string bundle_id = 2;
+
+    // If set, the worker is opting in to worker versioning. Otherwise, this is used as a marker for workflow reset
+    // points and the BuildIDs search attribute.
+    bool use_versioning = 3;
 }
 
 // Identifies the version(s) that a worker is compatible with when polling or identifying itself

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -206,6 +206,7 @@ message WorkflowTaskCompletedEventAttributes {
     // Data the SDK wishes to record for itself, but server need not interpret, and does not
     // directly impact workflow state.
     temporal.api.sdk.v1.WorkflowTaskCompletedMetadata sdk_metadata = 6;
+
     // Local usage data sent during workflow task completion and recorded here for posterity
     temporal.api.common.v1.MeteringMetadata metering_metadata = 13;
 }

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -109,8 +109,12 @@ message ResetPoints {
 }
 
 message ResetPointInfo {
+    // A worker binary version identifier, will be deprecated and superceeded by a newer concept of build_id (see
+    // below).
     string binary_checksum = 1;
+    // The first run ID in the execution chain that was touched by this worker build.
     string run_id = 2;
+    // Event ID of the first WorkflowTaskCompleted event processed by this worker build.
     int64 first_workflow_task_completed_id = 3;
     google.protobuf.Timestamp create_time = 4 [(gogoproto.stdtime) = true];
     // (-- api-linter: core::0214::resource-expiry=disabled
@@ -119,6 +123,8 @@ message ResetPointInfo {
     google.protobuf.Timestamp expire_time = 5 [(gogoproto.stdtime) = true];
     // false if the reset point has pending childWFs/reqCancels/signalExternals.
     bool resettable = 6;
+    // A worker build identifier, may or may not be tied to task dispatching and the "worker versioning" feature.
+    string build_id = 7;
 }
 
 // NewWorkflowExecutionInfo is a shared message that encapsulates all the

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -327,11 +327,6 @@ message RespondWorkflowTaskCompletedRequest {
     temporal.api.sdk.v1.WorkflowTaskCompletedMetadata sdk_metadata = 12;
     // Local usage data collected for metering
     temporal.api.common.v1.MeteringMetadata metering_metadata = 13;
-
-    // If set, the worker is opting in to worker versioning. Otherwise, worker_version_stamp is used as a marker for
-    // workflow reset points and the BuildId search attibute.
-    // This flag must only be set if worker_version_stamp is provided.
-    bool use_versioning = 14;
 }
 
 message RespondWorkflowTaskCompletedResponse {


### PR DESCRIPTION
- Moved uses_versioning into `WorkerVersionStamp` so its recorded in the `WorkflowTaskCompleted` event.
- Added build_id to `ResetPointInfo` to distinguish between build ID reset points and binary checksum reset points and take us a step closer towards deprecation of binary checksum.