### PR TITLE
Add operation for merging sets to build ID api

### DIFF
--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1084,6 +1084,13 @@ message UpdateWorkerBuildIdCompatibilityRequest {
         bool make_set_default = 3;
     }
 
+    message MergeSets {
+        // A build ID in the set whose default will become the merged set default
+        string primary_set_build_id = 1;
+        // A build ID in the set which will be merged into the primary set
+        string secondary_set_build_id = 2;
+    }
+
     string namespace = 1;
     // Must be set, the task queue to apply changes to. Because all workers on a given task queue
     // must have the same set of workflow & activity implementations, there is no reason to specify
@@ -1110,6 +1117,9 @@ message UpdateWorkerBuildIdCompatibilityRequest {
         // (-- api-linter: core::0140::prepositions=disabled
         //     aip.dev/not-precedent: Within makes perfect sense here. --)
         string promote_build_id_within_set = 6;
+        // Merge two existing sets together, thus declaring all build IDs in both sets compatible
+        // with one another. The primary set's default will become the default for the merged set.
+        MergeSets merge_sets = 7;
     }
 }
 message UpdateWorkerBuildIdCompatibilityResponse {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1119,6 +1119,9 @@ message UpdateWorkerBuildIdCompatibilityRequest {
         string promote_build_id_within_set = 6;
         // Merge two existing sets together, thus declaring all build IDs in both sets compatible
         // with one another. The primary set's default will become the default for the merged set.
+        // This is useful if you've accidentally declared a new ID as incompatible you meant to
+        // declare as compatible. The unusual case of incomplete replication during failover could
+        // also result in a split set, which this operation can repair.
         MergeSets merge_sets = 7;
     }
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added an operation for the merging of two compatible sets

<!-- Tell your future self why have you made these changes -->
**Why?**
It's possible in some edge situations that an incomplete replication could end up making two sets where the user's intention was that there only be one. This allows them to fix that.

Plus, theoretically this is useful if they've just made a mistake and declared something incompat they meant to be compat.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
No
