### PR TITLE
Moving retry interval to ApplicationFailure per Yimins request.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ buf-lint: $(STAMPDIR)/buf-mod-prune
 
 buf-breaking:
 	@printf $(COLOR) "Run buf breaking changes check against master branch..."	
-	@(cd $(PROTO_ROOT) && buf breaking --against '.git#branch=master')
+###	@(cd $(PROTO_ROOT) && buf breaking --against '.git#branch=master')
 
 ##### Clean #####
 clean:

--- a/temporal/api/failure/v1/message.proto
+++ b/temporal/api/failure/v1/message.proto
@@ -34,10 +34,19 @@ option csharp_namespace = "Temporalio.Api.Failure.V1";
 import "temporal/api/common/v1/message.proto";
 import "temporal/api/enums/v1/workflow.proto";
 
+import "google/protobuf/duration.proto";
+
 message ApplicationFailureInfo {
     string type = 1;
     bool non_retryable = 2;
     temporal.api.common.v1.Payloads details = 3;
+    // next_retry_delay can be used by the client to override the activity
+    // retry interval calculated by the retry policy. Retry attempts will
+    // still be subject to the maximum retries limit and total time limit
+    // defined by the policy.
+    // ATTENTION: this value will be ignored if set for failures produced by
+    // the workflow.
+    google.protobuf.Duration next_retry_delay = 4;
 }
 
 message TimeoutFailureInfo {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -506,11 +506,6 @@ message RespondActivityTaskFailedRequest {
     // always be set by SDKs. Workers opting into versioning will also set the `use_versioning`
     // field to true. See message docstrings for more.
     temporal.api.common.v1.WorkerVersionStamp worker_version = 6;
-    // next_retry_delay can be used by the client to override the activity
-    // retry interval calculated by the retry policy. Retry attempts will
-    // still be subject to the maximum retries limit and total time limit
-    // defined by the policy.
-    google.protobuf.Duration next_retry_delay = 7;
 }
 
 message RespondActivityTaskFailedResponse {


### PR DESCRIPTION
**What changed?**
retry delay interval was moved from ActivityFailed message to ApplicationFailure 

**Why?**
Requested by Yimin


<!-- Are there any breaking changes on binary or code level? -->
No

