### PR TITLE
adding signaling workflow information to the signal event.

### DIFF
--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -434,7 +434,7 @@ message WorkflowExecutionSignaledEventAttributes {
     temporal.api.common.v1.Header header = 4;
     // Indicates the signal did not generate a new workflow task when received.
     bool skip_generate_workflow_task = 5;
-    // Provides signaling workflow information
+    // When signal origin is a workflow execution, this field is set.
     temporal.api.common.v1.WorkflowExecution external_workflow_execution = 6;
 }
 

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -434,6 +434,8 @@ message WorkflowExecutionSignaledEventAttributes {
     temporal.api.common.v1.Header header = 4;
     // Indicates the signal did not generate a new workflow task when received.
     bool skip_generate_workflow_task = 5;
+    // Provides signaling workflow information
+    temporal.api.common.v1.WorkflowExecution external_workflow_execution = 6;
 }
 
 message WorkflowExecutionTerminatedEventAttributes {


### PR DESCRIPTION
**What changed?**
Added `external_workflow_execution` reference to History Signal Event attributes.

**Why?**
Allow signalling workflow information to be saved with the signal.

**Breaking changes**
No.