### PR TITLE
Add create_time to rules list output

### DIFF
--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -228,7 +228,8 @@ message CompatibleBuildIdRedirectRule {
     oneof ramp {
         // This option is intended for rolling deployments. When this field is
         // provided, we redirect a fraction of tasks proportional to the ratio
-        // of the target Build ID's active workers over the .
+        // of the target Build ID's active workers over the source Build ID's
+        // active workers.
         RampByWorkerRatio worker_ratio_ramp = 3;
     }
 }

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -233,3 +233,13 @@ message CompatibleBuildIdRedirectRule {
         RampByWorkerRatio worker_ratio_ramp = 3;
     }
 }
+
+message TimestampedBuildIdAssignmentRule {
+    BuildIdAssignmentRule rule = 1;
+    google.protobuf.Timestamp create_time = 2;
+}
+
+message TimestampedCompatibleBuildIdRedirectRule {
+    CompatibleBuildIdRedirectRule rule = 1;
+    google.protobuf.Timestamp create_time = 2;
+}

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1280,13 +1280,23 @@ message ListWorkerVersioningRulesRequest {
 }
 
 message ListWorkerVersioningRulesResponse {
-    repeated temporal.api.taskqueue.v1.BuildIdAssignmentRule assignment_rules = 1;
-    repeated temporal.api.taskqueue.v1.CompatibleBuildIdRedirectRule compatible_redirect_rules = 2;
+    repeated TimestampedBuildIdAssignmentRule assignment_rules = 1;
+    repeated TimestampedCompatibleBuildIdRedirectRule compatible_redirect_rules = 2;
 
     // This value can be passed back to UpdateWorkerVersioningRulesRequest to
     // ensure that the rules were not modified between this List and the Update,
     // which could lead to lost updates and other confusion.
     bytes conflict_token = 3;
+}
+
+message TimestampedBuildIdAssignmentRule {
+    temporal.api.taskqueue.v1.BuildIdAssignmentRule rule = 1;
+    google.protobuf.Timestamp create_time = 2;
+}
+
+message TimestampedCompatibleBuildIdRedirectRule {
+    temporal.api.taskqueue.v1.CompatibleBuildIdRedirectRule rule = 1;
+    google.protobuf.Timestamp create_time = 2;
 }
 
 message GetWorkerTaskReachabilityRequest {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1280,23 +1280,13 @@ message ListWorkerVersioningRulesRequest {
 }
 
 message ListWorkerVersioningRulesResponse {
-    repeated TimestampedBuildIdAssignmentRule assignment_rules = 1;
-    repeated TimestampedCompatibleBuildIdRedirectRule compatible_redirect_rules = 2;
+    repeated temporal.api.taskqueue.v1.TimestampedBuildIdAssignmentRule assignment_rules = 1;
+    repeated temporal.api.taskqueue.v1.TimestampedCompatibleBuildIdRedirectRule compatible_redirect_rules = 2;
 
     // This value can be passed back to UpdateWorkerVersioningRulesRequest to
     // ensure that the rules were not modified between this List and the Update,
     // which could lead to lost updates and other confusion.
     bytes conflict_token = 3;
-}
-
-message TimestampedBuildIdAssignmentRule {
-    temporal.api.taskqueue.v1.BuildIdAssignmentRule rule = 1;
-    google.protobuf.Timestamp create_time = 2;
-}
-
-message TimestampedCompatibleBuildIdRedirectRule {
-    temporal.api.taskqueue.v1.CompatibleBuildIdRedirectRule rule = 1;
-    google.protobuf.Timestamp create_time = 2;
 }
 
 message GetWorkerTaskReachabilityRequest {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added create_time field for the rules returned by ListWorkerVersioningRules API.

<!-- Tell your future self why have you made these changes -->
**Why?**
Creation time can be very useful for users when they what to consider cleaning up the rules.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
no
