### PR TITLE
Adding namespace_id in DeleteNamespaceRequest

### DIFF
--- a/temporal/api/operatorservice/v1/request_response.proto
+++ b/temporal/api/operatorservice/v1/request_response.proto
@@ -72,6 +72,7 @@ message ListSearchAttributesResponse {
 //     aip.dev/not-precedent: DeleteNamespace RPC doesn't follow Google API format. --)
 message DeleteNamespaceRequest {
     string namespace = 1;
+    string namespace_id = 2;
 }
 
 message DeleteNamespaceResponse {

--- a/temporal/api/operatorservice/v1/request_response.proto
+++ b/temporal/api/operatorservice/v1/request_response.proto
@@ -71,6 +71,7 @@ message ListSearchAttributesResponse {
 // (-- api-linter: core::0135::request-name-required=disabled
 //     aip.dev/not-precedent: DeleteNamespace RPC doesn't follow Google API format. --)
 message DeleteNamespaceRequest {
+    // Only one of namespace or namespace_id must be specified to identify namespace.
     string namespace = 1;
     string namespace_id = 2;
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding namespace_id in DeleteNamespace request.

<!-- Tell your future self why have you made these changes -->
**Why?**
DeleteNamespace API currently takes namespace name as input. Namespace name will be changed during the deletion process.
If the client wants to retry deleting the namespace again, it will have to use the new namespace name in next request.
By supporting namespace_id in the request, the client can retry DeleteNamespace with the same namespace_id again.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
None

