### PR TITLE
Merge ui service annotations with our official ones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,16 @@ PATH := $(GOBIN):$(PATH)
 
 COLOR := "\e[1;36m%s\e[0m\n"
 
+# Only prints output if the exit code is non-zero
+define silent_exec
+    @output=$$($(1) 2>&1); \
+    status=$$?; \
+    if [ $$status -ne 0 ]; then \
+        echo "$$output"; \
+    fi; \
+    exit $$status
+endef
+
 PROTO_ROOT := .
 PROTO_FILES = $(shell find $(PROTO_ROOT) -name "*.proto")
 PROTO_DIRS = $(sort $(dir $(PROTO_FILES)))
@@ -68,7 +78,7 @@ buf-install:
 ##### Linters #####
 api-linter:
 	printf $(COLOR) "Run api-linter..."
-	api-linter --set-exit-status $(PROTO_IMPORTS) --config $(PROTO_ROOT)/api-linter.yaml $(PROTO_FILES)
+	$(call silent_exec, api-linter --set-exit-status $(PROTO_IMPORTS) --config $(PROTO_ROOT)/api-linter.yaml $(PROTO_FILES))
 
 buf-lint:
 	printf $(COLOR) "Run buf linter..."

--- a/temporal/api/operatorservice/v1/service.proto
+++ b/temporal/api/operatorservice/v1/service.proto
@@ -33,6 +33,7 @@ option csharp_namespace = "Temporalio.Api.OperatorService.V1";
 
 
 import "temporal/api/operatorservice/v1/request_response.proto";
+import "google/api/annotations.proto";
 
 // OperatorService API defines how Temporal SDKs and other clients interact with the Temporal server
 // to perform administrative functions like registering a search attribute or a namespace.
