### PR TITLE
Add buffer size and dropped actions fields to ScheduleInfo

### DIFF
--- a/temporal/api/schedule/v1/message.proto
+++ b/temporal/api/schedule/v1/message.proto
@@ -322,6 +322,12 @@ message ScheduleInfo {
     // Number of skipped actions due to overlap.
     int64 overlap_skipped = 3;
 
+    // Number of actions in the buffer.
+    int64 buffer_size = 10;
+
+    // Number of actions dropped due to the buffer limit.
+    int64 buffer_dropped = 11;
+
     // Currently-running workflows started by this schedule. (There might be
     // more than one if the overlap policy allows overlaps.)
     // Note that the run_ids in here are the original execution run ids as

--- a/temporal/api/schedule/v1/message.proto
+++ b/temporal/api/schedule/v1/message.proto
@@ -325,7 +325,9 @@ message ScheduleInfo {
     // Number of dropped actions due to buffer limit.
     int64 buffer_dropped = 10;
 
-    // Number of actions in the buffer.
+    // Number of actions in the buffer. The buffer holds the actions that cannot
+    // be immediately triggered (due to the overlap policy). These actions can be a result of
+    // the normal schedule or a backfill.
     int64 buffer_size = 11;
 
     // Currently-running workflows started by this schedule. (There might be

--- a/temporal/api/schedule/v1/message.proto
+++ b/temporal/api/schedule/v1/message.proto
@@ -322,11 +322,11 @@ message ScheduleInfo {
     // Number of skipped actions due to overlap.
     int64 overlap_skipped = 3;
 
-    // Number of actions in the buffer.
-    int64 buffer_size = 10;
+    // Number of dropped actions due to buffer limit.
+    int64 buffer_dropped = 10;
 
-    // Number of actions dropped due to the buffer limit.
-    int64 buffer_dropped = 11;
+    // Number of actions in the buffer.
+    int64 buffer_size = 11;
 
     // Currently-running workflows started by this schedule. (There might be
     // more than one if the overlap policy allows overlaps.)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding two fields to ScheduleInfo proto

<!-- Tell your future self why have you made these changes -->
**Why?**
This is for visibility and completeness. Buffer overruns are already exposed in a metric, but we have similar fields in ScheduleInfo for number of runs skipped, etc. so I think it should go there too.

Buffer size is also interesting to monitor, but it doesn't make sense as a metric, it's more useful as a per-schedule thing to check with DescribeSchedule. I could imagine:

- a user does a large backfill with BufferAll and wants to know when they're all done
- a user runs a schedule periodically with BufferAll and wants to be alerted when there are > 5 runs backed up, but doesn't care before that

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
No test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No