### PR TITLE
Adding documentation for server behavior when TaskQueueType is not specified for DescribeTaskQueueRequest

### DIFF
--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -855,6 +855,7 @@ message DescribeWorkflowExecutionResponse {
 message DescribeTaskQueueRequest {
     string namespace = 1;
     temporal.api.taskqueue.v1.TaskQueue task_queue = 2;
+    // If unspecified (TASK_QUEUE_TYPE_UNSPECIFIED), then default value (TASK_QUEUE_TYPE_WORKFLOW) will be used.
     temporal.api.enums.v1.TaskQueueType task_queue_type = 3;
     bool include_task_queue_status = 4;
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added documentation in DescribeTaskQueueRequest to explain the server behaviour when task_queue_type is not specified (TASK_QUEUE_TYPE_UNSPECIFIED).


<!-- Tell your future self why have you made these changes -->
**Why?**
Server will use the default value (TASK_QUEUE_TYPE_WORKFLOW) if task_queue_type is not specified. Need to document this is DescribeTaskQueueRequest proto.


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
No

