### PR TITLE
Add a new resource exhausted cause

### DIFF
--- a/temporal/api/enums/v1/failed_cause.proto
+++ b/temporal/api/enums/v1/failed_cause.proto
@@ -122,4 +122,6 @@ enum ResourceExhaustedCause {
     RESOURCE_EXHAUSTED_CAUSE_SYSTEM_OVERLOADED = 3;
     // Namespace exceeds persistence rate limit.
     RESOURCE_EXHAUSTED_CAUSE_PERSISTENCE_LIMIT = 4;
+    // Workflow is busy
+    RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW = 5;
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added workflow busy enum item for resource exhausted. 


<!-- Tell your future self why have you made these changes -->
**Why?**
When workflow is busy and cannot be locked, we want to return a proper error.


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
No

