### PR TITLE
Remove run id from WorkflowExecutionStartedEventAttributes

### DIFF
--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -100,11 +100,8 @@ message WorkflowExecutionStartedEventAttributes {
     // It should be used together with parent_initiated_event_id to identify
     // a child initiated event for global namespace
     int64 parent_initiated_event_version = 26;
-    // The workflow and run id of the current workflow execution. This run id may be different from the
-    // original_execution_run_id. For example, if a workflow is reset, a second workflow-started event will be created,
-    // and it will have the same original run id, but a new run id in this field.
     // This field is new in 1.21.
-    temporal.api.common.v1.WorkflowExecution current_execution = 28;
+    string workflow_id = 28;
 }
 
 message WorkflowExecutionCompletedEventAttributes {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
^

<!-- Tell your future self why have you made these changes -->
**Why?**
The current run id is not something we can set in the workflow-started event because we don't produce a new workflow-started event when a workflow is reset. Also, we don't need the current run id, just the workflow id.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
I reserved the field number and name, and I also re-enabled buf breaking to ensure binary and JSON wire compatibility.