@@ -56,6 +57,9 @@ service OperatorService {
 
     // ListSearchAttributes returns comprehensive information about search attributes.
     rpc ListSearchAttributes (ListSearchAttributesRequest) returns (ListSearchAttributesResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/namespaces/{namespace}/search-attributes",
+        };
     }
 
     // DeleteNamespace synchronously deletes a namespace and asynchronously reclaims all namespace resources.

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -90,13 +90,9 @@ service WorkflowService {
     // workflow executions will continue to run on deprecated namespaces.
     // Deprecated.
     //
-    // (-- api-linter: core::0136::http-method=disabled
+    // (-- api-linter: core::0136::http-annotation=disabled
     //     aip.dev/not-precedent: Deprecated --)
-    rpc DeprecateNamespace (DeprecateNamespaceRequest) returns (DeprecateNamespaceResponse) {
-        option (google.api.http) = {
-            delete: "/api/v1/namespaces/{namespace}"
-        };
-    }
+    rpc DeprecateNamespace (DeprecateNamespaceRequest) returns (DeprecateNamespaceResponse) {}
 
     // StartWorkflowExecution starts a new workflow execution.
     //
@@ -353,26 +349,19 @@ service WorkflowService {
     //
     // (-- api-linter: core::0127::http-annotation=disabled
     //     aip.dev/not-precedent: Workflow deletion not exposed to HTTP, users should use cancel or terminate. --)
-    rpc DeleteWorkflowExecution (DeleteWorkflowExecutionRequest) returns (DeleteWorkflowExecutionResponse) {
-    }
+    rpc DeleteWorkflowExecution (DeleteWorkflowExecutionRequest) returns (DeleteWorkflowExecutionResponse) {}
 
     // ListOpenWorkflowExecutions is a visibility API to list the open executions in a specific namespace.
     //
-    // (-- aip.dev/not-precedent: HTTP users should use ListWorkflowExecutions instead. --)
-    rpc ListOpenWorkflowExecutions (ListOpenWorkflowExecutionsRequest) returns (ListOpenWorkflowExecutionsResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/workflows/open"
-        };
-    }
+    // (-- api-linter: core::0127::http-annotation=disabled
+    //     aip.dev/not-precedent: HTTP users should use ListWorkflowExecutions instead. --)
+    rpc ListOpenWorkflowExecutions (ListOpenWorkflowExecutionsRequest) returns (ListOpenWorkflowExecutionsResponse) {}
 
     // ListClosedWorkflowExecutions is a visibility API to list the closed executions in a specific namespace.
     //
-    // (-- aip.dev/not-precedent: HTTP users should use ListWorkflowExecutions instead. --)
-    rpc ListClosedWorkflowExecutions (ListClosedWorkflowExecutionsRequest) returns (ListClosedWorkflowExecutionsResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/workflows/closed"
-        };
-    }
+    // (-- api-linter: core::0127::http-annotation=disabled
+    //     aip.dev/not-precedent: HTTP users should use ListWorkflowExecutions instead. --)
+    rpc ListClosedWorkflowExecutions (ListClosedWorkflowExecutionsRequest) returns (ListClosedWorkflowExecutionsResponse) {}
 
     // ListWorkflowExecutions is a visibility API to list workflow executions in a specific namespace.
     rpc ListWorkflowExecutions (ListWorkflowExecutionsRequest) returns (ListWorkflowExecutionsResponse) {
@@ -404,12 +393,9 @@ service WorkflowService {
 
     // GetSearchAttributes is a visibility API to get all legal keys that could be used in list APIs
     //
-    // (-- aip.dev/not-precedent: We do not expose this search attribute API to HTTP (but may expose on OperatorService). --)
-    rpc GetSearchAttributes (GetSearchAttributesRequest) returns (GetSearchAttributesResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/search-attributes"
-        };
-    }
+    // (-- api-linter: core::0127::http-annotation=disabled
+    //     aip.dev/not-precedent: We do not expose this search attribute API to HTTP (but may expose on OperatorService). --)
+    rpc GetSearchAttributes (GetSearchAttributesRequest) returns (GetSearchAttributesResponse) {}
 
     // RespondQueryTaskCompleted is called by workers to complete queries which were delivered on
     // the `query` (not `queries`) field of a `PollWorkflowTaskQueueResponse`.
@@ -544,10 +530,11 @@ service WorkflowService {
     // (-- api-linter: core::0127::http-annotation=disabled
     //     aip.dev/not-precedent: We do yet expose versioning API to HTTP. --)
     rpc UpdateWorkerBuildIdCompatibility (UpdateWorkerBuildIdCompatibilityRequest) returns (UpdateWorkerBuildIdCompatibilityResponse) {}
+
     // Fetches the worker build id versioning sets for a task queue.
     rpc GetWorkerBuildIdCompatibility (GetWorkerBuildIdCompatibilityRequest) returns (GetWorkerBuildIdCompatibilityResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/task-queues/{task_queue}/compatibility"
+            get: "/api/v1/namespaces/{namespace}/task-queues/{task_queue}/worker-build-id-compatibility"
         };
     }
 

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -90,8 +90,8 @@ service WorkflowService {
     // workflow executions will continue to run on deprecated namespaces.
     // Deprecated.
     //
-    // (-- api-linter: core::0127::http-annotation=disabled
-    //     aip.dev/not-precedent: Deprecated. --)
+    // (-- api-linter: core::0136::http-method=disabled
+    //     aip.dev/not-precedent: Deprecated --)
     rpc DeprecateNamespace (DeprecateNamespaceRequest) returns (DeprecateNamespaceResponse) {
         option (google.api.http) = {
             delete: "/api/v1/namespaces/{namespace}"

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -93,6 +93,9 @@ service WorkflowService {
     // (-- api-linter: core::0127::http-annotation=disabled
     //     aip.dev/not-precedent: Deprecated. --)
     rpc DeprecateNamespace (DeprecateNamespaceRequest) returns (DeprecateNamespaceResponse) {
+        option (google.api.http) = {
+            delete: "/api/v1/namespaces/{namespace}"
+        };
     }
 
     // StartWorkflowExecution starts a new workflow execution.
@@ -102,7 +105,7 @@ service WorkflowService {
     // instance already exists with same workflow id.
     rpc StartWorkflowExecution (StartWorkflowExecutionRequest) returns (StartWorkflowExecutionResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_id}"
+            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_id}/start"
             body: "*"
         };
     }
@@ -111,7 +114,7 @@ service WorkflowService {
     // `NotFound` if the specified workflow execution is unknown to the service.
     rpc GetWorkflowExecutionHistory (GetWorkflowExecutionHistoryRequest) returns (GetWorkflowExecutionHistoryResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/history"
+            get: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/runs/{execution.run_id}/events"
         };
     }
     
@@ -120,7 +123,7 @@ service WorkflowService {
     // unknown to the service.
     rpc GetWorkflowExecutionHistoryReverse (GetWorkflowExecutionHistoryReverseRequest) returns (GetWorkflowExecutionHistoryReverseResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/history-reverse"
+            get: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/runs/{execution.run_id}/events/reverse"
         };
     }
 
@@ -226,7 +229,7 @@ service WorkflowService {
     //     aip.dev/not-precedent: "By" is used to indicate request type. --)
     rpc RespondActivityTaskCompletedById (RespondActivityTaskCompletedByIdRequest) returns (RespondActivityTaskCompletedByIdResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/activities/complete-by-id"
+            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_id}/runs/{run_id}/activities/{activity_id}/complete"
             body: "*"
         };
     }
@@ -250,7 +253,7 @@ service WorkflowService {
     //     aip.dev/not-precedent: "By" is used to indicate request type. --)
     rpc RespondActivityTaskFailedById (RespondActivityTaskFailedByIdRequest) returns (RespondActivityTaskFailedByIdResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/activities/fail-by-id"
+            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_id}/runs/{run_id}/activities/{activity_id}/fail"
             body: "*"
         };
     }
@@ -287,7 +290,7 @@ service WorkflowService {
     // workflow is already closed. It fails with 'NotFound' if the requested workflow doesn't exist.
     rpc RequestCancelWorkflowExecution (RequestCancelWorkflowExecutionRequest) returns (RequestCancelWorkflowExecutionResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/cancel"
+            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/runs/{workflow_execution.run_id}/cancel"
             body: "*"
         };
     }
@@ -298,7 +301,7 @@ service WorkflowService {
     // task being created for the execution.
     rpc SignalWorkflowExecution (SignalWorkflowExecutionRequest) returns (SignalWorkflowExecutionResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/signal/{signal_name}"
+            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/runs/{workflow_execution.run_id}/signal"
             body: "*"
         };
     }
@@ -328,7 +331,7 @@ service WorkflowService {
     // TODO: Does exclusive here mean *just* the completed event, or also WFT started? Otherwise the task is doomed to time out?
     rpc ResetWorkflowExecution (ResetWorkflowExecutionRequest) returns (ResetWorkflowExecutionResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/reset"
+            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/runs/{workflow_execution.run_id}/reset"
             body: "*"
         };
     }
@@ -338,7 +341,7 @@ service WorkflowService {
     // execution instance.
     rpc TerminateWorkflowExecution (TerminateWorkflowExecutionRequest) returns (TerminateWorkflowExecutionResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/terminate"
+            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/runs/{workflow_execution.run_id}/terminate"
             body: "*"
         };
     }
@@ -355,16 +358,20 @@ service WorkflowService {
 
     // ListOpenWorkflowExecutions is a visibility API to list the open executions in a specific namespace.
     //
-    // (-- api-linter: core::0127::http-annotation=disabled
-    //     aip.dev/not-precedent: HTTP users should use ListWorkflowExecutions instead. --)
+    // (-- aip.dev/not-precedent: HTTP users should use ListWorkflowExecutions instead. --)
     rpc ListOpenWorkflowExecutions (ListOpenWorkflowExecutionsRequest) returns (ListOpenWorkflowExecutionsResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/namespaces/{namespace}/workflows/open"
+        };
     }
 
     // ListClosedWorkflowExecutions is a visibility API to list the closed executions in a specific namespace.
     //
-    // (-- api-linter: core::0127::http-annotation=disabled
-    //     aip.dev/not-precedent: HTTP users should use ListWorkflowExecutions instead. --)
+    // (-- aip.dev/not-precedent: HTTP users should use ListWorkflowExecutions instead. --)
     rpc ListClosedWorkflowExecutions (ListClosedWorkflowExecutionsRequest) returns (ListClosedWorkflowExecutionsResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/namespaces/{namespace}/workflows/closed"
+        };
     }
 
     // ListWorkflowExecutions is a visibility API to list workflow executions in a specific namespace.
