### PR TITLE
Add Update lifecycle stage field to UpdateWorkflow and PollUpdate response protos

### DIFF
--- a/temporal/api/enums/v1/reset.proto
+++ b/temporal/api/enums/v1/reset.proto
@@ -31,7 +31,7 @@ option java_outer_classname = "ResetProto";
 option ruby_package = "Temporalio::Api::Enums::V1";
 option csharp_namespace = "Temporalio.Api.Enums.V1";
 
-// Reset reapplay(replay) options
+// Reset reapply (replay) options
 // * RESET_REAPPLY_TYPE_SIGNAL (default) - Signals are reapplied when workflow is reset
 // * RESET_REAPPLY_TYPE_NONE - nothing is reapplied
 enum ResetReapplyType {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -668,7 +668,7 @@ message ResetWorkflowExecutionRequest {
     int64 workflow_task_finish_event_id = 4;
     // Used to de-dupe reset requests
     string request_id = 5;
-    // Reset reapplay(replay) options.
+    // Reset reapply (replay) options.
     temporal.api.enums.v1.ResetReapplyType reset_reapply_type = 6;
 }
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1352,7 +1352,8 @@ message PollWorkflowExecutionUpdateRequest {
     temporal.api.update.v1.UpdateRef update_ref = 2;
     // The identity of the worker/client who is polling this update outcome
     string identity = 3;
-    // Describes when this poll request should return a response
+    // Describes when this poll request should return a response.
+    // Omit to request a non-blocking poll.
     temporal.api.update.v1.WaitPolicy wait_policy = 4;
 }
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1244,6 +1244,10 @@ message UpdateWorkflowExecutionResponse {
     // UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED <
     // UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED <
     // UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED.
+    // UNSPECIFIED will be returned if and only if the server's maximum wait
+    // time was reached before the Update reached the stage specified in the
+    // request WaitPolicy, and before the context deadline expired; clients may
+    // may then retry the call as needed.
     temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage stage = 3;
 }
 
@@ -1365,5 +1369,9 @@ message PollWorkflowExecutionUpdateResponse {
     // UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED <
     // UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED <
     // UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED.
+    // UNSPECIFIED will be returned if and only if the server's maximum wait
+    // time was reached before the Update reached the stage specified in the
+    // request WaitPolicy, and before the context deadline expired; clients may
+    // may then retry the call as needed.
     temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage stage = 2;
 }

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -39,6 +39,7 @@ import "temporal/api/enums/v1/common.proto";
 import "temporal/api/enums/v1/query.proto";
 import "temporal/api/enums/v1/reset.proto";
 import "temporal/api/enums/v1/task_queue.proto";
+import "temporal/api/enums/v1/update.proto";
 import "temporal/api/common/v1/message.proto";
 import "temporal/api/history/v1/message.proto";
 import "temporal/api/workflow/v1/message.proto";
@@ -1236,6 +1237,14 @@ message UpdateWorkflowExecutionResponse {
     // has completed. If this response is being returned before the update has
     // completed then this field will not be set.
     temporal.api.update.v1.Outcome outcome = 2;
+
+    // The most advanced lifecycle stage that the Update is known to have
+    // reached, where lifecycle stages are ordered
+    // UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED <
+    // UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED <
+    // UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED <
+    // UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED.
+    temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage stage = 3;
 }
 
 message StartBatchOperationRequest {
@@ -1350,4 +1359,11 @@ message PollWorkflowExecutionUpdateResponse {
     // UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED) then this field will
     // not be set.
     temporal.api.update.v1.Outcome outcome = 1;
+    // The most advanced lifecycle stage that the Update is known to have
+    // reached, where lifecycle stages are ordered
+    // UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED <
+    // UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED <
+    // UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED <
+    // UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED.
+    temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage stage = 2;
 }


### PR DESCRIPTION
### What changed?
- Add a new field `stage` to `UpdateWorkflowExecutionResponse` and `PollWorkflowExecutionUpdateResponse` 


### Why?
- See https://github.com/temporalio/temporal/pull/5084
- Both these endpoints attempt to wait until a requested Update lifecycle stage is reached, but they lack a way to explicitly communicate what was learned about the Update stage during this long poll. Instead, they imply this via the presence or absence of the outcome.
- In particular, `outcome=null` means `Accepted` but not `Completed` is known to have been reached.
- In addition to this being unclear, we have found that we want to use `outcome=null` to mean something different in another context (https://github.com/temporalio/temporal/issues/4742).


### Breaking changes
- No: addition of a field only
