### PR TITLE
Add Nexus callback related protos

### DIFF
--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -178,3 +178,18 @@ message ResetOptions {
     // possibly others in the future.)
     bool current_run_only = 11;
 }
+
+// Callback to attach to various events in the system, e.g. workflow run completion.
+message Callback {
+    message Nexus {
+        // Callback URL.
+        // (-- api-linter: core::0140::uri=disabled
+        //     aip.dev/not-precedent: Not following this guideline. --)
+        string url = 1;
+    }
+
+    reserved 1; // For a generic callback mechanism to be added later.
+    oneof variant {
+        Nexus nexus = 2;
+    }
+}

--- a/temporal/api/enums/v1/common.proto
+++ b/temporal/api/enums/v1/common.proto
@@ -59,6 +59,9 @@ enum Severity {
 // stateDiagram-v2
 //    Standby --> Ready
 //    Ready --> Scheduled
+//    Standby --> Blocked
+//    Ready --> Blocked
+//    Blocked --> Scheduled
 //    Scheduled --> Failed
 //    Scheduled --> Succeeded
 //    Failed --> BackingOff
@@ -68,18 +71,19 @@ enum CallbackState {
     CALLBACK_STATE_UNSPECIFIED = 0;
     // Callback is standing by, waiting to be triggered.
     CALLBACK_STATE_STANDBY = 1;
-    // Callback was triggered and is ready to be dispatched.
-    // Callbacks transition directly from STANDBY to SCHEDULED unless:
-    // 1. The callback is waiting for a previous callback to be dispatched.
-    // 2. The callback queue for this (source namespace, destination) is full in a given history shard.
-    // When the queue is full, callbacks can be rescheduled by an operator (TODO: mention which API when implemented).
+    // Callback was triggered and is ready and is waiting for a previous callback to be dispatched.
+    // This may happen if i.e. an Update callback completes before a Run callback for the same destination to ensure
+    // delivery order.
     CALLBACK_STATE_READY = 2;
-    // Callback is in the queue pending execution.
-    CALLBACK_STATE_SCHEDULED = 3;
+    // Callback cannot be scheduled because the queue for this source namespace and destination is full in a given history shard.
+    // Callbacks can be unblocked by an operator (TODO: mention which API when implemented).
+    CALLBACK_STATE_BLOCKED = 3;
+    // Callback is in the queue waiting to be executed or is currently executing.
+    CALLBACK_STATE_SCHEDULED = 4;
     // Callback has failed with a retryable error and is backing off before the next attempt.
-    CALLBACK_STATE_BACKING_OFF = 4;
+    CALLBACK_STATE_BACKING_OFF = 5;
     // Callback has failed.
-    CALLBACK_STATE_FAILED = 5;
+    CALLBACK_STATE_FAILED = 6;
     // Callback has succeeded.
-    CALLBACK_STATE_SUCCEEDED = 6;
+    CALLBACK_STATE_SUCCEEDED = 7;
 }

--- a/temporal/api/enums/v1/common.proto
+++ b/temporal/api/enums/v1/common.proto
@@ -54,3 +54,32 @@ enum Severity {
     SEVERITY_MEDIUM = 2;
     SEVERITY_LOW = 3;
 }
+
+// State of the callback.
+// stateDiagram-v2
+//    Standby --> Ready
+//    Ready --> Scheduled
+//    Scheduled --> Failed
+//    Scheduled --> Succeeded
+//    Failed --> BackingOff
+//    BackingOff --> Scheduled
+enum CallbackState {
+    // Default value, unspecified state.
+    CALLBACK_STATE_UNSPECIFIED = 0;
+    // Callback is standing by, waiting to be triggered.
+    CALLBACK_STATE_STANDBY = 1;
+    // Callback was triggered and is ready to be dispatched.
+    // Callbacks transition directly from STANDBY to SCHEDULED unless:
+    // 1. The callback is waiting for a previous callback to be dispatched.
+    // 2. The callback queue for this (source namespace, destination) is full in a given history shard.
+    // When the queue is full, callbacks can be rescheduled by an operator (TODO: mention which API when implemented).
+    CALLBACK_STATE_READY = 2;
+    // Callback is in the queue pending execution.
+    CALLBACK_STATE_SCHEDULED = 3;
+    // Callback has failed with a retryable error and is backing off before the next attempt.
+    CALLBACK_STATE_BACKING_OFF = 4;
+    // Callback has failed.
+    CALLBACK_STATE_FAILED = 5;
+    // Callback has succeeded.
+    CALLBACK_STATE_SUCCEEDED = 6;
+}

--- a/temporal/api/enums/v1/common.proto
+++ b/temporal/api/enums/v1/common.proto
@@ -56,16 +56,6 @@ enum Severity {
 }
 
 // State of the callback.
-// stateDiagram-v2
-//    Standby --> Ready
-//    Ready --> Scheduled
-//    Standby --> Blocked
-//    Ready --> Blocked
-//    Blocked --> Scheduled
-//    Scheduled --> Failed
-//    Scheduled --> Succeeded
-//    Failed --> BackingOff
-//    BackingOff --> Scheduled
 enum CallbackState {
     // Default value, unspecified state.
     CALLBACK_STATE_UNSPECIFIED = 0;

--- a/temporal/api/enums/v1/common.proto
+++ b/temporal/api/enums/v1/common.proto
@@ -61,19 +61,12 @@ enum CallbackState {
     CALLBACK_STATE_UNSPECIFIED = 0;
     // Callback is standing by, waiting to be triggered.
     CALLBACK_STATE_STANDBY = 1;
-    // Callback was triggered and is ready and is waiting for a previous callback to be dispatched.
-    // This may happen if i.e. an Update callback completes before a Run callback for the same destination to ensure
-    // delivery order.
-    CALLBACK_STATE_READY = 2;
-    // Callback cannot be scheduled because the queue for this source namespace and destination is full in a given history shard.
-    // Callbacks can be unblocked by an operator (TODO: mention which API when implemented).
-    CALLBACK_STATE_BLOCKED = 3;
     // Callback is in the queue waiting to be executed or is currently executing.
-    CALLBACK_STATE_SCHEDULED = 4;
+    CALLBACK_STATE_SCHEDULED = 2;
     // Callback has failed with a retryable error and is backing off before the next attempt.
-    CALLBACK_STATE_BACKING_OFF = 5;
+    CALLBACK_STATE_BACKING_OFF = 3;
     // Callback has failed.
-    CALLBACK_STATE_FAILED = 6;
+    CALLBACK_STATE_FAILED = 4;
     // Callback has succeeded.
-    CALLBACK_STATE_SUCCEEDED = 7;
+    CALLBACK_STATE_SUCCEEDED = 5;
 }

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -103,6 +103,9 @@ message WorkflowExecutionStartedEventAttributes {
     // If this workflow intends to use anything other than the current overall default version for
     // the queue, then we include it here.
     temporal.api.common.v1.WorkerVersionStamp source_version_stamp = 29;
+
+    // Callbacks attached when this workflow was started.
+    repeated temporal.api.common.v1.Callback callbacks = 30;
 }
 
 message WorkflowExecutionCompletedEventAttributes {

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -104,8 +104,8 @@ message WorkflowExecutionStartedEventAttributes {
     // the queue, then we include it here.
     temporal.api.common.v1.WorkerVersionStamp source_version_stamp = 29;
 
-    // Callbacks attached when this workflow was started.
-    repeated temporal.api.common.v1.Callback callbacks = 30;
+    // Completion callbacks attached when this workflow was started.
+    repeated temporal.api.common.v1.Callback completion_callbacks = 30;
 }
 
 message WorkflowExecutionCompletedEventAttributes {

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -34,6 +34,7 @@ option csharp_namespace = "Temporalio.Api.Workflow.V1";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
+import "temporal/api/enums/v1/common.proto";
 import "temporal/api/enums/v1/workflow.proto";
 import "temporal/api/common/v1/message.proto";
 import "temporal/api/failure/v1/message.proto";
@@ -152,3 +153,32 @@ message NewWorkflowExecutionInfo {
     temporal.api.common.v1.Header header = 13;
 }
 
+message CallbackInfo {
+    // Trigger for when the workflow is closed.
+    message WorkflowClosed {}
+
+    message Trigger {
+        oneof variant {
+            WorkflowClosed workflow_closed = 1;
+        }
+    }
+
+    // Information on how this callback should be invoked (e.g. its URL and type).
+    temporal.api.common.v1.Callback callback = 1;
+    // Trigger for this callback.
+    Trigger trigger = 2;
+    // The time when the callback was registered.
+    google.protobuf.Timestamp registration_time = 3;
+
+    temporal.api.enums.v1.CallbackState state = 4;
+    // The number of attempts made to deliver the callback.
+    // This number represents a minimum bound since the attempt is incremented after the callback request completes.
+    int64 attempt = 5;
+
+    // The time when the last attempt completed.
+    google.protobuf.Timestamp last_attempt_complete_time = 6;
+    // The last attempt's failure, if any.
+    temporal.api.failure.v1.Failure last_attempt_failure = 7;
+    // The time when the next attempt is scheduled.
+    google.protobuf.Timestamp next_attempt_schedule_time = 8;
+}

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -173,7 +173,7 @@ message CallbackInfo {
     temporal.api.enums.v1.CallbackState state = 4;
     // The number of attempts made to deliver the callback.
     // This number represents a minimum bound since the attempt is incremented after the callback request completes.
-    int64 attempt = 5;
+    int32 attempt = 5;
 
     // The time when the last attempt completed.
     google.protobuf.Timestamp last_attempt_complete_time = 6;

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -188,7 +188,7 @@ message StartWorkflowExecutionRequest {
     // Callbacks to be called by the server when this workflow reaches a terminal state.
     // If the workflow continues-as-new, these callbacks will be carried over to the new execution.
     // Callback addresses must be whitelisted in the server's dynamic configuration.
-    repeated temporal.api.common.v1.Callback callbacks = 21;
+    repeated temporal.api.common.v1.Callback completion_callbacks = 21;
 }
 
 message StartWorkflowExecutionResponse {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -184,6 +184,11 @@ message StartWorkflowExecutionRequest {
     // If the workflow gets a signal before the delay, a workflow task will be dispatched and the rest
     // of the delay will be ignored.
     google.protobuf.Duration workflow_start_delay = 20;
+
+    // Callbacks to be called by the server when this workflow reaches a terminal state.
+    // If the workflow continues-as-new, these callbacks will be carried over to the new execution.
+    // Callback addresses must be whitelisted in the server's dynamic configuration.
+    repeated temporal.api.common.v1.Callback callbacks = 21;
 }
 
 message StartWorkflowExecutionResponse {
@@ -852,6 +857,7 @@ message DescribeWorkflowExecutionResponse {
     repeated temporal.api.workflow.v1.PendingActivityInfo pending_activities = 3;
     repeated temporal.api.workflow.v1.PendingChildExecutionInfo pending_children = 4;
     temporal.api.workflow.v1.PendingWorkflowTaskInfo pending_workflow_task = 5;
+    repeated temporal.api.workflow.v1.CallbackInfo callbacks = 6;
 }
 
 message DescribeTaskQueueRequest {


### PR DESCRIPTION
> NOTE: PR base branch is the `nexus` branch.

**What changed?**

Add protos relevant for Nexus callbacks and consider future support for a generic Temporal callback mechanism.

**Why?**

This is useful in so many ways and critical for backing asynchronous Nexus operations.