@@ -377,7 +384,7 @@ service WorkflowService {
     // ListArchivedWorkflowExecutions is a visibility API to list archived workflow executions in a specific namespace.
     rpc ListArchivedWorkflowExecutions (ListArchivedWorkflowExecutionsRequest) returns (ListArchivedWorkflowExecutionsResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/archived-workflows"
+            get: "/api/v1/namespaces/{namespace}/workflows/archived"
         };
     }
 
@@ -391,15 +398,17 @@ service WorkflowService {
     // CountWorkflowExecutions is a visibility API to count of workflow executions in a specific namespace.
     rpc CountWorkflowExecutions (CountWorkflowExecutionsRequest) returns (CountWorkflowExecutionsResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/workflow-count"
+            get: "/api/v1/namespaces/{namespace}/workflows/count"
         };
     }
 
     // GetSearchAttributes is a visibility API to get all legal keys that could be used in list APIs
     //
-    // (-- api-linter: core::0127::http-annotation=disabled
-    //     aip.dev/not-precedent: We do not expose this search attribute API to HTTP (but may expose on OperatorService). --)
+    // (-- aip.dev/not-precedent: We do not expose this search attribute API to HTTP (but may expose on OperatorService). --)
     rpc GetSearchAttributes (GetSearchAttributesRequest) returns (GetSearchAttributesResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/search-attributes"
+        };
     }
 
     // RespondQueryTaskCompleted is called by workers to complete queries which were delivered on
