### PR TITLE
Add version stamp to WorkflowExecutionStartedEventAttributes

### DIFF
--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -100,6 +100,12 @@ message WorkflowExecutionStartedEventAttributes {
     // It should be used together with parent_initiated_event_id to identify
     // a child initiated event for global namespace
     int64 parent_initiated_event_version = 26;
+    // When using build-id versioning, we tie the version of a child workflow or
+    // continued-as-new workflow on the same task queue to the parent/previous workflow by
+    // default (unless requested with use_latest_build_id). To make that version
+    // information available in the new workflow, we include it here. If this field is not
+    // present, workflows on a versioned task queue will be assigned the latest version.
+    temporal.api.common.v1.WorkerVersionStamp source_version_stamp = 29;
 }
 
 message WorkflowExecutionCompletedEventAttributes {


### PR DESCRIPTION
**What changed?**
Add version stamp to WorkflowExecutionStartedEventAttributes

**Why?**
We need the stamp to the tie version of child and continued-as-new workflows to their source (parent/previous)

**Breaking changes**
no
