### PR TITLE
Remove unused field from UpdateWorkerBuildIdCompatibilityResponse

### DIFF
--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1126,9 +1126,8 @@ message UpdateWorkerBuildIdCompatibilityRequest {
     }
 }
 message UpdateWorkerBuildIdCompatibilityResponse {
-    // The id of the compatible set that the updated version was added to, or exists in. Users don't
-    // need to understand or care about this value, but it has value for debugging purposes.
-    string version_set_id = 1;
+    reserved 1;
+    reserved "version_set_id";
 }
 
 // (-- api-linter: core::0134::request-resource-required=disabled


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove unused field

<!-- Tell your future self why have you made these changes -->
**Why?**
We decided not to expose these values

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
No, it was never set and never used
