### PR TITLE
Add UpdateRef to poll endpoint

### DIFF
--- a/temporal/api/update/v1/message.proto
+++ b/temporal/api/update/v1/message.proto
@@ -44,7 +44,7 @@ message WaitPolicy {
     temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage lifecycle_stage = 1;
 }
 
-// The data needed by a client to refer to an previously invoked workflow
+// The data needed by a client to refer to a previously invoked workflow
 // execution update process.
 message UpdateRef {
     temporal.api.common.v1.WorkflowExecution workflow_execution = 1;

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1375,4 +1375,6 @@ message PollWorkflowExecutionUpdateResponse {
     // request WaitPolicy, and before the context deadline expired; clients may
     // may then retry the call as needed.
     temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage stage = 2;
+    // Sufficient information to address this update.
+    temporal.api.update.v1.UpdateRef update_ref = 3;
 }


### PR DESCRIPTION
Follow-on from https://github.com/temporalio/api/pull/325

Adds `UpdateRef` to the poll endpoint response.

**Summary of proposed server-side changes to compute this value for the response:**

- The server `PollWorkflowExecutionUpdate` API handler receives an `UpdateRef` from the client, but this is allowed to omit `RunId`.
- It then attempts to locate the Update given the information supplied by the client.
- If successful, it will construct the *returned* `UpdateRef` using the `RunId` associated with the successfully-found Update.
- Thus, the returned `RunId` may be non-empty even though the supplied `RunId` was empty.