@@ -429,7 +438,7 @@ service WorkflowService {
     // QueryWorkflow requests a query be executed for a specified workflow execution.
     rpc QueryWorkflow (QueryWorkflowRequest) returns (QueryWorkflowResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/query/{query.query_type}"
+            post: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/runs/{execution.run_id}/query"
             body: "*"
         };
     }
@@ -437,21 +446,21 @@ service WorkflowService {
     // DescribeWorkflowExecution returns information about the specified workflow execution.
     rpc DescribeWorkflowExecution (DescribeWorkflowExecutionRequest) returns (DescribeWorkflowExecutionResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}"
+            get: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/runs/{execution.run_id}"
         };
     }
 
     // DescribeTaskQueue returns information about the target task queue.
     rpc DescribeTaskQueue (DescribeTaskQueueRequest) returns (DescribeTaskQueueResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/task-queues/{task_queue.name}"
+            get: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}"
         };
     }
 
     // GetClusterInfo returns information about temporal cluster
     rpc GetClusterInfo(GetClusterInfoRequest) returns (GetClusterInfoResponse) {
         option (google.api.http) = {
-            get: "/api/v1/cluster-info"
+            get: "/api/v1/cluster"
         };
     }
 
@@ -468,9 +477,15 @@ service WorkflowService {
     }
 
     // Creates a new schedule.
+    // (-- api-linter: core::0133::method-signature=disabled
+    //     aip.dev/not-precedent: CreateSchedule doesn't follow Google API format --)
+    // (-- api-linter: core::0133::response-message-name=disabled
+    //     aip.dev/not-precedent: CreateSchedule doesn't follow Google API format --)
+    // (-- api-linter: core::0133::http-uri-parent=disabled
+    //     aip.dev/not-precedent: CreateSchedule doesn't follow Google API format --)
     rpc CreateSchedule (CreateScheduleRequest) returns (CreateScheduleResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/schedules/{schedule_id}"
+            post: "/api/v1/namespaces/{namespace}/schedules"
             body: "*"
         };
     }
