### PR TITLE
Add normal_task_queue_name to TaskQueue

### DIFF
--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -47,7 +47,7 @@ message TaskQueue {
     temporal.api.enums.v1.TaskQueueKind kind = 2;
     // Iff kind == TASK_QUEUE_KIND_STICKY, then this field contains the name of
     // the normal task that the sticky worker is running on.
-    string normal_task_queue_name = 3;
+    string normal_name = 3;
 }
 
 // Only applies to activity task queues

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -45,6 +45,9 @@ message TaskQueue {
     string name = 1;
     // Default: TASK_QUEUE_KIND_NORMAL.
     temporal.api.enums.v1.TaskQueueKind kind = 2;
+    // Iff kind == TASK_QUEUE_KIND_STICKY, then this field contains the name of
+    // the normal task that the sticky worker is running on.
+    string normal_task_queue_name = 3;
 }
 
 // Only applies to activity task queues


### PR DESCRIPTION
**What changed?**
Include normal task queue name with sticky queues.

**Why?**
For versioning, we want sticky queues to subscribe to versioning data for their associated normal queues, so that we can properly stop dispatching tasks to out-of-date workers that are still polling. There are various ways to get this information into matching, but the best is to ensure it's always present in the TaskQueue message.

**Breaking changes**
There are some subtle compatibility concerns around using this field in the server, but in general it won't break anything that already works because by definition, sticky queues are ephemeral, only sticky queues get this new field, and workers using versioning need to be using new versions of the SDK anyway.
