### PR TITLE
Fix comment for use_latest_build_id and add some advice in the Update…

### DIFF
--- a/temporal/api/command/v1/message.proto
+++ b/temporal/api/command/v1/message.proto
@@ -86,8 +86,6 @@ message ScheduleActivityTaskCommandAttributes {
     // If this is set and the workflow executing this command is on a task queue using build-id
     // versioning, then the scheduled activity will not use the same compatible version set (which
     // is the default behavior) and instead will use the current overall default for the queue.
-    // If this command's `task_queue` field differs from the executing workflow's task queue, then
-    // this flag has no effect.
     bool use_latest_build_id = 13;
 }
 
@@ -200,8 +198,6 @@ message ContinueAsNewWorkflowExecutionCommandAttributes {
     // If this is set and the workflow executing this command is on a task queue using build-id
     // versioning, then the continued workflow will not use the same compatible version set (which
     // is the default behavior) and instead will use the current overall default for the queue.
-    // If this command's `task_queue` field differs from the executing workflow's task queue, then
-    // this flag has no effect.
     bool use_latest_build_id = 15;
 
     // `workflow_execution_timeout` is omitted as it shouldn't be overridden from within a workflow.
@@ -233,8 +229,6 @@ message StartChildWorkflowExecutionCommandAttributes {
     // If this is set and the workflow executing this command is on a task queue using build-id
     // versioning, then the child workflow will not use the same compatible version set (which
     // is the default behavior) and instead will use the current overall default for the queue.
-    // If this command's `task_queue` field differs from the executing workflow's task queue, then
-    // this flag has no effect.
     bool use_latest_build_id = 17;
 }
 

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -161,8 +161,6 @@ message WorkflowExecutionContinuedAsNewEventAttributes {
     // If this is set and the workflow executing this command is on a task queue using build-id
     // versioning, then the scheduled activity will not use the same compatible version set (which
     // is the default behavior) and instead will use the current overall default for the queue.
-    // If this command's `task_queue` field differs from the executing workflow's task queue, then
-    // this flag has no effect.
     bool use_latest_build_id = 15;
 
     // workflow_execution_timeout is omitted as it shouldn't be overridden from within a workflow.
@@ -286,8 +284,6 @@ message ActivityTaskScheduledEventAttributes {
     // If this is set and the workflow executing this command is on a task queue using build-id
     // versioning, then the scheduled activity will not use the same compatible version set (which
     // is the default behavior) and instead will use the current overall default for the queue.
-    // If this command's `task_queue` field differs from the executing workflow's task queue, then
-    // this flag has no effect.
     bool use_latest_build_id = 13;
 }
 
@@ -578,8 +574,6 @@ message StartChildWorkflowExecutionInitiatedEventAttributes {
     // If this is set and the workflow executing this command is on a task queue using build-id
     // versioning, then the child workflow will not use the same compatible version set (which
     // is the default behavior) and instead will use the current overall default for the queue.
-    // If this command's `task_queue` field differs from the executing workflow's task queue, then
-    // this flag has no effect.
     bool use_latest_build_id = 19;
 }
 

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -385,11 +385,17 @@ service WorkflowService {
     // version, forming sets of ids which are incompatible with each other, but whose contained
     // members are compatible with one another.
     //
+    // A single build id may be mapped to multiple task queues using this API for cases where a single process hosts
+    // multiple workers.
+    // 
+    // To query which workers can be retired, use the `GetWorkerTaskReachability` API.
+    //
     // (-- api-linter: core::0134::response-message-name=disabled
     //     aip.dev/not-precedent: UpdateWorkerBuildIdCompatibility RPC doesn't follow Google API format. --)
     // (-- api-linter: core::0134::method-signature=disabled
     //     aip.dev/not-precedent: UpdateWorkerBuildIdCompatibility RPC doesn't follow Google API format. --)
     rpc UpdateWorkerBuildIdCompatibility (UpdateWorkerBuildIdCompatibilityRequest) returns (UpdateWorkerBuildIdCompatibilityResponse) {}
+
     // Fetches the worker build id versioning sets for a task queue.
     rpc GetWorkerBuildIdCompatibility (GetWorkerBuildIdCompatibilityRequest) returns (GetWorkerBuildIdCompatibilityResponse) {}
 


### PR DESCRIPTION
…WorkerBuildIdCompatibility API docstring


**Why?**

The SDK may choose to set `use_latest_build_id` when a single process hosts multiple workers on different task queues. Deleted the incorrect comment.