### PR TITLE
Add namespace_delete_delay option to DeleteNamespaceRequest

### DIFF
--- a/temporal/api/operatorservice/v1/request_response.proto
+++ b/temporal/api/operatorservice/v1/request_response.proto
@@ -75,6 +75,8 @@ message DeleteNamespaceRequest {
     // Only one of namespace or namespace_id must be specified to identify namespace.
     string namespace = 1;
     string namespace_id = 2;
+    // If provided, the deletion of namespace info will be delayed for given duration (0 means no delay).
+    // If not provided, use default delay configured in the cluster.
     google.protobuf.Duration namespace_delete_delay = 3;
 }
 

--- a/temporal/api/operatorservice/v1/request_response.proto
+++ b/temporal/api/operatorservice/v1/request_response.proto
@@ -32,6 +32,7 @@ option ruby_package = "Temporalio::Api::OperatorService::V1";
 option csharp_namespace = "Temporalio.Api.OperatorService.V1";
 
 import "temporal/api/enums/v1/common.proto";
+import "google/protobuf/duration.proto";
 
 // (-- Search Attribute --)
 
@@ -74,6 +75,7 @@ message DeleteNamespaceRequest {
     // Only one of namespace or namespace_id must be specified to identify namespace.
     string namespace = 1;
     string namespace_id = 2;
+    google.protobuf.Duration namespace_delete_delay = 3;
 }
 
 message DeleteNamespaceResponse {

--- a/temporal/api/operatorservice/v1/request_response.proto
+++ b/temporal/api/operatorservice/v1/request_response.proto
@@ -75,8 +75,8 @@ message DeleteNamespaceRequest {
     // Only one of namespace or namespace_id must be specified to identify namespace.
     string namespace = 1;
     string namespace_id = 2;
-    // If provided, the deletion of namespace info will be delayed for given duration (0 means no delay).
-    // If not provided, use default delay configured in the cluster.
+    // If provided, the deletion of namespace info will be delayed for the given duration (0 means no delay).
+    // If not provided, the default delay configured in the cluster will be used.
     google.protobuf.Duration namespace_delete_delay = 3;
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

<!-- Tell your future self why have you made these changes -->
**Why?**
So we can override DeleteNamespaceNamespaceDeleteDelay dynamic config setting for deleting namespace info. 

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**

