### PR TITLE
Add group by support to count API

### DIFF
--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -781,7 +781,21 @@ message CountWorkflowExecutionsRequest {
 }
 
 message CountWorkflowExecutionsResponse {
+    // If `query` is not grouping by any field, the count is an approximate number
+    // of workflows that matches the query.
+    // If `query` is grouping by a field, the count is simply the sum of the counts
+    // of the groups returned in the response. This number can be smaller than the
+    // total number of workflows matching the query.
     int64 count = 1;
+
+    // `groups` contains the groups if the request is grouping by a field.
+    // The list might not be complete, and the counts of each group is approximate.
+    repeated AggregationGroup groups = 2;
+
+    message AggregationGroup {
+        repeated temporal.api.common.v1.Payload group_values = 1;
+        int64 count = 2;
+    }
 }
 
 message GetSearchAttributesRequest {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add fields for count group by response.

The `CountWorkflowExecutions` will support the `GROUP BY` clause in the query.
The returned response will contain an additional field that will contain the groups and their counts.
The group type (`AggregationGroup`) contains two fields:
- `GroupValues`: this is tuple of values that defines the group.
- `Count`: the number workflows in the group.

### Example
If you have a query like `GROUP BY ExecutionStatus`, a possible response could be:
```
&CountWorkflowExecutionsResponse{
  Count: 10,
  Groups: []*AggregationGroup{
    {
      GroupValues: &Payloads{
        Payloads: []*Payload{"Completed"},
      },
      Count: 8,
    },
    {
      GroupValues: &Payloads{
        Payloads: []*Payload{"Running"},
      },
      Count: 2,
    },
  },
}
```

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**

