### PR TITLE
Add SDK-only workflow metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.gen
 /.vscode
 /.stamp
+*~

--- a/temporal/api/sdk/v1/workflow_metadata.proto
+++ b/temporal/api/sdk/v1/workflow_metadata.proto
@@ -31,6 +31,7 @@ option java_outer_classname = "WorkflowMetadataProto";
 option ruby_package = "Temporalio::Api::Sdk::V1";
 option csharp_namespace = "Temporalio.Api.Sdk.V1";
 
+// The name of the query to retrieve this information is `__temporal_getWorkflowMetadata`.
 message WorkflowMetadata {
   // Metadata provided at declaration or creation time.
   WorkflowDefinition definition = 1;
@@ -39,28 +40,27 @@ message WorkflowMetadata {
 // (-- api-linter: core::0203::optional=disabled --)
 message WorkflowDefinition {
   // A name scoped by the task queue that maps to this workflow definition.
-  // If missing, it represents a dynamic workflow invoked when the requested
-  // type does not match any other registered workflow type.
-  // There is at most one dynamic workflow per task queue.
+  // If missing, this workflow is a dynamic workflow.
   string type = 1;
   // An optional workflow description provided by the application.
-  // By convention, external tools may interpret its first sentence,
-  // i.e., ending with a "." followed by a line break, as a summary of the description. 
+  // By convention, external tools may interpret its first part,
+  // i.e., ending with a line break, as a summary of the description.
   string description = 2;
-  repeated InteractionDefinition query_definitions = 3;
-  repeated InteractionDefinition signal_definitions = 4;
-  repeated InteractionDefinition update_definitions = 5;
+  repeated WorkflowInteractionDefinition query_definitions = 3;
+  repeated WorkflowInteractionDefinition signal_definitions = 4;
+  repeated WorkflowInteractionDefinition update_definitions = 5;
 }
+
 // (-- api-linter: core::0123::resource-annotation=disabled
 //     aip.dev/not-precedent: The `name` field is optional. --)
 // (-- api-linter: core::0203::optional=disabled --)
-message InteractionDefinition {
-  // An optional name to select the handler. If missing, it represents
-  // a dynamic handler that process any interactions not handled by others.
+message WorkflowInteractionDefinition {
+  // An optional name for the handler. If missing, it represents
+  // a dynamic handler that processes any interactions not handled by others.
   // There is at most one dynamic handler per workflow and interaction kind.
   string name = 1;
   // An optional interaction description provided by the application.
-  // By convention, external tools may interpret its first sentence,
-  // i.e., ending with a "." followed by a line break, as a summary of the description. 
+  // By convention, external tools may interpret its first part,
+  // i.e., ending with a line break, as a summary of the description.
   string description = 2; 
 }

--- a/temporal/api/sdk/v1/workflow_metadata.proto
+++ b/temporal/api/sdk/v1/workflow_metadata.proto
@@ -1,0 +1,66 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+syntax = "proto3";
+
+package temporal.api.sdk.v1;
+
+option go_package = "go.temporal.io/api/sdk/v1;sdk";
+option java_package = "io.temporal.api.sdk.v1";
+option java_multiple_files = true;
+option java_outer_classname = "WorkflowMetadataProto";
+option ruby_package = "Temporalio::Api::Sdk::V1";
+option csharp_namespace = "Temporalio.Api.Sdk.V1";
+
+message WorkflowMetadata {
+  // Metadata provided at declaration or creation time.
+  WorkflowDefinition definition = 1;
+}
+
+// (-- api-linter: core::0203::optional=disabled --)
+message WorkflowDefinition {
+  // A name scoped by the task queue that maps to this workflow definition.
+  // If missing, it represents a dynamic workflow invoked when the requested
+  // type does not match any other registered workflow type.
+  // There is at most one dynamic workflow per task queue.
+  string type = 1;
+  // An optional workflow description provided by the application.
+  // By convention, external tools may interpret its first sentence,
+  // i.e., ending with a "." followed by a line break, as a summary of the description. 
+  string description = 2;
+  repeated InteractionDefinition query_definitions = 3;
+  repeated InteractionDefinition signal_definitions = 4;
+  repeated InteractionDefinition update_definitions = 5;
+}
+// (-- api-linter: core::0123::resource-annotation=disabled
+//     aip.dev/not-precedent: The `name` field is optional. --)
+// (-- api-linter: core::0203::optional=disabled --)
+message InteractionDefinition {
+  // An optional name to select the handler. If missing, it represents
+  // a dynamic handler that process any interactions not handled by others.
+  // There is at most one dynamic handler per workflow and interaction kind.
+  string name = 1;
+  // An optional interaction description provided by the application.
+  // By convention, external tools may interpret its first sentence,
+  // i.e., ending with a "." followed by a line break, as a summary of the description. 
+  string description = 2; 
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding a message for workflow metadata that is only available in the SDK.

<!-- Tell your future self why have you made these changes -->
**Why?**
The goal is to provide a standard interface for all the SDKs to read workflow metadata such as registered query, signal or update handlers.
See #temporalio/features#51

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
no
