### PR TITLE
Another take on the task reachability API

### DIFF
--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -104,14 +104,6 @@ message TaskQueueReachability {
     repeated temporal.api.enums.v1.TaskReachability reachability = 2;
 }
 
-// Reachability of tasks for a worker by build id, in one or more task queues.
-message BuildIdReachability {
-    // A build id or empty if unversioned.
-    string build_id = 1;
-    // Reachability per task queue.
-    repeated TaskQueueReachability task_queue_reachability = 2;
-}
-
 // Scope of task reachability for a reachability query.
 message TaskReachabilityScope {
     oneof variant {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1137,7 +1137,7 @@ message GetWorkerTaskReachabilityResponse {
     // Task reachability, broken down by task queue.
     // This response lists all task queues mapped to the requested build id when the requested query scope is for an
     // entire namespace but the number of task queues that include reachability information is limited.
-    // When reaching the limit, task queues that do not have reachability information will be marked with a single
+    // When reaching the limit, task queues that reachability information could not be retrieved for will be marked with a single
     // TASK_REACHABILITY_UNSPECIFIED entry. The caller may issue separate calls to get the reachability for those task
     // queues.
     // Open source users can adjust this limit by setting the server's dynamic config value for

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1126,17 +1126,23 @@ message GetWorkerBuildIdCompatibilityResponse {
 
 message GetWorkerTaskReachabilityRequest {
     string namespace = 1;
-    // Specify whether reachability should be returned for a specific worker version or all workers polling on a specific task queue.
-    oneof subject {
-        string task_queue = 2;
-        string build_id = 3;
-    }
-    temporal.api.taskqueue.v1.TaskReachabilityScope scope = 4;
+    // Build id to retrieve reachability for. Leave empty to query reachability of an unversioned worker.
+    string build_id = 2;
+    // Scope of the reachability query (namespace or task queue).
+    // Must specify a task queue if querying for an unversioned worker.
+    temporal.api.taskqueue.v1.TaskReachabilityScope scope = 3;
 }
 
 message GetWorkerTaskReachabilityResponse {
-    // Task reachability, broken down by build id.
-    repeated temporal.api.taskqueue.v1.BuildIdReachability build_id_reachability = 1;
+    // Task reachability, broken down by task queue.
+    // This response lists all task queues mapped to the requested build id when the requested query scope is for an
+    // entire namespace but the number of task queues that include reachability information is limited.
+    // When reaching the limit, task queues that do not have reachability information will be marked with a single
+    // TASK_REACHABILITY_UNSPECIFIED entry. The caller may issue separate calls to get the reachability for those task
+    // queues.
+    // Open source users can adjust this limit by setting the server's dynamic config value for
+    // `limit.reachabilityTaskQueueScan` with the caveat that this call can strain the visibility store.
+    repeated temporal.api.taskqueue.v1.TaskQueueReachability task_queue_reachability = 1;
 }
 
 // (-- api-linter: core::0134=disabled

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -396,7 +396,7 @@ service WorkflowService {
     // Fetches task reachability to determine whether a worker may be retired.
     // The response lists all task queues mapped to the requested build id when the requested query scope is for an
     // entire namespace but the number of task queues that include reachability information is limited.
-    // When reaching the limit, task queues that do not have reachability information will be marked with a single
+    // When reaching the limit, task queues that reachability information could not be retrieved for will be marked with a single
     // TASK_REACHABILITY_UNSPECIFIED entry. The caller may issue separate calls to get the reachability for those task
     // queues.
     // Open source users can adjust this limit by setting the server's dynamic config value for

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -393,8 +393,14 @@ service WorkflowService {
     // Fetches the worker build id versioning sets for a task queue.
     rpc GetWorkerBuildIdCompatibility (GetWorkerBuildIdCompatibilityRequest) returns (GetWorkerBuildIdCompatibilityResponse) {}
 
-    // Fetches task reachability to determine whether a single worker or all workers polling on a specific task queue may
-    // be retired.
+    // Fetches task reachability to determine whether a worker may be retired.
+    // The response lists all task queues mapped to the requested build id when the requested query scope is for an
+    // entire namespace but the number of task queues that include reachability information is limited.
+    // When reaching the limit, task queues that do not have reachability information will be marked with a single
+    // TASK_REACHABILITY_UNSPECIFIED entry. The caller may issue separate calls to get the reachability for those task
+    // queues.
+    // Open source users can adjust this limit by setting the server's dynamic config value for
+    // `limit.reachabilityTaskQueueScan` with the caveat that this call can strain the visibility store.
     rpc GetWorkerTaskReachability (GetWorkerTaskReachabilityRequest) returns (GetWorkerTaskReachabilityResponse) {}
 
     // Invokes the specified update function on user workflow code.


### PR DESCRIPTION
After implementing the previous take on this API, I decided to go back to a previous design and remove the ability to query by task queue to reduce the amount of visibility query fanout caused by a single request.
Also documented some of the limitations that will be enforced server side along with a recommendation for working around those limits.