### PR TITLE
Apply more feedback to the reachability API

### DIFF
--- a/temporal/api/enums/v1/task_queue.proto
+++ b/temporal/api/enums/v1/task_queue.proto
@@ -59,15 +59,20 @@ enum TaskQueueType {
 }
 
 // Specifies which category of tasks may reach a worker on a versioned task queue.
+// Used both in a reachability query and its response.
 enum TaskReachability {
     TASK_REACHABILITY_UNSPECIFIED = 0;
     // There's a possiblity for a worker to receive new workflow tasks. Workers should *not* be retired.
     TASK_REACHABILITY_NEW_WORKFLOWS = 1;
+    // There's a possiblity for a worker to receive existing workflow and activity tasks from existing workflows. Workers
+    // should *not* be retired.
+    // This enum value does not distinguish between open and closed workflows.
+    TASK_REACHABILITY_EXISTING_WORKFLOWS = 2;
     // There's a possiblity for a worker to receive existing workflow and activity tasks from open workflows. Workers
     // should *not* be retired.
-    TASK_REACHABILITY_OPEN_WORKFLOWS = 2;
+    TASK_REACHABILITY_OPEN_WORKFLOWS = 3;
     // There's a possiblity for a worker to receive existing workflow tasks from closed workflows. Workers may be
     // retired dependending on application requirements. For example, if there's no need to query closed workflows.
-    TASK_REACHABILITY_CLOSED_WORKFLOWS = 3;
+    TASK_REACHABILITY_CLOSED_WORKFLOWS = 4;
 }
 

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -104,6 +104,14 @@ message TaskQueueReachability {
     repeated temporal.api.enums.v1.TaskReachability reachability = 2;
 }
 
+// Reachability of tasks for a worker by build id, in one or more task queues.
+message BuildIdReachability {
+    // A build id or empty if unversioned.
+    string build_id = 1;
+    // Reachability per task queue.
+    repeated TaskQueueReachability task_queue_reachability = 2;
+}
+
 // Scope of task reachability for a reachability query.
 message TaskReachabilityScope {
     oneof variant {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1126,23 +1126,31 @@ message GetWorkerBuildIdCompatibilityResponse {
 
 message GetWorkerTaskReachabilityRequest {
     string namespace = 1;
-    // Build id to retrieve reachability for. Leave empty to query reachability of an unversioned worker.
-    string build_id = 2;
+    // Build id to retrieve reachability for. An empty string will be interpreted as an unversioned worker.
+    repeated string build_ids = 2;
     // Scope of the reachability query (namespace or task queue).
     // Must specify a task queue if querying for an unversioned worker.
     temporal.api.taskqueue.v1.TaskReachabilityScope scope = 3;
+
+    // Type of reachability to query for.
+    // TASK_REACHABILITY_NEW_WORKFLOWS is always returned in the response and is considered the default if reachability
+    // is unspecified here.
+    // Use TASK_REACHABILITY_OPEN_WORKFLOWS if your application needs to respond to queries on closed workflows.
+    // Otherwise, use TASK_REACHABILITY_EXISTING_WORKFLOWS.
+    // See the TaskReachability docstring for information about each enum variant.
+    temporal.api.enums.v1.TaskReachability reachability = 4;
 }
 
 message GetWorkerTaskReachabilityResponse {
-    // Task reachability, broken down by task queue.
-    // This response lists all task queues mapped to the requested build id when the requested query scope is for an
+    // Task reachability, broken down by build id and then task queue.
+    // This response lists all task queues mapped to the requested build ids when the requested query scope is for an
     // entire namespace but the number of task queues that include reachability information is limited.
     // When reaching the limit, task queues that reachability information could not be retrieved for will be marked with a single
     // TASK_REACHABILITY_UNSPECIFIED entry. The caller may issue separate calls to get the reachability for those task
     // queues.
     // Open source users can adjust this limit by setting the server's dynamic config value for
     // `limit.reachabilityTaskQueueScan` with the caveat that this call can strain the visibility store.
-    repeated temporal.api.taskqueue.v1.TaskQueueReachability task_queue_reachability = 1;
+    repeated temporal.api.taskqueue.v1.BuildIdReachability build_id_reachability = 1;
 }
 
 // (-- api-linter: core::0134=disabled

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1126,7 +1126,10 @@ message GetWorkerBuildIdCompatibilityResponse {
 
 message GetWorkerTaskReachabilityRequest {
     string namespace = 1;
-    // Build id to retrieve reachability for. An empty string will be interpreted as an unversioned worker.
+    // Build ids to retrieve reachability for. An empty string will be interpreted as an unversioned worker.
+    // The number of build ids that can be queried in a single API call is limited.
+    // Open source users can adjust this limit by setting the server's dynamic config value for
+    // `limit.reachabilityQueryMaxBuildIds` with the caveat that this call can strain the visibility store.
     repeated string build_ids = 2;
     // Scope of the reachability query (namespace or task queue).
     // Must specify a task queue if querying for an unversioned worker.
@@ -1149,7 +1152,7 @@ message GetWorkerTaskReachabilityResponse {
     // TASK_REACHABILITY_UNSPECIFIED entry. The caller may issue separate calls to get the reachability for those task
     // queues.
     // Open source users can adjust this limit by setting the server's dynamic config value for
-    // `limit.reachabilityTaskQueueScan` with the caveat that this call can strain the visibility store.
+    // `limit.reachabilityMaxTaskQueueScan` with the caveat that this call can strain the visibility store.
     repeated temporal.api.taskqueue.v1.BuildIdReachability build_id_reachability = 1;
 }
 

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -385,6 +385,14 @@ service WorkflowService {
     // version, forming sets of ids which are incompatible with each other, but whose contained
     // members are compatible with one another.
     //
+    // A single build id may be mapped to multiple task queues using this API for cases where a single process hosts
+    // multiple workers. 
+    // 
+    // To query which workers can be retired, use the `GetWorkerTaskReachability` API.
+    //
+    // NOTE: The number of task queues mapped to a single build id is limited by the `limit.taskQueuesPerBuildId`
+    // (default is 20), if this limit is exceeded this API will error with a FailedPrecondition.
+    //
     // (-- api-linter: core::0134::response-message-name=disabled
     //     aip.dev/not-precedent: UpdateWorkerBuildIdCompatibility RPC doesn't follow Google API format. --)
     // (-- api-linter: core::0134::method-signature=disabled


### PR DESCRIPTION
Allow querying multiple build IDs (yes, reverted back to that).
Let the caller specify the type of reachability they're interested in to avoid needlessly doubling the number of visibility queries on the server side.