### PR TITLE
Allow querying reachability of multiple specific task queues

### DIFF
--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -111,13 +111,3 @@ message BuildIdReachability {
     // Reachability per task queue.
     repeated TaskQueueReachability task_queue_reachability = 2;
 }
-
-// Scope of task reachability for a reachability query.
-message TaskReachabilityScope {
-    oneof variant {
-        // Query task reachability globally in a namespace.
-        google.protobuf.Empty namespace = 1;
-        // Query task reachability for a specific task queue.
-        string task_queue = 2;
-    }
-}

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -32,7 +32,6 @@ option ruby_package = "Temporalio::Api::TaskQueue::V1";
 option csharp_namespace = "Temporalio.Api.TaskQueue.V1";
 
 import "google/protobuf/duration.proto";
-import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1131,9 +1131,11 @@ message GetWorkerTaskReachabilityRequest {
     // Open source users can adjust this limit by setting the server's dynamic config value for
     // `limit.reachabilityQueryBuildIds` with the caveat that this call can strain the visibility store.
     repeated string build_ids = 2;
-    // Scope of the reachability query (namespace or task queue).
-    // Must specify a task queue if querying for an unversioned worker.
-    temporal.api.taskqueue.v1.TaskReachabilityScope scope = 3;
+
+    // Task queues to retrieve reachability for. Leave this empty to query for all task queues associated with given
+    // build ids in the namespace.
+    // Must specify at least one task queue if querying for an unversioned worker.
+    repeated string task_queues = 3;
 
     // Type of reachability to query for.
     // TASK_REACHABILITY_NEW_WORKFLOWS is always returned in the response and is considered the default if reachability
@@ -1146,11 +1148,11 @@ message GetWorkerTaskReachabilityRequest {
 
 message GetWorkerTaskReachabilityResponse {
     // Task reachability, broken down by build id and then task queue.
-    // This response lists all task queues mapped to the requested build ids when the requested query scope is for an
-    // entire namespace but the number of task queues that include reachability information is limited.
-    // When reaching the limit, task queues that reachability information could not be retrieved for will be marked with a single
-    // TASK_REACHABILITY_UNSPECIFIED entry. The caller may issue separate calls to get the reachability for those task
-    // queues.
+    // When requesting all task queues associated with the given build ids in a namespace, all task queues will be
+    // listed in the response but some of them may not contain reachability information due to a server enforced limit.
+    // When reaching the limit, task queues that reachability information could not be retrieved for will be marked with
+    // a single TASK_REACHABILITY_UNSPECIFIED entry. The caller may issue another call to get the reachability for those
+    // task queues.
     // Open source users can adjust this limit by setting the server's dynamic config value for
     // `limit.reachabilityTaskQueueScan` with the caveat that this call can strain the visibility store.
     repeated temporal.api.taskqueue.v1.BuildIdReachability build_id_reachability = 1;

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1135,6 +1135,8 @@ message GetWorkerTaskReachabilityRequest {
     // Task queues to retrieve reachability for. Leave this empty to query for all task queues associated with given
     // build ids in the namespace.
     // Must specify at least one task queue if querying for an unversioned worker.
+    // The number of task queues that the server will fetch reachability information for is limited.
+    // See the `GetWorkerTaskReachabilityResponse` documentation for more information.
     repeated string task_queues = 3;
 
     // Type of reachability to query for.
@@ -1148,11 +1150,12 @@ message GetWorkerTaskReachabilityRequest {
 
 message GetWorkerTaskReachabilityResponse {
     // Task reachability, broken down by build id and then task queue.
-    // When requesting all task queues associated with the given build ids in a namespace, all task queues will be
-    // listed in the response but some of them may not contain reachability information due to a server enforced limit.
-    // When reaching the limit, task queues that reachability information could not be retrieved for will be marked with
-    // a single TASK_REACHABILITY_UNSPECIFIED entry. The caller may issue another call to get the reachability for those
-    // task queues.
+    // When requesting a large number of task queues or all task queues associated with the given build ids in a
+    // namespace, all task queues will be listed in the response but some of them may not contain reachability
+    // information due to a server enforced limit. When reaching the limit, task queues that reachability information
+    // could not be retrieved for will be marked with a single TASK_REACHABILITY_UNSPECIFIED entry. The caller may issue
+    // another call to get the reachability for those task queues.
+    //
     // Open source users can adjust this limit by setting the server's dynamic config value for
     // `limit.reachabilityTaskQueueScan` with the caveat that this call can strain the visibility store.
     repeated temporal.api.taskqueue.v1.BuildIdReachability build_id_reachability = 1;

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -404,11 +404,13 @@ service WorkflowService {
     // Fetches task reachability to determine whether a worker may be retired.
     // The request may specify task queues to query for or let the server fetch all task queues mapped to the given
     // build IDs.
-    // When requesting all task queues associated with the given build ids in a namespace, all task queues will be
-    // listed in the response but some of them may not contain reachability information due to a server enforced limit.
-    // When reaching the limit, task queues that reachability information could not be retrieved for will be marked with
-    // a single TASK_REACHABILITY_UNSPECIFIED entry. The caller may issue another call to get the reachability for those
-    // task queues.
+    //
+    // When requesting a large number of task queues or all task queues associated with the given build ids in a
+    // namespace, all task queues will be listed in the response but some of them may not contain reachability
+    // information due to a server enforced limit. When reaching the limit, task queues that reachability information
+    // could not be retrieved for will be marked with a single TASK_REACHABILITY_UNSPECIFIED entry. The caller may issue
+    // another call to get the reachability for those task queues.
+    //
     // Open source users can adjust this limit by setting the server's dynamic config value for
     // `limit.reachabilityTaskQueueScan` with the caveat that this call can strain the visibility store.
     rpc GetWorkerTaskReachability (GetWorkerTaskReachabilityRequest) returns (GetWorkerTaskReachabilityResponse) {}

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -402,11 +402,13 @@ service WorkflowService {
     rpc GetWorkerBuildIdCompatibility (GetWorkerBuildIdCompatibilityRequest) returns (GetWorkerBuildIdCompatibilityResponse) {}
 
     // Fetches task reachability to determine whether a worker may be retired.
-    // The response lists all task queues mapped to the requested build id when the requested query scope is for an
-    // entire namespace but the number of task queues that include reachability information is limited.
-    // When reaching the limit, task queues that reachability information could not be retrieved for will be marked with a single
-    // TASK_REACHABILITY_UNSPECIFIED entry. The caller may issue separate calls to get the reachability for those task
-    // queues.
+    // The request may specify task queues to query for or let the server fetch all task queues mapped to the given
+    // build IDs.
+    // When requesting all task queues associated with the given build ids in a namespace, all task queues will be
+    // listed in the response but some of them may not contain reachability information due to a server enforced limit.
+    // When reaching the limit, task queues that reachability information could not be retrieved for will be marked with
+    // a single TASK_REACHABILITY_UNSPECIFIED entry. The caller may issue another call to get the reachability for those
+    // task queues.
     // Open source users can adjust this limit by setting the server's dynamic config value for
     // `limit.reachabilityTaskQueueScan` with the caveat that this call can strain the visibility store.
     rpc GetWorkerTaskReachability (GetWorkerTaskReachabilityRequest) returns (GetWorkerTaskReachabilityResponse) {}


### PR DESCRIPTION
Figured that if the advice we give when a user has too many task queues for a given build id, they should (usually) be able to query the rest of the task queues in a followup API call and not have to issue a call per task queue.

This also flattens the API a bit, which is a nice side-effect.