### PR TITLE
ResetReapplyExcludeType (preparation for Update reapply)

### DIFF
--- a/temporal/api/enums/v1/reset.proto
+++ b/temporal/api/enums/v1/reset.proto
@@ -31,19 +31,24 @@ option java_outer_classname = "ResetProto";
 option ruby_package = "Temporalio::Api::Enums::V1";
 option csharp_namespace = "Temporalio.Api.Enums.V1";
 
-// Operations to be reapplied when reapplying events.
-// The server will decide which events to reapply based on these values.
-enum ResetReapplyOperation {
-    RESET_REAPPLY_OPERATION_UNSPECIFIED = 0;
-    RESET_REAPPLY_OPERATION_SIGNAL = 1;
+// Event types to exclude when reapplying events.
+enum ResetReapplyExcludeType {
+    RESET_REAPPLY_EXCLUDE_TYPE_UNSPECIFIED = 0;
+    // Exclude signals when reapplying events.
+    RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL = 1;
 }
 
+// Event types to include when reapplying events. Deprecated: applications
+// should use ResetReapplyExcludeType to specify exclusions from this set, and
+// new event types should be added to ResetReapplyExcludeType instead of here.
 enum ResetReapplyType {
     RESET_REAPPLY_TYPE_UNSPECIFIED = 0;
     // Signals are reapplied when workflow is reset.
     RESET_REAPPLY_TYPE_SIGNAL = 1;
     // No events are reapplied when workflow is reset.
     RESET_REAPPLY_TYPE_NONE = 2;
+    // All eligible events are reapplied when workflow is reset.
+    RESET_REAPPLY_TYPE_ALL_ELIGIBLE = 3;
 }
 
 // Reset type options. Deprecated, see temporal.api.common.v1.ResetOptions.

--- a/temporal/api/enums/v1/reset.proto
+++ b/temporal/api/enums/v1/reset.proto
@@ -31,13 +31,24 @@ option java_outer_classname = "ResetProto";
 option ruby_package = "Temporalio::Api::Enums::V1";
 option csharp_namespace = "Temporalio.Api.Enums.V1";
 
-// Reset reapply (replay) options
-// * RESET_REAPPLY_TYPE_SIGNAL (default) - Signals are reapplied when workflow is reset
-// * RESET_REAPPLY_TYPE_NONE - nothing is reapplied
+// Event types to exclude when reapplying events.
+enum ResetReapplyExcludeType {
+    RESET_REAPPLY_EXCLUDE_TYPE_UNSPECIFIED = 0;
+    // Exclude signals when reapplying events.
+    RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL = 1;
+}
+
+// Event types to include when reapplying events. Deprecated: applications
+// should use ResetReapplyExcludeType to specify exclusions from this set, and
+// new event types should be added to ResetReapplyExcludeType instead of here.
 enum ResetReapplyType {
     RESET_REAPPLY_TYPE_UNSPECIFIED = 0;
+    // Signals are reapplied when workflow is reset.
     RESET_REAPPLY_TYPE_SIGNAL = 1;
+    // No events are reapplied when workflow is reset.
     RESET_REAPPLY_TYPE_NONE = 2;
+    // All eligible events are reapplied when workflow is reset.
+    RESET_REAPPLY_TYPE_ALL_ELIGIBLE = 3;
 }
 
 // Reset type options. Deprecated, see temporal.api.common.v1.ResetOptions.

--- a/temporal/api/enums/v1/reset.proto
+++ b/temporal/api/enums/v1/reset.proto
@@ -31,24 +31,19 @@ option java_outer_classname = "ResetProto";
 option ruby_package = "Temporalio::Api::Enums::V1";
 option csharp_namespace = "Temporalio.Api.Enums.V1";
 
-// Event types to exclude when reapplying events.
-enum ResetReapplyExcludeType {
-    RESET_REAPPLY_EXCLUDE_TYPE_UNSPECIFIED = 0;
-    // Exclude signals when reapplying events.
-    RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL = 1;
+// Operations to be reapplied when reapplying events.
+// The server will decide which events to reapply based on these values.
+enum ResetReapplyOperation {
+    RESET_REAPPLY_OPERATION_UNSPECIFIED = 0;
+    RESET_REAPPLY_OPERATION_SIGNAL = 1;
 }
 
-// Event types to include when reapplying events. Deprecated: applications
-// should use ResetReapplyExcludeType to specify exclusions from this set, and
-// new event types should be added to ResetReapplyExcludeType instead of here.
 enum ResetReapplyType {
     RESET_REAPPLY_TYPE_UNSPECIFIED = 0;
     // Signals are reapplied when workflow is reset.
     RESET_REAPPLY_TYPE_SIGNAL = 1;
     // No events are reapplied when workflow is reset.
     RESET_REAPPLY_TYPE_NONE = 2;
-    // All eligible events are reapplied when workflow is reset.
-    RESET_REAPPLY_TYPE_ALL_ELIGIBLE = 3;
 }
 
 // Reset type options. Deprecated, see temporal.api.common.v1.ResetOptions.

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -669,8 +669,10 @@ message ResetWorkflowExecutionRequest {
     int64 workflow_task_finish_event_id = 4;
     // Used to de-dupe reset requests
     string request_id = 5;
-    // Reset reapply (replay) options.
+    // Event types to be reapplied (deprecated)
     temporal.api.enums.v1.ResetReapplyType reset_reapply_type = 6;
+    // Event types not to be reapplied
+    repeated temporal.api.enums.v1.ResetReapplyExcludeType reset_reapply_exclude_types = 7;
 }
 
 message ResetWorkflowExecutionResponse {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -669,10 +669,11 @@ message ResetWorkflowExecutionRequest {
     int64 workflow_task_finish_event_id = 4;
     // Used to de-dupe reset requests
     string request_id = 5;
-    // Event type to be reapplied (deprecated; may not be sent together with reset_reapply_operations)
+    // Event types to be reapplied (deprecated)
+    // Default: RESET_REAPPLY_TYPE_ALL_ELIGIBLE
     temporal.api.enums.v1.ResetReapplyType reset_reapply_type = 6;
-    // Operations to be reapplied
-    repeated temporal.api.enums.v1.ResetReapplyOperation reset_reapply_operations = 7;
+    // Event types not to be reapplied
+    repeated temporal.api.enums.v1.ResetReapplyExcludeType reset_reapply_exclude_types = 7;
 }
 
 message ResetWorkflowExecutionResponse {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -669,10 +669,10 @@ message ResetWorkflowExecutionRequest {
     int64 workflow_task_finish_event_id = 4;
     // Used to de-dupe reset requests
     string request_id = 5;
-    // Event types to be reapplied (deprecated)
+    // Event type to be reapplied (deprecated; may not be sent together with reset_reapply_operations)
     temporal.api.enums.v1.ResetReapplyType reset_reapply_type = 6;
-    // Event types not to be reapplied
-    repeated temporal.api.enums.v1.ResetReapplyExcludeType reset_reapply_exclude_types = 7;
+    // Operations to be reapplied
+    repeated temporal.api.enums.v1.ResetReapplyOperation reset_reapply_operations = 7;
 }
 
 message ResetWorkflowExecutionResponse {


### PR DESCRIPTION
These are proposed proto changes in preparation for Update reapply, based on a design by @yycptt.

- Currently, the Reset request allows a user to send `RESET_REAPPLY_TYPE_SIGNAL` or `RESET_REAPPLY_TYPE_NONE`. The server defaults to `RESET_REAPPLY_TYPE_SIGNAL`.

- We are about to start reapplying Updates and, in the future, we may reapply other events such as Nexus-related events.

- We do not want to expand the `ResetReapplyType` enum to encode arbitrary subsets of event types to be reapplied.

- Instead, this PR adds to the Reset request the ability to send a list of event types to be _excluded_ from reapply.

- I have also added one final value to the legacy enum: `RESET_REAPPLY_TYPE_ALL_ELIGIBLE`. I propose to make this the new default for `ResetReapplyType`. In practice, today, that has the same consequences (i.e. "reapply signals"), just under a different name.

- Other than that final addition, `ResetReapplyType` now becomes deprecated.

Thus what I'm proposing is that, in the future, the server's implementation will be to:

1. Take the set of events to reapply implied by the value of `ResetReapplyType`
2. Remove from this set all `ResetReapplyExcludeType` events

The result is the set of event types that will be reapplied during Reset.