### PR TITLE
Add a flag to enable running when schedule runs out of actions

### DIFF
--- a/temporal/api/schedule/v1/message.proto
+++ b/temporal/api/schedule/v1/message.proto
@@ -242,6 +242,11 @@ message SchedulePolicies {
     // This applies after retry policies: the full chain of retries must fail to
     // trigger a pause here.
     bool pause_on_failure = 3;
+
+    // If true, and the schedule runs out of actions, it will keep running. By default
+    // the schedule workflow finishes execution when it runs out of actions.
+    bool run_with_no_actions = 4;
+
 }
 
 message ScheduleAction {

--- a/temporal/api/schedule/v1/message.proto
+++ b/temporal/api/schedule/v1/message.proto
@@ -243,8 +243,8 @@ message SchedulePolicies {
     // trigger a pause here.
     bool pause_on_failure = 3;
 
-    // If true, and the schedule runs out of actions, it will keep running. By default
-    // the schedule workflow finishes execution when it runs out of actions.
+    // If true and the schedule runs out of actions it will not finish execution. 
+    // By default the schedule workflow finishes execution when it runs out of actions.
     bool remain_after_action_limit = 4;
 
 }

--- a/temporal/api/schedule/v1/message.proto
+++ b/temporal/api/schedule/v1/message.proto
@@ -247,7 +247,7 @@ message SchedulePolicies {
     // workflow that does not have any more jobs scheduled (e.g., ran out of actions)
     // By default idle schedule workflow finishes execution when it has not more schedules
     // to run.
-    bool keep_idle_schedule= 4;
+    bool keep_idle_schedule = 4;
 
 }
 

--- a/temporal/api/schedule/v1/message.proto
+++ b/temporal/api/schedule/v1/message.proto
@@ -243,9 +243,11 @@ message SchedulePolicies {
     // trigger a pause here.
     bool pause_on_failure = 3;
 
-    // If true and the schedule runs out of actions it will not finish execution. 
-    // By default the schedule workflow finishes execution when it runs out of actions.
-    bool remain_after_action_limit = 4;
+    // If true, idle schedule workflow will keep running. Idle schedule is an schedule
+    // workflow that does not have any more jobs scheduled (e.g., ran out of actions)
+    // By default idle schedule workflow finishes execution when it has not more schedules
+    // to run.
+    bool keep_idle_schedule= 4;
 
 }
 

--- a/temporal/api/schedule/v1/message.proto
+++ b/temporal/api/schedule/v1/message.proto
@@ -245,7 +245,7 @@ message SchedulePolicies {
 
     // If true, and the schedule runs out of actions, it will keep running. By default
     // the schedule workflow finishes execution when it runs out of actions.
-    bool run_with_no_actions = 4;
+    bool remain_after_action_limit = 4;
 
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added a new flag to schedule policies to keep the schedule running when it runs
out of action. The plan is to finish the schedule by default when it
runs out of actions.


<!-- Tell your future self why have you made these changes -->
**Why?**
Currently, when a schedule runs out of actions the schedule workflow keeps
running without doing anything unless it receives a signal or the schedule gets
updated.


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
This PR along with the one in server
(https://github.com/temporalio/temporal/pull/4399) are changing the default
behavior of schedule to finish workflow when it runs out of actions instead of
(current behavior) running. This can affect users that expect the schedule to
run even after we run out of actions.