@@ -483,17 +498,23 @@ service WorkflowService {
     }
 
     // Changes the configuration or state of an existing schedule.
+    // (-- api-linter: core::0134::response-message-name=disabled
+    //     aip.dev/not-precedent: UpdateSchedule RPC doesn't follow Google API format. --)
+    // (-- api-linter: core::0134::method-signature=disabled
+    //     aip.dev/not-precedent: UpdateSchedule RPC doesn't follow Google API format. --)
     rpc UpdateSchedule (UpdateScheduleRequest) returns (UpdateScheduleResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/schedules/{schedule_id}/update"
+            post: "/api/v1/namespaces/{namespace}/schedules/{schedule_id}"
             body: "*"
         };
     }
 
     // Makes a specific change to a schedule or triggers an immediate action.
+    // (-- api-linter: core::0134::synonyms=disabled
+    //     aip.dev/not-precedent: we have both patch and update. --)
     rpc PatchSchedule (PatchScheduleRequest) returns (PatchScheduleResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/schedules/{schedule_id}/patch"
+            patch: "/api/v1/namespaces/{namespace}/schedules/{schedule_id}"
             body: "*"
         };
     }
@@ -508,7 +529,7 @@ service WorkflowService {
     // Deletes a schedule, removing it from the system.
     rpc DeleteSchedule (DeleteScheduleRequest) returns (DeleteScheduleResponse) {
         option (google.api.http) = {
-            delete: "/api/v1/namespaces/{namespace}/schedules/{schedule_id}"
+            delete:  "/api/v1/namespaces/{namespace}/schedules/{schedule_id}"
         };
     }
 
@@ -536,10 +557,11 @@ service WorkflowService {
     //     aip.dev/not-precedent: We do yet expose versioning API to HTTP. --)
     rpc UpdateWorkerBuildIdCompatibility (UpdateWorkerBuildIdCompatibilityRequest) returns (UpdateWorkerBuildIdCompatibilityResponse) {}
     // Fetches the worker build id versioning sets for a task queue.
-    //
-    // (-- api-linter: core::0127::http-annotation=disabled
-    //     aip.dev/not-precedent: We do yet expose versioning API to HTTP. --)
-    rpc GetWorkerBuildIdCompatibility (GetWorkerBuildIdCompatibilityRequest) returns (GetWorkerBuildIdCompatibilityResponse) {}
+    rpc GetWorkerBuildIdCompatibility (GetWorkerBuildIdCompatibilityRequest) returns (GetWorkerBuildIdCompatibilityResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/namespaces/{namespace}/task-queues/{task_queue}/compatibility"
+        };
+    }
 
     // Fetches task reachability to determine whether a worker may be retired.
     // The request may specify task queues to query for or let the server fetch all task queues mapped to the given
@@ -553,10 +575,11 @@ service WorkflowService {
     //
     // Open source users can adjust this limit by setting the server's dynamic config value for
     // `limit.reachabilityTaskQueueScan` with the caveat that this call can strain the visibility store.
-    //
-    // (-- api-linter: core::0127::http-annotation=disabled
-    //     aip.dev/not-precedent: We do yet expose versioning API to HTTP. --)
-    rpc GetWorkerTaskReachability (GetWorkerTaskReachabilityRequest) returns (GetWorkerTaskReachabilityResponse) {}
+    rpc GetWorkerTaskReachability (GetWorkerTaskReachabilityRequest) returns (GetWorkerTaskReachabilityResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/namespaces/{namespace}/worker-task-reachability"
+        };
+    }
 
     // Invokes the specified update function on user workflow code.
     rpc UpdateWorkflowExecution(UpdateWorkflowExecutionRequest) returns (UpdateWorkflowExecutionResponse) {
@@ -579,7 +602,7 @@ service WorkflowService {
     // StartBatchOperation starts a new batch operation
     rpc StartBatchOperation(StartBatchOperationRequest) returns (StartBatchOperationResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/batch-operations/{job_id}"
+            post: "/api/v1/namespaces/{namespace}/batch-operations"
             body: "*"
         };
     }
@@ -587,7 +610,7 @@ service WorkflowService {
     // StopBatchOperation stops a batch operation
     rpc StopBatchOperation(StopBatchOperationRequest) returns (StopBatchOperationResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/batch-operations/{job_id}/stop"
+            put: "/api/v1/namespaces/{namespace}/batch-operations/stop",
             body: "*"
         };
     }
@@ -595,7 +618,7 @@ service WorkflowService {
     // DescribeBatchOperation returns the information about a batch operation
     rpc DescribeBatchOperation(DescribeBatchOperationRequest) returns (DescribeBatchOperationResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/batch-operations/{job_id}"
+            get: "/api/v1/namespaces/{namespace}/batch-operations/describe"
         };
     }
 

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -105,7 +105,7 @@ service WorkflowService {
     // instance already exists with same workflow id.
     rpc StartWorkflowExecution (StartWorkflowExecutionRequest) returns (StartWorkflowExecutionResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_id}/start"
+            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_id}"
             body: "*"
         };
     }
