### PR TITLE
Batch operation rate limit

### DIFF
--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1242,15 +1242,17 @@ message StartBatchOperationRequest {
     // Namespace that contains the batch operation
     string namespace = 1;
     // Visibility query defines the the group of workflow to apply the batch operation
-    // This field and Executions are mutually exclusive
+    // This field and `executions` are mutually exclusive
     string visibility_query = 2;
     // Job ID defines the unique ID for the batch job
     string job_id = 3;
     // Reason to perform the batch operation
     string reason = 4;
     // Executions to apply the batch operation
-    // This field and VisibilityQuery are mutually exclusive
+    // This field and `visibility_query` are mutually exclusive
     repeated temporal.api.common.v1.WorkflowExecution executions = 5;
+    // RequestsPerSecond limits the number of requests per second for the batch.
+    int32 requests_per_second = 6;
     // Operation input
     oneof operation {
         temporal.api.batch.v1.BatchOperationTermination termination_operation = 10;

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1251,7 +1251,11 @@ message StartBatchOperationRequest {
     // Executions to apply the batch operation
     // This field and `visibility_query` are mutually exclusive
     repeated temporal.api.common.v1.WorkflowExecution executions = 5;
-    // Limit the number of operations per second for the batch.
+    // Optional parameter that limits the number of operations processed per second within this batch.
+    // Its purpose is to alleviate the server load arising from batch operations and
+    // minimize their impact on other workloads managed by the server's workers. 
+    // When no explicit limit is provided, the server will operate according to its default limit.
+    // If the specified limit exceeds the server's configured limit, the server's limit will take precedence.
     int32 max_operations_per_second = 6;
     // Operation input
     oneof operation {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1252,8 +1252,8 @@ message StartBatchOperationRequest {
     // This field and `visibility_query` are mutually exclusive
     repeated temporal.api.common.v1.WorkflowExecution executions = 5;
     // Limit for the number of operations processed per second within this batch.
-    // Its purpose is to alleviate the server load arising from batch operations and
-    // minimize their impact on other workloads managed by the server's workers. 
+    // Its purpose is to reduce the stress on the system caused by batch operations, which helps to prevent system
+    // overloads and minimize potential delays in executing ongoing tasks for both server workers and user workers.
     // When no explicit limit is provided, the server will operate according to its configured limit.
     // If the specified limit exceeds the server's configured limit, the server's limit will take precedence.
     int32 max_operations_per_second = 6;

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1253,7 +1253,7 @@ message StartBatchOperationRequest {
     repeated temporal.api.common.v1.WorkflowExecution executions = 5;
     // Limit for the number of operations processed per second within this batch.
     // Its purpose is to reduce the stress on the system caused by batch operations, which helps to prevent system
-    // overloads and minimize potential delays in executing ongoing tasks for both server workers and user workers.
+    // overload and minimize potential delays in executing ongoing tasks for user workers.
     // When no explicit limit is provided, the server will operate according to its configured limit.
     // If the specified limit exceeds the server's configured limit, the server's limit will take precedence.
     float max_operations_per_second = 6;

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1255,7 +1255,8 @@ message StartBatchOperationRequest {
     // Its purpose is to reduce the stress on the system caused by batch operations, which helps to prevent system
     // overload and minimize potential delays in executing ongoing tasks for user workers.
     // When no explicit limit is provided, the server will operate according to its configured limit.
-    // If the specified limit exceeds the server's configured limit, the server's limit will take precedence.
+    // If the specified limit exceeds the server's configured limit in `worker.batcherRPS`,
+    // the server's limit will take precedence.
     float max_operations_per_second = 6;
     // Operation input
     oneof operation {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1256,7 +1256,7 @@ message StartBatchOperationRequest {
     // overloads and minimize potential delays in executing ongoing tasks for both server workers and user workers.
     // When no explicit limit is provided, the server will operate according to its configured limit.
     // If the specified limit exceeds the server's configured limit, the server's limit will take precedence.
-    int32 max_operations_per_second = 6;
+    float max_operations_per_second = 6;
     // Operation input
     oneof operation {
         temporal.api.batch.v1.BatchOperationTermination termination_operation = 10;

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1254,9 +1254,9 @@ message StartBatchOperationRequest {
     // Limit for the number of operations processed per second within this batch.
     // Its purpose is to reduce the stress on the system caused by batch operations, which helps to prevent system
     // overload and minimize potential delays in executing ongoing tasks for user workers.
-    // When no explicit limit is provided, the server will operate according to its configured limit.
-    // If the specified limit exceeds the server's configured limit in `worker.batcherRPS`,
-    // the server's limit will take precedence.
+    // Note that when no explicit limit is provided, the server will operate according to its limit defined by the
+    // dynamic configuration key `worker.batcherRPS`. This also applies if the value in this field exceeds the
+    // server's configured limit.
     float max_operations_per_second = 6;
     // Operation input
     oneof operation {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1251,8 +1251,8 @@ message StartBatchOperationRequest {
     // Executions to apply the batch operation
     // This field and `visibility_query` are mutually exclusive
     repeated temporal.api.common.v1.WorkflowExecution executions = 5;
-    // RequestsPerSecond limits the number of requests per second for the batch.
-    int32 requests_per_second = 6;
+    // Limit the number of operations per second for the batch.
+    int32 max_operation_per_second = 6;
     // Operation input
     oneof operation {
         temporal.api.batch.v1.BatchOperationTermination termination_operation = 10;

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1251,7 +1251,7 @@ message StartBatchOperationRequest {
     // Executions to apply the batch operation
     // This field and `visibility_query` are mutually exclusive
     repeated temporal.api.common.v1.WorkflowExecution executions = 5;
-    // Optional parameter that limits the number of operations processed per second within this batch.
+    // Limit for the number of operations processed per second within this batch.
     // Its purpose is to alleviate the server load arising from batch operations and
     // minimize their impact on other workloads managed by the server's workers. 
     // When no explicit limit is provided, the server will operate according to its configured limit.

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1254,7 +1254,7 @@ message StartBatchOperationRequest {
     // Optional parameter that limits the number of operations processed per second within this batch.
     // Its purpose is to alleviate the server load arising from batch operations and
     // minimize their impact on other workloads managed by the server's workers. 
-    // When no explicit limit is provided, the server will operate according to its default limit.
+    // When no explicit limit is provided, the server will operate according to its configured limit.
     // If the specified limit exceeds the server's configured limit, the server's limit will take precedence.
     int32 max_operations_per_second = 6;
     // Operation input

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1252,7 +1252,7 @@ message StartBatchOperationRequest {
     // This field and `visibility_query` are mutually exclusive
     repeated temporal.api.common.v1.WorkflowExecution executions = 5;
     // Limit the number of operations per second for the batch.
-    int32 max_operation_per_second = 6;
+    int32 max_operations_per_second = 6;
     // Operation input
     oneof operation {
         temporal.api.batch.v1.BatchOperationTermination termination_operation = 10;


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Adding (optional) `max_operations_per_second` for batch operations to limit their rate.

<!-- Tell your future self why have you made these changes -->
**Why?**

To fix https://github.com/temporalio/temporal/issues/4926.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**

None