### PR TITLE
Allow client to suggest delay until next retry

### DIFF
--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -506,6 +506,11 @@ message RespondActivityTaskFailedRequest {
     // always be set by SDKs. Workers opting into versioning will also set the `use_versioning`
     // field to true. See message docstrings for more.
     temporal.api.common.v1.WorkerVersionStamp worker_version = 6;
+    // next_retry_delay can be used by the client to override the activity
+    // retry interval calculated by the retry policy. Retry attempts will
+    // still be subject to the maximum retries limit and total time limit
+    // defined by the policy.
+    google.protobuf.Duration next_retry_delay = 7;
 }
 
 message RespondActivityTaskFailedResponse {


### PR DESCRIPTION
**What changed?**
`retry_after` field was added to `RespondActivityTaskFailedRequest` message.

**Why?**
Activity should be able to specify retry interval.

**Breaking changes**
No.