@@ -114,7 +114,7 @@ service WorkflowService {
     // `NotFound` if the specified workflow execution is unknown to the service.
     rpc GetWorkflowExecutionHistory (GetWorkflowExecutionHistoryRequest) returns (GetWorkflowExecutionHistoryResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/runs/{execution.run_id}/events"
+            get: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/history"
         };
     }
     
@@ -123,7 +123,7 @@ service WorkflowService {
     // unknown to the service.
     rpc GetWorkflowExecutionHistoryReverse (GetWorkflowExecutionHistoryReverseRequest) returns (GetWorkflowExecutionHistoryReverseResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/runs/{execution.run_id}/events/reverse"
+            get: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/history-reverse"
         };
     }
 
@@ -229,7 +229,7 @@ service WorkflowService {
     //     aip.dev/not-precedent: "By" is used to indicate request type. --)
     rpc RespondActivityTaskCompletedById (RespondActivityTaskCompletedByIdRequest) returns (RespondActivityTaskCompletedByIdResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_id}/runs/{run_id}/activities/{activity_id}/complete"
+            post: "/api/v1/namespaces/{namespace}/activities/complete-by-id"
             body: "*"
         };
     }
@@ -253,7 +253,7 @@ service WorkflowService {
     //     aip.dev/not-precedent: "By" is used to indicate request type. --)
     rpc RespondActivityTaskFailedById (RespondActivityTaskFailedByIdRequest) returns (RespondActivityTaskFailedByIdResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_id}/runs/{run_id}/activities/{activity_id}/fail"
+            post: "/api/v1/namespaces/{namespace}/activities/fail-by-id"
             body: "*"
         };
     }
@@ -290,7 +290,7 @@ service WorkflowService {
     // workflow is already closed. It fails with 'NotFound' if the requested workflow doesn't exist.
     rpc RequestCancelWorkflowExecution (RequestCancelWorkflowExecutionRequest) returns (RequestCancelWorkflowExecutionResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/runs/{workflow_execution.run_id}/cancel"
+            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/cancel"
             body: "*"
         };
     }
@@ -301,7 +301,7 @@ service WorkflowService {
     // task being created for the execution.
     rpc SignalWorkflowExecution (SignalWorkflowExecutionRequest) returns (SignalWorkflowExecutionResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/runs/{workflow_execution.run_id}/signal"
+            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/signal/{signal_name}"
             body: "*"
         };
     }
@@ -331,7 +331,7 @@ service WorkflowService {
     // TODO: Does exclusive here mean *just* the completed event, or also WFT started? Otherwise the task is doomed to time out?
     rpc ResetWorkflowExecution (ResetWorkflowExecutionRequest) returns (ResetWorkflowExecutionResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/runs/{workflow_execution.run_id}/reset"
+            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/reset"
             body: "*"
         };
     }
