### PR TITLE
Add build-id-based reset

### DIFF
--- a/temporal/api/batch/v1/message.proto
+++ b/temporal/api/batch/v1/message.proto
@@ -90,10 +90,16 @@ message BatchOperationDeletion {
 // BatchOperationReset sends reset requests to batch workflows.
 // Keep the parameter in sync with temporal.api.workflowservice.v1.ResetWorkflowExecutionRequest.
 message BatchOperationReset {
-  // Reset type.
-  temporal.api.enums.v1.ResetType reset_type = 1; 
-  // History event reapply options.
-  temporal.api.enums.v1.ResetReapplyType reset_reapply_type = 2; 
   // The identity of the worker/client.
   string identity = 3;
+
+  // Describes what to reset (exclusive with `reset_type` and `reset_reapply_type`)
+  temporal.api.common.v1.ResetOptions options = 4;
+
+  // Deprecated (use `options`):
+  // Reset type.
+  temporal.api.enums.v1.ResetType reset_type = 1;
+  // History event reapply options.
+  temporal.api.enums.v1.ResetReapplyType reset_reapply_type = 2;
+
 }

--- a/temporal/api/batch/v1/message.proto
+++ b/temporal/api/batch/v1/message.proto
@@ -93,13 +93,12 @@ message BatchOperationReset {
   // The identity of the worker/client.
   string identity = 3;
 
-  // Describes what to reset (exclusive with `reset_type` and `reset_reapply_type`)
+  // Describes what to reset to and how (exclusive with `reset_type` and `reset_reapply_type`)
   temporal.api.common.v1.ResetOptions options = 4;
 
-  // Deprecated (use `options`):
-  // Reset type.
+  // Reset type (deprecated, use `options`).
   temporal.api.enums.v1.ResetType reset_type = 1;
-  // History event reapply options.
+  // History event reapply options (deprecated, use `options`).
   temporal.api.enums.v1.ResetReapplyType reset_reapply_type = 2;
 
 }

--- a/temporal/api/batch/v1/message.proto
+++ b/temporal/api/batch/v1/message.proto
@@ -93,7 +93,7 @@ message BatchOperationReset {
   // The identity of the worker/client.
   string identity = 3;
 
-  // Describes what to reset to and how (exclusive with `reset_type` and `reset_reapply_type`)
+  // Describes what to reset to and how. If set, `reset_type` and `reset_reapply_type` are ignored.
   temporal.api.common.v1.ResetOptions options = 4;
 
   // Reset type (deprecated, use `options`).

--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -150,7 +150,8 @@ message WorkerVersionCapabilities {
     // Later, may include info like "I can process WASM and/or JS bundles"
 }
 
-// Describes where and how to reset a workflow, used for batch reset.
+// Describes where and how to reset a workflow, used for batch reset currently
+// and may be used for single-workflow reset later.
 message ResetOptions {
     // Which workflow task to reset to.
     oneof target {
@@ -160,6 +161,7 @@ message ResetOptions {
         google.protobuf.Empty last_workflow_task = 2;
         // The id of a specific `WORKFLOW_TASK_COMPLETED`,`WORKFLOW_TASK_TIMED_OUT`, `WORKFLOW_TASK_FAILED`, or
         // `WORKFLOW_TASK_STARTED` event to reset to.
+        // Note that this option doesn't make sense when used as part of a batch request.
         int64 workflow_task_id = 3;
         // Resets to the first workflow task processed by this build id.
         // If the workflow was not processed by the build id, or the workflow task can't be

--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -32,8 +32,10 @@ option ruby_package = "Temporalio::Api::Common::V1";
 option csharp_namespace = "Temporalio.Api.Common.V1";
 
 import "google/protobuf/duration.proto";
+import "google/protobuf/empty.proto";
 
 import "temporal/api/enums/v1/common.proto";
+import "temporal/api/enums/v1/reset.proto";
 
 message DataBlob {
     temporal.api.enums.v1.EncodingType encoding_type = 1;
@@ -146,4 +148,31 @@ message WorkerVersionCapabilities {
     bool use_versioning = 2;
 
     // Later, may include info like "I can process WASM and/or JS bundles"
+}
+
+// Describes where and how to reset a workflow, used for batch reset.
+message ResetOptions {
+    // Which workflow task to reset to.
+    oneof target {
+        // Resets to the first workflow task completed or started event.
+        google.protobuf.Empty first_workflow_task = 1;
+        // Resets to the last workflow task completed or started event.
+        google.protobuf.Empty last_workflow_task = 2;
+        // The id of a specific `WORKFLOW_TASK_COMPLETED`,`WORKFLOW_TASK_TIMED_OUT`, `WORKFLOW_TASK_FAILED`, or
+        // `WORKFLOW_TASK_STARTED` event to reset to.
+        int64 workflow_task_id = 3;
+        // Resets to the first workflow task processed by this build id.
+        // If the workflow was not processed by the build id, or the workflow task can't be
+        // determined, no reset will be performed.
+        // Note that by default, this reset is allowed to be to a prior run in a chain of
+        // continue-as-new.
+        string build_id = 4;
+    }
+
+    // History event reapply options.
+    temporal.api.enums.v1.ResetReapplyType reset_reapply_type = 10;
+
+    // If true, limit the reset to only within the current run. (Applies to build_id targets and
+    // possibly others in the future.)
+    bool current_run_only = 11;
 }

--- a/temporal/api/enums/v1/reset.proto
+++ b/temporal/api/enums/v1/reset.proto
@@ -40,8 +40,8 @@ enum ResetReapplyType {
     RESET_REAPPLY_TYPE_NONE = 2;
 }
 
-// Reset type options
-enum ResetType { 
+// Reset type options. Deprecated, see temporal.api.common.v1.ResetOptions.
+enum ResetType {
     RESET_TYPE_UNSPECIFIED = 0;
     // Resets to event of the first workflow task completed, or if it does not exist, the event after task scheduled.
     RESET_TYPE_FIRST_WORKFLOW_TASK = 1;

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -106,9 +106,13 @@ message ResetPoints {
     repeated ResetPointInfo points = 1;
 }
 
+// ResetPointInfo records the workflow event id that is the first one processed by a given
+// build id or binary checksum. A new reset point will be created if either build id or binary
+// checksum changes (although in general only one or the other will be used at a time).
 message ResetPointInfo {
-    // A worker binary version identifier, will be deprecated and superseded by a newer concept of
-    // build_id.
+    // Worker build id.
+    string build_id = 7;
+    // A worker binary version identifier (deprecated).
     string binary_checksum = 1;
     // The first run ID in the execution chain that was touched by this worker build.
     string run_id = 2;


### PR DESCRIPTION
**What changed?**
- Add `ResetOptions` to encapsulate options for resetting one or more workflows
- The `target` for `ResetOptions` uses a `oneof` to allow a reset type to have an argument.
- `BatchOperationReset` uses `ResetOptions`
- `ResetPointInfo` contains a `build_id` in addition to `binary_checksum` (which is now marked deprecated).

**Why?**
Help recover from a bad deployment situation

**Breaking changes**
no, the old reset options will continue to be supported
