### PR TITLE
Re-enable buf breaking

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -1,12 +1,7 @@
 version: v1
 breaking:
-  ignore:
-    # TODO: Remove after PR 237
-    - temporal/api/taskqueue/v1
-    - temporal/api/workflowservice/v1
-    - temporal/api/history/v1
   use:
-    - PACKAGE
+    - WIRE_JSON
 lint:
   use:
     - DEFAULT


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
1. I removed all of the ignored directories from our buf breaking config.
2. I changed our compatibility setting to WIRE_JSON

<!-- Tell your future self why have you made these changes -->
**Why?**
1. Because these were supposed to be removed a while ago after some refactoring
2. Because FILE and PACKAGE make it impossible to rename/remove existing-but-deprecated fields. WIRE_JSON ensures binary and JSON compatibility.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
This will break #280 , so I will only land this after that is merged.
