### PR TITLE
New event: update requested

### DIFF
--- a/temporal/api/enums/v1/event_type.proto
+++ b/temporal/api/enums/v1/event_type.proto
@@ -167,4 +167,10 @@ enum EventType {
     EVENT_TYPE_ACTIVITY_PROPERTIES_MODIFIED_EXTERNALLY = 45;
     // Workflow properties modified by user workflow code
     EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED = 46;
+    // An update request was reapplied to this branch of workflow history. Note
+    // that update requests are typically non-durable (i.e. do not have a
+    // corresponding event in history). This event type is created when an
+    // accepted update (on one branch of workflow history) is converted into a
+    // requested update (on a different branch).
+    EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_REQUEST_REAPPLIED = 47;
 }

--- a/temporal/api/enums/v1/event_type.proto
+++ b/temporal/api/enums/v1/event_type.proto
@@ -167,10 +167,8 @@ enum EventType {
     EVENT_TYPE_ACTIVITY_PROPERTIES_MODIFIED_EXTERNALLY = 45;
     // Workflow properties modified by user workflow code
     EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED = 46;
-    // An update request was reapplied to this branch of workflow history. Note
-    // that update requests are typically non-durable (i.e. do not have a
-    // corresponding event in history). This event type is created when an
-    // accepted update (on one branch of workflow history) is converted into a
-    // requested update (on a different branch).
-    EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_REQUEST_REAPPLIED = 47;
+    // An update was requested. Note that not all update requests result in this
+    // event. See UpdateRequestedEventOrigin for situations in which this event
+    // is created.
+    EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_REQUESTED = 47;
 }

--- a/temporal/api/enums/v1/reset.proto
+++ b/temporal/api/enums/v1/reset.proto
@@ -36,6 +36,8 @@ enum ResetReapplyExcludeType {
     RESET_REAPPLY_EXCLUDE_TYPE_UNSPECIFIED = 0;
     // Exclude signals when reapplying events.
     RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL = 1;
+    // Exclude updates when reapplying events.
+    RESET_REAPPLY_EXCLUDE_TYPE_UPDATE = 2;
 }
 
 // Event types to include when reapplying events. Deprecated: applications

--- a/temporal/api/enums/v1/update.proto
+++ b/temporal/api/enums/v1/update.proto
@@ -55,9 +55,8 @@ enum UpdateWorkflowExecutionLifecycleStage {
     UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED = 3;
 }
 
-// UpdateRequestedEventOrigin records why an
-// WorkflowExecutionUpdateRequestedEvent was written to history. Note that not
-// all update requests result in a WorkflowExecutionUpdateRequestedEvent.
+// Records why a WorkflowExecutionUpdateRequestedEvent was written to history.
+// Note that not all update requests result in this event.
 enum UpdateRequestedEventOrigin {
     UPDATE_REQUESTED_EVENT_ORIGIN_UNSPECIFIED = 0;
     // The UpdateRequested event was created when reapplying events during reset

--- a/temporal/api/enums/v1/update.proto
+++ b/temporal/api/enums/v1/update.proto
@@ -54,3 +54,14 @@ enum UpdateWorkflowExecutionLifecycleStage {
     // on a worker and has either been rejected or returned a value or an error.
     UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED = 3;
 }
+
+// UpdateRequestedEventOrigin records why an
+// WorkflowExecutionUpdateRequestedEvent was written to history. Note that not
+// all update requests result in a WorkflowExecutionUpdateRequestedEvent.
+enum UpdateRequestedEventOrigin {
+    UPDATE_REQUESTED_EVENT_ORIGIN_UNSPECIFIED = 0;
+    // The UpdateRequested event was created when reapplying events during reset
+    // or replication. I.e. an accepted update on one branch of workflow history
+    // was converted into a requested update on a different branch.
+    UPDATE_REQUESTED_EVENT_ORIGIN_REAPPLY = 1;
+}

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -36,6 +36,7 @@ import "google/protobuf/timestamp.proto";
 
 import "temporal/api/enums/v1/event_type.proto";
 import "temporal/api/enums/v1/failed_cause.proto";
+import "temporal/api/enums/v1/update.proto";
 import "temporal/api/enums/v1/workflow.proto";
 import "temporal/api/common/v1/message.proto";
 import "temporal/api/failure/v1/message.proto";
@@ -749,8 +750,11 @@ message WorkflowExecutionUpdateRejectedEventAttributes {
     temporal.api.failure.v1.Failure failure = 5;
 }
 
-message WorkflowExecutionUpdateRequestReappliedEventAttributes {
+message WorkflowExecutionUpdateRequestedEventAttributes {
+    // The update request associated with this event.
     temporal.api.update.v1.Request request = 1;
+    // An explanation of why this event was written to history.
+    temporal.api.enums.v1.UpdateRequestedEventOrigin origin = 2;
 }
 
 // History events are the method by which Temporal SDKs advance (or recreate) workflow state.
@@ -817,7 +821,7 @@ message HistoryEvent {
         WorkflowPropertiesModifiedExternallyEventAttributes workflow_properties_modified_externally_event_attributes = 49;
         ActivityPropertiesModifiedExternallyEventAttributes activity_properties_modified_externally_event_attributes = 50;
         WorkflowPropertiesModifiedEventAttributes workflow_properties_modified_event_attributes = 51;
-        WorkflowExecutionUpdateRequestReappliedEventAttributes workflow_execution_update_request_reapplied_event_attributes = 52;
+        WorkflowExecutionUpdateRequestedEventAttributes workflow_execution_update_requested_event_attributes = 52;
     }
 }
 

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -749,6 +749,9 @@ message WorkflowExecutionUpdateRejectedEventAttributes {
     temporal.api.failure.v1.Failure failure = 5;
 }
 
+message WorkflowExecutionUpdateRequestReappliedEventAttributes {
+    temporal.api.update.v1.Request request = 1;
+}
 
 // History events are the method by which Temporal SDKs advance (or recreate) workflow state.
 // See the `EventType` enum for more info about what each event is for.
@@ -814,6 +817,7 @@ message HistoryEvent {
         WorkflowPropertiesModifiedExternallyEventAttributes workflow_properties_modified_externally_event_attributes = 49;
         ActivityPropertiesModifiedExternallyEventAttributes activity_properties_modified_externally_event_attributes = 50;
         WorkflowPropertiesModifiedEventAttributes workflow_properties_modified_event_attributes = 51;
+        WorkflowExecutionUpdateRequestReappliedEventAttributes workflow_execution_update_request_reapplied_event_attributes = 52;
     }
 }
 


### PR DESCRIPTION
Add new event `EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_REQUESTED` for update reapply.

As explained in comments, this event will initially be restricted to updates reapplied during reset or replication. In the future we plan to use it for updates that are durable on admission.