### PR TITLE
Add namespace level capabilities

### DIFF
--- a/temporal/api/namespace/v1/message.proto
+++ b/temporal/api/namespace/v1/message.proto
@@ -50,8 +50,6 @@ message NamespaceInfo {
 
     // Namespace capability details. Should contain what features are enabled in a namespace.
     message Capabilities {
-        // Server to always set to true. If false the client should disregard Capabilities.
-        bool valid_capabilities = 1;
     }
 
     // Whether scheduled workflows are supported on this namespace. This is only needed

--- a/temporal/api/namespace/v1/message.proto
+++ b/temporal/api/namespace/v1/message.proto
@@ -45,6 +45,14 @@ message NamespaceInfo {
     // A key-value map for any customized purpose.
     map<string, string> data = 5;
     string id = 6;
+    // All capabilities the namespace supports.
+    Capabilities capabilities = 7;
+
+    // Namespace capability details. Should contain what features are enabled in a namespace.
+    message Capabilities {
+        // Server to always set to true. If false the client should disregard Capabilities.
+        bool valid_capabilities = 1;
+    }
 
     // Whether scheduled workflows are supported on this namespace. This is only needed
     // temporarily while the feature is experimental, so we can give it a high tag.

--- a/temporal/api/namespace/v1/message.proto
+++ b/temporal/api/namespace/v1/message.proto
@@ -50,6 +50,12 @@ message NamespaceInfo {
 
     // Namespace capability details. Should contain what features are enabled in a namespace.
     message Capabilities {
+        // True if the namespace supports eager workflow start.
+        bool eager_workflow_start = 1;
+        // True if the namespace supports sync update
+        bool sync_update = 2;
+        // True if the namespace supports async update
+        bool async_update = 3;
     }
 
     // Whether scheduled workflows are supported on this namespace. This is only needed


### PR DESCRIPTION
Add a message to `NamespaceInfo` to include namespace level capabilities. Different then the `capabilities` returned by `GetSystemInfoResponse` because those are scoped to a cluster where these are scoped to a namespace. I included the field in `NamespaceInfo` since that is exposed for all users already and is already been used for similar feature flags in a less general way. This is scoped to server configs, not to include cloud account level configs.

### Is this intended to work in OS and Cloud
Yes

### Who is intended to use this

Applications like UI (Not the SDKs internally)
