### PR TITLE
New Worker Versioning API

### DIFF
--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -92,12 +92,6 @@ message ActivityType {
     string name = 1;
 }
 
-message KeywordFilter {
-    // It's possible to either allow-list or block-list some hints.
-    repeated string include = 1;
-    repeated string exclude = 2;
-}
-
 // How retries ought to be handled, usable by both workflows and activities
 message RetryPolicy {
     // Interval of the first retry. If retryBackoffCoefficient is 1.0 then it is used for all retries.

--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -92,6 +92,12 @@ message ActivityType {
     string name = 1;
 }
 
+message KeywordFilter {
+    // It's possible to either allow-list or block-list some hints.
+    repeated string include = 1;
+    repeated string exclude = 2;
+}
+
 // How retries ought to be handled, usable by both workflows and activities
 message RetryPolicy {
     // Interval of the first retry. If retryBackoffCoefficient is 1.0 then it is used for all retries.

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -166,9 +166,9 @@ message BuildIdReachability {
 message BuildIdAssignmentRule {
     string target_build_id = 1;
 
-    // Filter executions based on the "VersioningHint" Search Attribute set by the Starter
-    // or parent Workflow.
-    temporal.api.common.v1.KeywordFilter hint_filter = 2;
+    // Filter executions based on the "VersioningHint" Search Attribute set by
+    // the Starter or parent Workflow.
+    string hint_filter = 2;
 
     // Among the tasks that match the hint filter, only this percentage of them
     // to be sent to the target Build ID. The sampling decisions is
@@ -220,12 +220,4 @@ message CompatibleBuildIdRedirectRule {
     // This option can be used only on "terminal" Build IDs (the ones not used
     // as source in any redirect rules).
     bool contingent_on_worker_availability = 3;
-
-    // (For the future)
-    // In this mode, the Workflow Tasks will be sent to both source and target
-    // Build IDs, but the tasks sent to the target Build ID are marked as
-    // "dry run". Workers will process dry run tasks only for the purpose of
-    // verifying compatibility, without causing any mutation to the execution.
-    // Dry run redirect rules do not apply to Activity Tasks.
-    // bool dry_run_mode = 4;
 }

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -112,6 +112,14 @@ message BuildIdReachability {
     repeated TaskQueueReachability task_queue_reachability = 2;
 }
 
+message RampByPercentage {
+    // Acceptable range is [0,100].
+    float ramp_percentage = 1;
+}
+
+message RampByWorkerRatio {
+}
+
 // These rules assign a Build ID to Unassigned Workflow Executions and
 // Activities.
 //
@@ -145,14 +153,15 @@ message BuildIdReachability {
 //      Attribute. This is useful for Canary deployments, for example, when
 //      only the executions with `VersioningHint="canary"` should be sent to
 //      the new Build ID.
-//    - And/or setting a `ramp_percentage` value. This is useful for gradual
-//      shift of the traffic To the new Build ID in Blue/Green deployments and
-//      alike.
-//
-// Additionally, the rule can be contingent upon the availability of target
-// Workers. This is useful for rolling deployments, when the gradual shift of
-// traffic to the new Build ID is driven by the gradual upgrade of the Workers,
-// rather than a `ramp_percentage` value.
+//    - And/or setting a "ramp". This is useful for gradual shift of the
+//      traffic To the new Build ID. An assignment rule can have one of the
+//      following ramps:
+//      - Ramp by percentage: suitable for Blue/Green and similar deployments,
+//        when you want to send a certain percentage of traffic to the new
+//        Build ID.
+//      - Ramp by worker ratio: suitable for rolling deployments, when you want
+//        to shift more traffic to the new Build ID as the workers being
+//        gradually upgraded.
 //
 // When there are multiple assignment rules for a Task Queue, the rules are
 // evaluated in order, starting from index 0. The first applicable rule will be
@@ -170,17 +179,21 @@ message BuildIdAssignmentRule {
     // the Starter or parent Workflow.
     string hint_filter = 2;
 
-    // Among the tasks that match the hint filter, only this percentage of them
-    // to be sent to the target Build ID.
-    // The default ramp value is 100. The valid range is [0-100].
-    float ramp_percentage = 3;
-
-    // This option is intended for rolling deployments. When enabled, we try
-    // immediate dispatch to the target Build ID. If no poller is available, we
-    // skip this rule for the task at hand.
+    // If a ramp is provided, the tasks that match the hint filter will be
+    // subject to the given ramp.
     // This option can be used only on "terminal" Build IDs (the ones not used
     // as source in any redirect rules).
-    bool contingent_on_worker_availability = 4;
+    oneof ramp {
+        // This ramp is useful for gradual Blue/Green deployments (and similar)
+        // where you want to send a certain portion of the traffic to the target
+        // Build ID.
+        RampByPercentage percentage_ramp = 3;
+        // This option is intended for rolling deployments. The ramp percentage
+        // is automatically set as the ratio of the target Build ID's active
+        // workers over all active workers for any Build ID used in the
+        // assignment rules.
+        RampByWorkerRatio worker_ratio_ramp = 4;
+    }
 }
 
 // These rules apply to tasks assigned to a particular Build ID
@@ -196,8 +209,8 @@ message BuildIdAssignmentRule {
 //    newer one.
 //  - Need to hotfix some broken or stuck Workflow Executions.
 //
-// Similar to the assignment rules, redirect rules can be contingent upon the
-// availability of target Workers, which is useful for rolling deployments.
+// Similar to assignment rule, redirect rules support ramp by worker ratio.
+// They do not currently support ramp by percentage.
 //
 // In steady state, redirect rules are beneficial when dealing with old
 // Executions ran on now-decommissioned Build IDs:
@@ -206,15 +219,16 @@ message BuildIdAssignmentRule {
 //    (compatible) Build ID.
 //
 // Redirect rules can be chained, but only the last rule in the chain can have
-// the `contingent_on_worker_availability` options enabled.
+// a ramp.
 message CompatibleBuildIdRedirectRule {
     string source_build_id = 1;
     string target_build_id = 2;
 
-    // This option is intended for rolling deployments. When enabled, we try
-    // immediate dispatch to the target Build ID. If it has no available
-    // pollers, we fallback to the source Build ID.
-    // This option can be used only on "terminal" Build IDs (the ones not used
-    // as source in any redirect rules).
-    bool contingent_on_worker_availability = 3;
+    // Only the last redirect rule in a chain can have a ramp.
+    oneof ramp {
+        // This option is intended for rolling deployments. When this field is
+        // provided, we redirect a fraction of tasks proportional to the ratio
+        // of the target Build ID's active workers over the .
+        RampByWorkerRatio worker_ratio_ramp = 3;
+    }
 }

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -111,3 +111,121 @@ message BuildIdReachability {
     // Reachability per task queue.
     repeated TaskQueueReachability task_queue_reachability = 2;
 }
+
+// These rules assign a Build ID to Unassigned Workflow Executions and
+// Activities.
+//
+// Specifically, assignment rules are applied to the following Executions or
+// Activities when they are scheduled in a Task Queue:
+//    - Generally, any new Workflow Execution, except:
+//      - Child Workflows started without overriding their Task Queue or
+//        assignment status.
+//      - Continue-As-New Executions started without overriding assignment
+//        status.
+//      - Workflow Executions started Eagerly.
+//    - An Activity that is scheduled on a Task Queue different from the one
+//      their Workflow runs on, without overriding assignment status.
+//
+// In absence of (applicable) redirect rules (`CompatibleBuildIdRedirectRule`s)
+// the task will be dispatched to Workers of the Build ID determined by the
+// assignment rules. Otherwise, the final Build ID will be determined by the
+// redirect rules.
+//
+// When using Worker Versioning, in the steady state, for a given Task Queue,
+// there should typically be exactly one assignment rule to send all Unassigned
+// tasks to the latest Build ID. Existence of at least one such "unconditional"
+// rule at all times is enforce by the system, unless the `force` flag is used
+// by the user when replacing/deleting these rules (for exceptional cases).
+//
+// During a deployment, one or more additional rules can be added to assign a
+// subset of the tasks to a new Build ID.
+//
+// The subset is defined by:
+//    - Including or excluding particular values of the `VersioningHint` Search
+//      Attribute. This is useful for Canary deployments, for example, when
+//      only the executions with `versioning_hint="canary"` should be sent to
+//      the new Build ID.
+//    - And/or setting a `ramp_percentage` value. This is useful for gradual
+//      shift of the traffic To the new Build ID in Blue/Green deployments and
+//      alike.
+//
+// Additionally, the rule can be contingent upon the availability of target
+// Workers. This is useful for rolling deployments, when the gradual shift of
+// traffic to the new Build ID is driven by the gradual upgrade of the Workers,
+// rather than a `ramp_percentage` value.
+//
+// When there are multiple assignment rules for a Task Queue, the rules are
+// evaluated in order, starting from index 0. The first applicable rule will be
+// applied and the rest will be ignored.
+//
+// In the event that no assignment rule is applicable on a task (or the Task
+// Queue is simply not versioned), the tasks will be sent to unversioned
+// workers, if available. Otherwise, they remain Unassigned, and will be
+// retried for assignment, or dispatch to unversioned workers, at a later time
+// depending on the availability of workers.
+message BuildIdAssignmentRule {
+    string target_build_id = 1;
+
+    // The Starter (or parent Workflow) can send a "versioning_hint" value
+    // which can be used as filter criteria in here.
+    temporal.api.common.v1.KeywordFilter hint_filter = 2;
+
+    // Among the tasks that match the hint filter, only this percentage of them
+    // to be sent to the target Build ID. The sampling decisions is
+    // deterministic for a given Workflow Execution (i.e. given a fixed ramp
+    // value, the same decision will be made for a particular Workflow
+    // Execution no matter how many time it is tested against the ramp value).
+    // The default ramp value is 100. The valid range is [0-100].
+    float ramp_percentage = 3;
+
+    // This option is intended for rolling deployments. When enabled, we try
+    // immediate dispatch to the target Build ID. If no poller is available, we
+    // skip this rule for the task at hand.
+    // This option can be used only on "terminal" Build IDs (the ones not used
+    // as source in any redirect rules).
+    bool contingent_on_worker_availability = 4;
+}
+
+// These rules apply to tasks assigned to a particular Build ID
+// (`source_build_id`) to redirect them to another *compatible* Build ID
+// (`target_build_id`).
+//
+// It is user's responsibility to ensure that the target Build ID is compatible
+// with the source Build ID (e.g. by using the Patching API).
+//
+// Most deployments are not expected to need these rules, however following
+// situations can greatly benefit from redirects:
+//  - Need to move long-running Workflow Executions from an old Build ID to a
+//    newer one.
+//  - Need to hotfix some broken or stuck Workflow Executions.
+//
+// Similar to the assignment rules, redirect rules can be contingent upon the
+// availability of target Workers, which is useful for rolling deployments.
+//
+// In steady state, redirect rules are beneficial when dealing with old
+// Executions ran on now-decommissioned Build IDs:
+//  - To redirecting the Workflow Queries to the current (compatible) Build ID.
+//  - To be able to Reset an old Execution so it can run on the current
+//    (compatible) Build ID.
+//
+// Redirect rules can be chained, but only the last rule in the chain can have
+// the `contingent_on_worker_availability` options enabled.
+message CompatibleBuildIdRedirectRule {
+    string source_build_id = 1;
+    string target_build_id = 2;
+
+    // This option is intended for rolling deployments. When enabled, we try
+    // immediate dispatch to the target Build ID. If it has no available
+    // pollers, we fallback to the source Build ID.
+    // This option can be used only on "terminal" Build IDs (the ones not used
+    // as source in any redirect rules).
+    bool contingent_on_worker_availability = 3;
+
+    // (For the future)
+    // In this mode, the Workflow Tasks will be sent to both source and target
+    // Build IDs, but the tasks sent to the target Build ID are marked as
+    // "dry run". Workers will process dry run tasks only for the purpose of
+    // verifying compatibility, without causing any mutation to the execution.
+    // Dry run redirect rules do not apply to Activity Tasks.
+    // bool dry_run_mode = 4;
+}

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -171,10 +171,7 @@ message BuildIdAssignmentRule {
     string hint_filter = 2;
 
     // Among the tasks that match the hint filter, only this percentage of them
-    // to be sent to the target Build ID. The sampling decisions is
-    // deterministic for a given Workflow Execution (i.e. given a fixed ramp
-    // value, the same decision will be made for a particular Workflow
-    // Execution no matter how many time it is tested against the ramp value).
+    // to be sent to the target Build ID.
     // The default ramp value is 100. The valid range is [0-100].
     float ramp_percentage = 3;
 

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -166,8 +166,8 @@ message BuildIdReachability {
 message BuildIdAssignmentRule {
     string target_build_id = 1;
 
-    // The Starter (or parent Workflow) can send a "versioning_hint" value
-    // which can be used as filter criteria in here.
+    // Filter executions based on the "VersioningHint" Search Attribute set by the Starter
+    // or parent Workflow.
     temporal.api.common.v1.KeywordFilter hint_filter = 2;
 
     // Among the tasks that match the hint filter, only this percentage of them

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -141,9 +141,9 @@ message BuildIdReachability {
 // subset of the tasks to a new Build ID.
 //
 // The subset is defined by:
-//    - Including or excluding particular values of the `VersioningHint` Search
+//    - Filtering based on a particular value of the `VersioningHint` Search
 //      Attribute. This is useful for Canary deployments, for example, when
-//      only the executions with `versioning_hint="canary"` should be sent to
+//      only the executions with `VersioningHint="canary"` should be sent to
 //      the new Build ID.
 //    - And/or setting a `ramp_percentage` value. This is useful for gradual
 //      shift of the traffic To the new Build ID in Blue/Green deployments and

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1169,6 +1169,11 @@ message GetWorkerBuildIdCompatibilityResponse {
     repeated temporal.api.taskqueue.v1.CompatibleVersionSet major_version_sets = 1;
 }
 
+
+// (-- api-linter: core::0134::request-mask-required=disabled
+//     aip.dev/not-precedent: UpdateNamespace RPC doesn't follow Google API format. --)
+// (-- api-linter: core::0134::request-resource-required=disabled
+//     aip.dev/not-precedent: GetWorkerBuildIdCompatibilityRequest RPC doesn't follow Google API format. --)
 message UpdateWorkerVersioningRulesRequest {
 
     // Inserts the rule to the list of assignment rules for this Task Queue.
@@ -1179,7 +1184,7 @@ message UpdateWorkerVersioningRulesRequest {
         // default, the new rule is inserted at the beginning of the list
         // (index 0). If the given index is too larger the rule will be
         // inserted at the end of the list.
-        int32 insert_at = 1;
+        int32 rule_index = 1;
         temporal.api.taskqueue.v1.BuildIdAssignmentRule rule = 2;
     }
 
@@ -1268,7 +1273,8 @@ message UpdateWorkerVersioningRulesResponse {
 message ListWorkerVersioningRulesRequest {
     string namespace = 1;
     string task_queue = 2;
-    // Optional. list rules only concerning particular Build IDs.
+
+    // Use this option to list rules only related to particular Build IDs.
     repeated string build_ids = 3;
 }
 message ListWorkerVersioningRulesResponse {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1169,6 +1169,114 @@ message GetWorkerBuildIdCompatibilityResponse {
     repeated temporal.api.taskqueue.v1.CompatibleVersionSet major_version_sets = 1;
 }
 
+message UpdateWorkerVersioningRulesRequest {
+
+    // Inserts the rule to the list of assignment rules for this Task Queue.
+    // The rules are evaluated in order, starting from index 0. The first
+    // applicable rule will be applied and the rest will be ignored.
+    message InsertBuildIdAssignmentRule {
+        // Use this option to insert the rule in a particular index. By
+        // default, the new rule is inserted at the beginning of the list
+        // (index 0). If the given index is too larger the rule will be
+        // inserted at the end of the list.
+        int32 insert_at = 1;
+        temporal.api.taskqueue.v1.BuildIdAssignmentRule rule = 2;
+    }
+
+    // Replaces the assignment rule at a given index.
+    message ReplaceBuildIdAssignmentRule {
+        int32 rule_index = 1;
+        temporal.api.taskqueue.v1.BuildIdAssignmentRule rule = 2;
+
+        // By default presence of one unconditional rule is enforced, otherwise
+        // the replace operation will be rejected. Set `force` to true to
+        // bypass this validation. An unconditional assignment rule:
+        //   - Has no hint filter
+        //   - Has 100% ramp
+        //   - Is not contingent on worker availability
+        bool force = 3;
+    }
+
+    message DeleteBuildIdAssignmentRule {
+        int32 rule_index = 1;
+
+        // By default presence of one unconditional rule is enforced, otherwise
+        // the delete operation will be rejected. Set `force` to true to
+        // bypass this validation. An unconditional assignment rule:
+        //   - Has no hint filter
+        //   - Has 100% ramp
+        //   - Is not contingent on worker availability
+        bool force = 2;
+    }
+
+    // Adds the rule to the list of redirect rules for this Task Queue. There
+    // can be at most one redirect rule from each Build ID.
+    message AddCompatibleBuildIdRedirectRule {
+        temporal.api.taskqueue.v1.CompatibleBuildIdRedirectRule rule = 1;
+    }
+
+    // Replaces the routing rule with the given source Build ID.
+    message ReplaceCompatibleBuildIdRedirectRule {
+        temporal.api.taskqueue.v1.CompatibleBuildIdRedirectRule rule = 1;
+    }
+
+    message DeleteCompatibleBuildIdRedirectRule {
+        string source_build_id = 1;
+    }
+
+    // This command is intended to be used to complete the rollout of a Build
+    // ID and cleanup unnecessary rules possibly created during a gradual
+    // rollout. Specifically, this command will make the following changes
+    // atomically:
+    //  1. Adds an unconditional assignment rule for the target Build ID at the
+    //     end of the list. An unconditional assignment rule:
+    //      - Has no hint filter
+    //      - Has 100% ramp
+    //      - Is not contingent on worker availability
+    //  2. Removes all previously added assignment rules to the given target
+    //     Build ID (if any).
+    //  3. Removes any *unconditional* assignment rule for other Build IDs.
+    //  4. Removes the `contingent_on_worker_availability` flag of any incoming
+    //     redirect rules to this Build ID.
+    message CommitBuildId {
+        string target_build_id = 1;
+
+        // To prevent committing invalid Build IDs, we reject the request if no
+        // pollers has been seen recently for this Build ID. Use the `force`
+        // option to disable this validation.
+        string force = 2;
+    }
+
+    string namespace = 1;
+    string task_queue = 2;
+
+    oneof operation {
+        InsertBuildIdAssignmentRule insert_assignment_rule = 3;
+        ReplaceBuildIdAssignmentRule replace_assignment_rule = 4;
+        DeleteBuildIdAssignmentRule delete_assignment_rule = 5;
+        AddCompatibleBuildIdRedirectRule insert_compatible_redirect_rule = 6;
+        ReplaceCompatibleBuildIdRedirectRule replace_compatible_redirect_rule = 7;
+        DeleteCompatibleBuildIdRedirectRule delete_compatible_redirect_rule = 8;
+        CommitBuildId commit_build_id = 9;
+    }
+}
+message UpdateWorkerVersioningRulesResponse {
+    reserved 1;
+    reserved "rule_index";
+}
+
+message ListWorkerVersioningRulesRequest {
+    string namespace = 1;
+    string task_queue = 2;
+    // Optional. list rules only concerning particular Build IDs.
+    repeated string build_ids = 3;
+}
+message ListWorkerVersioningRulesResponse {
+    repeated temporal.api.taskqueue.v1.BuildIdAssignmentRule assignment_rules = 1;
+    repeated temporal.api.taskqueue.v1.CompatibleBuildIdRedirectRule compatible_redirect_rules = 2;
+}
+
+
 message GetWorkerTaskReachabilityRequest {
     string namespace = 1;
     // Build ids to retrieve reachability for. An empty string will be interpreted as an unversioned worker.
@@ -1378,3 +1486,4 @@ message PollWorkflowExecutionUpdateResponse {
     // Sufficient information to address this update.
     temporal.api.update.v1.UpdateRef update_ref = 3;
 }
+

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1169,13 +1169,11 @@ message GetWorkerBuildIdCompatibilityResponse {
     repeated temporal.api.taskqueue.v1.CompatibleVersionSet major_version_sets = 1;
 }
 
-
 // (-- api-linter: core::0134::request-mask-required=disabled
 //     aip.dev/not-precedent: UpdateNamespace RPC doesn't follow Google API format. --)
 // (-- api-linter: core::0134::request-resource-required=disabled
 //     aip.dev/not-precedent: GetWorkerBuildIdCompatibilityRequest RPC doesn't follow Google API format. --)
 message UpdateWorkerVersioningRulesRequest {
-
     // Inserts the rule to the list of assignment rules for this Task Queue.
     // The rules are evaluated in order, starting from index 0. The first
     // applicable rule will be applied and the rest will be ignored.
@@ -1215,7 +1213,7 @@ message UpdateWorkerVersioningRulesRequest {
     }
 
     // Adds the rule to the list of redirect rules for this Task Queue. There
-    // can be at most one redirect rule from each Build ID.
+    // can be at most one redirect rule for each distinct Source Build ID.
     message AddCompatibleBuildIdRedirectRule {
         temporal.api.taskqueue.v1.CompatibleBuildIdRedirectRule rule = 1;
     }
@@ -1249,39 +1247,51 @@ message UpdateWorkerVersioningRulesRequest {
         // To prevent committing invalid Build IDs, we reject the request if no
         // pollers has been seen recently for this Build ID. Use the `force`
         // option to disable this validation.
-        string force = 2;
+        bool force = 2;
     }
 
     string namespace = 1;
     string task_queue = 2;
 
+    // This can be the value of conflict_token from the previous
+    // ListWorkerVersioningRulesResponse or UpdateWorkerVersioningRulesResponse
+    // which will cause this request to fail if the rules have been modified
+    // for this Task Queue between the previous and current operation.
+    // If missing, the rules will be updated unconditionally.
+    bytes conflict_token = 3;
+
     oneof operation {
-        InsertBuildIdAssignmentRule insert_assignment_rule = 3;
-        ReplaceBuildIdAssignmentRule replace_assignment_rule = 4;
-        DeleteBuildIdAssignmentRule delete_assignment_rule = 5;
-        AddCompatibleBuildIdRedirectRule insert_compatible_redirect_rule = 6;
-        ReplaceCompatibleBuildIdRedirectRule replace_compatible_redirect_rule = 7;
-        DeleteCompatibleBuildIdRedirectRule delete_compatible_redirect_rule = 8;
-        CommitBuildId commit_build_id = 9;
+        InsertBuildIdAssignmentRule insert_assignment_rule = 4;
+        ReplaceBuildIdAssignmentRule replace_assignment_rule = 5;
+        DeleteBuildIdAssignmentRule delete_assignment_rule = 6;
+        AddCompatibleBuildIdRedirectRule insert_compatible_redirect_rule = 7;
+        ReplaceCompatibleBuildIdRedirectRule replace_compatible_redirect_rule = 8;
+        DeleteCompatibleBuildIdRedirectRule delete_compatible_redirect_rule = 9;
+        CommitBuildId commit_build_id = 10;
     }
 }
+
 message UpdateWorkerVersioningRulesResponse {
-    reserved 1;
-    reserved "rule_index";
+    // This value can be passed back to UpdateWorkerVersioningRulesRequest to
+    // ensure that the rules were not modified between the two updates, which
+    // could lead to lost updates and other confusion.
+    bytes conflict_token = 1;
 }
 
 message ListWorkerVersioningRulesRequest {
     string namespace = 1;
     string task_queue = 2;
-
-    // Use this option to list rules only related to particular Build IDs.
-    repeated string build_ids = 3;
 }
+
 message ListWorkerVersioningRulesResponse {
     repeated temporal.api.taskqueue.v1.BuildIdAssignmentRule assignment_rules = 1;
     repeated temporal.api.taskqueue.v1.CompatibleBuildIdRedirectRule compatible_redirect_rules = 2;
-}
 
+    // This value can be passed back to UpdateWorkerVersioningRulesRequest to
+    // ensure that the rules were not modified between this List and the Update,
+    // which could lead to lost updates and other confusion.
+    bytes conflict_token = 3;
+}
 
 message GetWorkerTaskReachabilityRequest {
     string namespace = 1;

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1195,8 +1195,7 @@ message UpdateWorkerVersioningRulesRequest {
         // the replace operation will be rejected. Set `force` to true to
         // bypass this validation. An unconditional assignment rule:
         //   - Has no hint filter
-        //   - Has 100% ramp
-        //   - Is not contingent on worker availability
+        //   - Has no ramp
         bool force = 3;
     }
 
@@ -1207,8 +1206,7 @@ message UpdateWorkerVersioningRulesRequest {
         // the delete operation will be rejected. Set `force` to true to
         // bypass this validation. An unconditional assignment rule:
         //   - Has no hint filter
-        //   - Has 100% ramp
-        //   - Is not contingent on worker availability
+        //   - Has no ramp
         bool force = 2;
     }
 
@@ -1234,13 +1232,11 @@ message UpdateWorkerVersioningRulesRequest {
     //  1. Adds an unconditional assignment rule for the target Build ID at the
     //     end of the list. An unconditional assignment rule:
     //      - Has no hint filter
-    //      - Has 100% ramp
-    //      - Is not contingent on worker availability
+    //      - Has no ramp
     //  2. Removes all previously added assignment rules to the given target
     //     Build ID (if any).
     //  3. Removes any *unconditional* assignment rule for other Build IDs.
-    //  4. Removes the `contingent_on_worker_availability` flag of any incoming
-    //     redirect rules to this Build ID.
+    //  4. Removes the ramp of any incoming redirect rules to this Build ID.
     message CommitBuildId {
         string target_build_id = 1;
 

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -542,6 +542,8 @@ service WorkflowService {
     }
 
     // Allows updating the Build ID assignment and redirect rules for a given Task Queue.
+    // (-- api-linter: core::0127::http-annotation=disabled
+    //     aip.dev/not-precedent: We do yet expose versioning API to HTTP. --)
     rpc UpdateWorkerVersioningRules (UpdateWorkerVersioningRulesRequest) returns (UpdateWorkerVersioningRulesResponse) {}
 
     // Fetches the Build ID assignment and redirect rules for a Task Queue

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -514,6 +514,8 @@ service WorkflowService {
         };
     }
 
+    // Deprecated. Use `UpdateWorkerVersioningRules`.
+    //
     // Allows users to specify sets of worker build id versions on a per task queue basis. Versions
     // are ordered, and may be either compatible with some extant version, or a new incompatible
     // version, forming sets of ids which are incompatible with each other, but whose contained
@@ -531,10 +533,21 @@ service WorkflowService {
     //     aip.dev/not-precedent: We do yet expose versioning API to HTTP. --)
     rpc UpdateWorkerBuildIdCompatibility (UpdateWorkerBuildIdCompatibilityRequest) returns (UpdateWorkerBuildIdCompatibilityResponse) {}
 
+    // Deprecated. Use `ListWorkerVersioningRules`.
     // Fetches the worker build id versioning sets for a task queue.
     rpc GetWorkerBuildIdCompatibility (GetWorkerBuildIdCompatibilityRequest) returns (GetWorkerBuildIdCompatibilityResponse) {
         option (google.api.http) = {
             get: "/api/v1/namespaces/{namespace}/task-queues/{task_queue}/worker-build-id-compatibility"
+        };
+    }
+
+    // Allows updating the Build ID assignment and redirect rules for a given Task Queue.
+    rpc UpdateWorkerVersioningRules (UpdateWorkerVersioningRulesRequest) returns (UpdateWorkerVersioningRulesResponse) {}
+
+    // Fetches the Build ID assignment and redirect rules for a Task Queue
+    rpc ListWorkerVersioningRules (ListWorkerVersioningRulesRequest) returns (ListWorkerVersioningRulesResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/namespaces/{namespace}/task-queues/{task_queue}/worker-versioning-rules"
         };
     }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Deprecating `UpdateWorkerBuildIdCompatibility` and `GetWorkerBuildIdCompatibility` and replacing them with `UpdateWorkerVersioningRules` and `ListWorkerVersioningRules`.
- Deprecating the concept of Version Set and "default Version Set", replacing them with more flexible `BuildIdAssignmentRule` and `CompatibleBuildIdRedirectRule` concepts.
- The assignment rules assign a Build ID to new (Unassigned) Workflow Executions and Activities.
- The redirect rules are only used in context of compatible Build IDs. These rules apply to tasks assigned to a particular Build ID (`source_build_id`) to redirect them to another compatible Build ID (`target_build_id`).

<!-- Tell your future self why have you made these changes -->
**Why?**
- Be able to support **Gradual rollout** for Canary, Blue/Green, Rolling deployments (and alike)
    - Rolling:  ability to send new and/or existing executions to the new build based on the worker count of new vs old build.
    - Blue/Green: ability to send a particular percentage of the new executions to the new build
    - Canary: ability to filter new executions based on “VersioningHint” Search Attribute set by Starter
- Version Set is not the right abstraction for the Build ID compatibility relationships, replaced it with `CompatibleBuildIdRedirectRule` which:
    - Do not loose the directionality: a redirect is from a source Build ID to a target Build ID
    - Are removable (useful in cases that the compatibility was claimed by mistake)
    - Are more powerful: redirect rules support worker-ratio-based ramps. Other ramp types, dry run mode, and filter can be added in the future.
- Making the API Incompatible-first: The primary beneficiary of WV are use cases with presumed-incompatible build IDs because WV frees them from caring about compatibility. They should be able to use WV without having to learn or think about Version Sets which currently takes the center stage of the API. Now these use cases can use `BuildIdAssignmentRule` with independent Build IDs.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
The `UpdateWorkerBuildIdCompatibility` and `GetWorkerBuildIdCompatibility` become deprecated, but supported for one version beside the new API.