@@ -341,7 +341,7 @@ service WorkflowService {
     // execution instance.
     rpc TerminateWorkflowExecution (TerminateWorkflowExecutionRequest) returns (TerminateWorkflowExecutionResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/runs/{workflow_execution.run_id}/terminate"
+            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/terminate"
             body: "*"
         };
     }
@@ -384,7 +384,7 @@ service WorkflowService {
     // ListArchivedWorkflowExecutions is a visibility API to list archived workflow executions in a specific namespace.
     rpc ListArchivedWorkflowExecutions (ListArchivedWorkflowExecutionsRequest) returns (ListArchivedWorkflowExecutionsResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/workflows/archived"
+            get: "/api/v1/namespaces/{namespace}/archived-workflows"
         };
     }
 
@@ -398,7 +398,7 @@ service WorkflowService {
     // CountWorkflowExecutions is a visibility API to count of workflow executions in a specific namespace.
     rpc CountWorkflowExecutions (CountWorkflowExecutionsRequest) returns (CountWorkflowExecutionsResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/workflows/count"
+            get: "/api/v1/namespaces/{namespace}/workflow-count"
         };
     }
 
@@ -438,7 +438,7 @@ service WorkflowService {
     // QueryWorkflow requests a query be executed for a specified workflow execution.
     rpc QueryWorkflow (QueryWorkflowRequest) returns (QueryWorkflowResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/runs/{execution.run_id}/query"
+            post: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/query/{query.query_type}"
             body: "*"
         };
     }
@@ -446,21 +446,21 @@ service WorkflowService {
     // DescribeWorkflowExecution returns information about the specified workflow execution.
     rpc DescribeWorkflowExecution (DescribeWorkflowExecutionRequest) returns (DescribeWorkflowExecutionResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/runs/{execution.run_id}"
+            get: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}"
         };
     }
 
     // DescribeTaskQueue returns information about the target task queue.
     rpc DescribeTaskQueue (DescribeTaskQueueRequest) returns (DescribeTaskQueueResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}"
+            get: "/api/v1/namespaces/{namespace}/task-queues/{task_queue.name}"
         };
     }
 
     // GetClusterInfo returns information about temporal cluster
     rpc GetClusterInfo(GetClusterInfoRequest) returns (GetClusterInfoResponse) {
         option (google.api.http) = {
-            get: "/api/v1/cluster"
+            get: "/api/v1/cluster-info"
         };
     }
 
@@ -477,15 +477,9 @@ service WorkflowService {
     }
 
     // Creates a new schedule.
-    // (-- api-linter: core::0133::method-signature=disabled
-    //     aip.dev/not-precedent: CreateSchedule doesn't follow Google API format --)
-    // (-- api-linter: core::0133::response-message-name=disabled
-    //     aip.dev/not-precedent: CreateSchedule doesn't follow Google API format --)
-    // (-- api-linter: core::0133::http-uri-parent=disabled
-    //     aip.dev/not-precedent: CreateSchedule doesn't follow Google API format --)
     rpc CreateSchedule (CreateScheduleRequest) returns (CreateScheduleResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/schedules"
+            post: "/api/v1/namespaces/{namespace}/schedules/{schedule_id}"
             body: "*"
         };
     }
@@ -498,23 +492,17 @@ service WorkflowService {
     }
 
     // Changes the configuration or state of an existing schedule.
-    // (-- api-linter: core::0134::response-message-name=disabled
-    //     aip.dev/not-precedent: UpdateSchedule RPC doesn't follow Google API format. --)
-    // (-- api-linter: core::0134::method-signature=disabled
-    //     aip.dev/not-precedent: UpdateSchedule RPC doesn't follow Google API format. --)
     rpc UpdateSchedule (UpdateScheduleRequest) returns (UpdateScheduleResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/schedules/{schedule_id}"
+            post: "/api/v1/namespaces/{namespace}/schedules/{schedule_id}/update"
             body: "*"
         };
     }
 
     // Makes a specific change to a schedule or triggers an immediate action.
-    // (-- api-linter: core::0134::synonyms=disabled
-    //     aip.dev/not-precedent: we have both patch and update. --)
     rpc PatchSchedule (PatchScheduleRequest) returns (PatchScheduleResponse) {
         option (google.api.http) = {
-            patch: "/api/v1/namespaces/{namespace}/schedules/{schedule_id}"
+            post: "/api/v1/namespaces/{namespace}/schedules/{schedule_id}/patch"
             body: "*"
         };
     }
@@ -529,7 +517,7 @@ service WorkflowService {
     // Deletes a schedule, removing it from the system.
     rpc DeleteSchedule (DeleteScheduleRequest) returns (DeleteScheduleResponse) {
         option (google.api.http) = {
-            delete:  "/api/v1/namespaces/{namespace}/schedules/{schedule_id}"
+            delete: "/api/v1/namespaces/{namespace}/schedules/{schedule_id}"
         };
     }
 
@@ -602,7 +590,7 @@ service WorkflowService {
     // StartBatchOperation starts a new batch operation
     rpc StartBatchOperation(StartBatchOperationRequest) returns (StartBatchOperationResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/batch-operations"
+            post: "/api/v1/namespaces/{namespace}/batch-operations/{job_id}"
             body: "*"
         };
     }
@@ -610,7 +598,7 @@ service WorkflowService {
     // StopBatchOperation stops a batch operation
     rpc StopBatchOperation(StopBatchOperationRequest) returns (StopBatchOperationResponse) {
         option (google.api.http) = {
-            put: "/api/v1/namespaces/{namespace}/batch-operations/stop",
+            post: "/api/v1/namespaces/{namespace}/batch-operations/{job_id}/stop"
             body: "*"
         };
     }
@@ -618,7 +606,7 @@ service WorkflowService {
     // DescribeBatchOperation returns the information about a batch operation
     rpc DescribeBatchOperation(DescribeBatchOperationRequest) returns (DescribeBatchOperationResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/batch-operations/describe"
+            get: "/api/v1/namespaces/{namespace}/batch-operations/{job_id}"
         };
     }
 

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -90,9 +90,10 @@ service WorkflowService {
     // workflow executions will continue to run on deprecated namespaces.
     // Deprecated.
     //
-    // (-- api-linter: core::0136::http-annotation=disabled
+    // (-- api-linter: core::0127::http-annotation=disabled
     //     aip.dev/not-precedent: Deprecated --)
-    rpc DeprecateNamespace (DeprecateNamespaceRequest) returns (DeprecateNamespaceResponse) {}
+    rpc DeprecateNamespace (DeprecateNamespaceRequest) returns (DeprecateNamespaceResponse) {
+    }
 
     // StartWorkflowExecution starts a new workflow execution.
     //
@@ -405,8 +406,7 @@ service WorkflowService {
     //
     // (-- api-linter: core::0127::http-annotation=disabled
     //     aip.dev/not-precedent: We do not expose worker API to HTTP. --)
-    rpc RespondQueryTaskCompleted (RespondQueryTaskCompletedRequest) returns (RespondQueryTaskCompletedResponse) {
-    }
+    rpc RespondQueryTaskCompleted (RespondQueryTaskCompletedRequest) returns (RespondQueryTaskCompletedResponse) {}
 
     // ResetStickyTaskQueue resets the sticky task queue related information in the mutable state of
     // a given workflow. This is prudent for workers to perform if a workflow has been paged out of


### PR DESCRIPTION
**What changed?**
I merged the operatorservice and workflowservice protos between here and our UI repo.
When a conflict arose I chose the version in the UI; this may not be the correct choice but I hope to rectify that as part of this PR

**Why?**
The new proto library we're attempting to use crashes if you have multiple service definitions for a given proto. gogo/protobuf technically _should_ have but didn't, so now we need to merge our definitions so there's only one.

This blocks me from upgrading our UI and CLI repos (our CLI embeds the ui-server)

**Breaking changes**
No
