### PR TITLE
Generate OperatorService API docs and remove operationId prefixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ go-grpc: clean $(PROTO_OUT)
 		-p openapi_out=$(OAPI_OUT) \
 		-p openapi_opt=enum_type=string \
 		-p openapiv2_out=openapi \
-        -p openapiv2_opt=allow_merge=true,merge_file_name=openapiv2
+        -p openapiv2_opt=allow_merge=true,merge_file_name=openapiv2,simple_operation_ids=true
 
 fix-path:
 	mv -f $(PROTO_OUT)/temporal/api/* $(PROTO_OUT) && rm -rf $(PROTO_OUT)/temporal

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,6 @@ fix-path:
 # We need to rewrite bits of this to support our shorthand payload format
 # We use both yq and jq here as they preserve comments and the ordering of the original
 # document
-
 http-api-docs:
 	protoc -I $(PROTO_ROOT) \
 		--openapi_out=$(OAPI_OUT) \
@@ -79,8 +78,8 @@ http-api-docs:
 	mv -f $(OAPI_OUT)/v2.tmp $(OAPI_OUT)/openapiv2.json
 	rm -f $(OAPI_OUT)/openapiv2.swagger.json
 	DESC=$$(cat $(OAPI_OUT)/payload_description.txt) yq e -i '$(OAPIV3_PATH).description = strenv(DESC) | del($(OAPI3_PATH).type) | del($(OAPI3_PATH).properties)' $(OAPI_OUT)/openapi.yaml
-# TODO: remove operationId prefixes from yaml
-	mv $(OAPI_OUT)/openapi.yaml $(OAPI_OUT)/openapiv3.yaml
+	yq e -i '(.paths[] | .[] | .operationId) |= sub("\w+_(.*)", "$$1")' $(OAPI_OUT)/openapi.yaml
+	mv -f $(OAPI_OUT)/openapi.yaml $(OAPI_OUT)/openapiv3.yaml
 
 ##### Plugins & tools #####
 grpc-install:

--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,7 @@ go-grpc: clean $(PROTO_OUT)
 		-I $(PROTO_ROOT) \
 		-p go-grpc_out=$(PROTO_PATHS) \
 		-p grpc-gateway_out=allow_patch_feature=false,$(PROTO_PATHS) \
-		-p doc_out=html,index.html,source_relative:$(PROTO_OUT) \
-		-p openapi_out=$(OAPI_OUT) \
-		-p openapi_opt=enum_type=string \
-		-p openapiv2_out=openapi \
-        -p openapiv2_opt=allow_merge=true,merge_file_name=openapiv2,simple_operation_ids=true
+		-p doc_out=html,index.html,source_relative:$(PROTO_OUT)
 
 fix-path:
 	mv -f $(PROTO_OUT)/temporal/api/* $(PROTO_OUT) && rm -rf $(PROTO_OUT)/temporal
@@ -69,11 +65,21 @@ fix-path:
 # We need to rewrite bits of this to support our shorthand payload format
 # We use both yq and jq here as they preserve comments and the ordering of the original
 # document
-http-api-docs: go-grpc
+
+http-api-docs:
+	protoc -I $(PROTO_ROOT) \
+		--openapi_out=$(OAPI_OUT) \
+		--openapi_opt=enum_type=string \
+		--openapiv2_out=openapi \
+        --openapiv2_opt=allow_merge=true,merge_file_name=openapiv2,simple_operation_ids=true \
+		temporal/api/workflowservice/v1/* \
+		temporal/api/operatorservice/v1/*
+
 	jq --rawfile desc $(OAPI_OUT)/payload_description.txt < $(OAPI_OUT)/openapiv2.swagger.json '.definitions.v1Payload={description: $$desc}' > $(OAPI_OUT)/v2.tmp
 	mv -f $(OAPI_OUT)/v2.tmp $(OAPI_OUT)/openapiv2.json
 	rm -f $(OAPI_OUT)/openapiv2.swagger.json
 	DESC=$$(cat $(OAPI_OUT)/payload_description.txt) yq e -i '$(OAPIV3_PATH).description = strenv(DESC) | del($(OAPI3_PATH).type) | del($(OAPI3_PATH).properties)' $(OAPI_OUT)/openapi.yaml
+# TODO: remove operationId prefixes from yaml
 	mv $(OAPI_OUT)/openapi.yaml $(OAPI_OUT)/openapiv3.yaml
 
 ##### Plugins & tools #####

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -7,6 +7,9 @@
   "tags": [
     {
       "name": "WorkflowService"
+    },
+    {
+      "name": "OperatorService"
     }
   ],
   "consumes": [
@@ -1025,6 +1028,37 @@
         ],
         "tags": [
           "WorkflowService"
+        ]
+      }
+    },
+    "/api/v1/namespaces/{namespace}/search-attributes": {
+      "get": {
+        "summary": "ListSearchAttributes returns comprehensive information about search attributes.",
+        "operationId": "ListSearchAttributes",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListSearchAttributesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "OperatorService"
         ]
       }
     },
@@ -3126,6 +3160,12 @@
       },
       "title": "Represents the identifier used by a activity author to define the activity. Typically, the\nname of a function. This is sometimes referred to as the activity's \"name\""
     },
+    "v1AddOrUpdateRemoteClusterResponse": {
+      "type": "object"
+    },
+    "v1AddSearchAttributesResponse": {
+      "type": "object"
+    },
     "v1Alert": {
       "type": "object",
       "properties": {
@@ -3709,6 +3749,37 @@
         }
       }
     },
+    "v1ClusterMetadata": {
+      "type": "object",
+      "properties": {
+        "clusterName": {
+          "type": "string",
+          "description": "Name of the cluster name."
+        },
+        "clusterId": {
+          "type": "string",
+          "description": "Id of the cluster."
+        },
+        "address": {
+          "type": "string",
+          "description": "Cluster accessible address."
+        },
+        "initialFailoverVersion": {
+          "type": "string",
+          "format": "int64",
+          "description": "A unique failover version across all connected clusters."
+        },
+        "historyShardCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "History service shard number."
+        },
+        "isConnectionEnabled": {
+          "type": "boolean",
+          "description": "A flag to indicate if a connection is active."
+        }
+      }
+    },
     "v1ClusterReplicationConfig": {
       "type": "object",
       "properties": {
@@ -3902,6 +3973,15 @@
         }
       }
     },
+    "v1CreateOrUpdateNexusIncomingServiceResponse": {
+      "type": "object",
+      "properties": {
+        "service": {
+          "$ref": "#/definitions/v1IncomingService",
+          "description": "Data post acceptance. Can be used to issue additional updates to this record."
+        }
+      }
+    },
     "v1CreateScheduleResponse": {
       "type": "object",
       "properties": {
@@ -3922,6 +4002,18 @@
           "format": "byte"
         }
       }
+    },
+    "v1DeleteNamespaceResponse": {
+      "type": "object",
+      "properties": {
+        "deletedNamespace": {
+          "type": "string",
+          "description": "Temporary namespace name that is used during reclaim resources step."
+        }
+      }
+    },
+    "v1DeleteNexusIncomingServiceResponse": {
+      "type": "object"
     },
     "v1DeleteScheduleResponse": {
       "type": "object"
@@ -4253,6 +4345,14 @@
         }
       },
       "description": "GetClusterInfoResponse contains information about Temporal cluster."
+    },
+    "v1GetNexusIncomingServiceResponse": {
+      "type": "object",
+      "properties": {
+        "service": {
+          "$ref": "#/definitions/v1IncomingService"
+        }
+      }
     },
     "v1GetSearchAttributesResponse": {
       "type": "object",
@@ -4605,6 +4705,36 @@
       ],
       "default": "HISTORY_EVENT_FILTER_TYPE_UNSPECIFIED"
     },
+    "v1IncomingService": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string",
+          "format": "int64",
+          "description": "Data version for this service. Must match current version on update or set to 0 to create a new service."
+        },
+        "name": {
+          "type": "string",
+          "description": "Service name, unique for this cluster.\nThe service name is used to address this service.\nBy default, when using Nexus over HTTP, the service name is matched against the base URL path.\nE.g. the URL /my-service would match a service named \"my-service\".\nThe name can contain any characters and is escaped when matched against a URL."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Namespace to route requests to."
+        },
+        "taskQueue": {
+          "type": "string",
+          "description": "Task queue to route requests to."
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/protobufAny"
+          },
+          "description": "Generic service metadata that is available to the server's authorizer."
+        }
+      },
+      "description": "A binding from a service name to namespace, task queue, and metadata for dispatching incoming Nexus requests."
+    },
     "v1IndexedValueType": {
       "type": "string",
       "enum": [
@@ -4697,6 +4827,23 @@
         }
       }
     },
+    "v1ListClustersResponse": {
+      "type": "object",
+      "properties": {
+        "clusters": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ClusterMetadata"
+          },
+          "title": "List of all cluster information"
+        },
+        "nextPageToken": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
     "v1ListNamespacesResponse": {
       "type": "object",
       "properties": {
@@ -4710,6 +4857,23 @@
         "nextPageToken": {
           "type": "string",
           "format": "byte"
+        }
+      }
+    },
+    "v1ListNexusIncomingServicesResponse": {
+      "type": "object",
+      "properties": {
+        "nextPageToken": {
+          "type": "string",
+          "format": "byte",
+          "description": "Token for getting the next page."
+        },
+        "services": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1IncomingService"
+          }
         }
       }
     },
@@ -4754,6 +4918,32 @@
         "nextPageToken": {
           "type": "string",
           "format": "byte"
+        }
+      }
+    },
+    "v1ListSearchAttributesResponse": {
+      "type": "object",
+      "properties": {
+        "customAttributes": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/v1IndexedValueType"
+          },
+          "description": "Mapping between custom (user-registered) search attribute name to its IndexedValueType."
+        },
+        "systemAttributes": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/v1IndexedValueType"
+          },
+          "description": "Mapping between system (predefined) search attribute name to its IndexedValueType."
+        },
+        "storageSchema": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Mapping from the attribute name to the visibility storage native type."
         }
       }
     },
@@ -5606,6 +5796,12 @@
         }
       },
       "description": "ReleaseInfo contains information about specific version of temporal."
+    },
+    "v1RemoveRemoteClusterResponse": {
+      "type": "object"
+    },
+    "v1RemoveSearchAttributesResponse": {
+      "type": "object"
     },
     "v1ReplicationState": {
       "type": "string",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -19,7 +19,7 @@
     "/api/v1/cluster-info": {
       "get": {
         "summary": "GetClusterInfo returns information about temporal cluster",
-        "operationId": "WorkflowService_GetClusterInfo",
+        "operationId": "GetClusterInfo",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -42,7 +42,7 @@
     "/api/v1/namespaces": {
       "get": {
         "summary": "ListNamespaces returns the information and configuration for all namespaces.",
-        "operationId": "WorkflowService_ListNamespaces",
+        "operationId": "ListNamespaces",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -87,7 +87,7 @@
       "post": {
         "summary": "RegisterNamespace creates a new namespace which can be used as a container for all resources.",
         "description": "A Namespace is a top level entity within Temporal, and is used as a container for resources\nlike workflow executions, task queues, etc. A Namespace acts as a sandbox and provides\nisolation for all resources within the namespace. All resources belongs to exactly one\nnamespace.",
-        "operationId": "WorkflowService_RegisterNamespace",
+        "operationId": "RegisterNamespace",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -120,7 +120,7 @@
     "/api/v1/namespaces/{namespace}": {
       "get": {
         "summary": "DescribeNamespace returns the information and configuration for a registered namespace.",
-        "operationId": "WorkflowService_DescribeNamespace",
+        "operationId": "DescribeNamespace",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -158,7 +158,7 @@
       "post": {
         "summary": "RespondActivityTaskFailed is called by workers when processing an activity task fails.",
         "description": "This results in a new `ACTIVITY_TASK_CANCELED` event being written to the workflow history\nand a new workflow task created for the workflow. Fails with `NotFound` if the task token is\nno longer valid due to activity timeout, already being completed, or never having existed.",
-        "operationId": "WorkflowService_RespondActivityTaskCanceled",
+        "operationId": "RespondActivityTaskCanceled",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -197,7 +197,7 @@
     "/api/v1/namespaces/{namespace}/activities/cancel-by-id": {
       "post": {
         "summary": "See `RecordActivityTaskCanceled`. This version allows clients to record failures by\nnamespace/workflow id/activity id instead of task token.",
-        "operationId": "WorkflowService_RespondActivityTaskCanceledById",
+        "operationId": "RespondActivityTaskCanceledById",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -238,7 +238,7 @@
       "post": {
         "summary": "RespondActivityTaskCompleted is called by workers when they successfully complete an activity\ntask.",
         "description": "This results in a new `ACTIVITY_TASK_COMPLETED` event being written to the workflow history\nand a new workflow task created for the workflow. Fails with `NotFound` if the task token is\nno longer valid due to activity timeout, already being completed, or never having existed.",
-        "operationId": "WorkflowService_RespondActivityTaskCompleted",
+        "operationId": "RespondActivityTaskCompleted",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -277,7 +277,7 @@
     "/api/v1/namespaces/{namespace}/activities/complete-by-id": {
       "post": {
         "summary": "See `RecordActivityTaskCompleted`. This version allows clients to record completions by\nnamespace/workflow id/activity id instead of task token.",
-        "operationId": "WorkflowService_RespondActivityTaskCompletedById",
+        "operationId": "RespondActivityTaskCompletedById",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -318,7 +318,7 @@
       "post": {
         "summary": "RespondActivityTaskFailed is called by workers when processing an activity task fails.",
         "description": "This results in a new `ACTIVITY_TASK_FAILED` event being written to the workflow history and\na new workflow task created for the workflow. Fails with `NotFound` if the task token is no\nlonger valid due to activity timeout, already being completed, or never having existed.",
-        "operationId": "WorkflowService_RespondActivityTaskFailed",
+        "operationId": "RespondActivityTaskFailed",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -357,7 +357,7 @@
     "/api/v1/namespaces/{namespace}/activities/fail-by-id": {
       "post": {
         "summary": "See `RecordActivityTaskFailed`. This version allows clients to record failures by\nnamespace/workflow id/activity id instead of task token.",
-        "operationId": "WorkflowService_RespondActivityTaskFailedById",
+        "operationId": "RespondActivityTaskFailedById",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -398,7 +398,7 @@
       "post": {
         "summary": "RecordActivityTaskHeartbeat is optionally called by workers while they execute activities.",
         "description": "If worker fails to heartbeat within the `heartbeat_timeout` interval for the activity task,\nthen it will be marked as timed out and an `ACTIVITY_TASK_TIMED_OUT` event will be written to\nthe workflow history. Calling `RecordActivityTaskHeartbeat` will fail with `NotFound` in\nsuch situations, in that event, the SDK should request cancellation of the activity.",
-        "operationId": "WorkflowService_RecordActivityTaskHeartbeat",
+        "operationId": "RecordActivityTaskHeartbeat",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -437,7 +437,7 @@
     "/api/v1/namespaces/{namespace}/activities/heartbeat-by-id": {
       "post": {
         "summary": "See `RecordActivityTaskHeartbeat`. This version allows clients to record heartbeats by\nnamespace/workflow id/activity id instead of task token.",
-        "operationId": "WorkflowService_RecordActivityTaskHeartbeatById",
+        "operationId": "RecordActivityTaskHeartbeatById",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -477,7 +477,7 @@
     "/api/v1/namespaces/{namespace}/archived-workflows": {
       "get": {
         "summary": "ListArchivedWorkflowExecutions is a visibility API to list archived workflow executions in a specific namespace.",
-        "operationId": "WorkflowService_ListArchivedWorkflowExecutions",
+        "operationId": "ListArchivedWorkflowExecutions",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -528,7 +528,7 @@
     "/api/v1/namespaces/{namespace}/batch-operations": {
       "get": {
         "summary": "ListBatchOperations returns a list of batch operations",
-        "operationId": "WorkflowService_ListBatchOperations",
+        "operationId": "ListBatchOperations",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -576,7 +576,7 @@
     "/api/v1/namespaces/{namespace}/batch-operations/{jobId}": {
       "get": {
         "summary": "DescribeBatchOperation returns the information about a batch operation",
-        "operationId": "WorkflowService_DescribeBatchOperation",
+        "operationId": "DescribeBatchOperation",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -613,7 +613,7 @@
       },
       "post": {
         "summary": "StartBatchOperation starts a new batch operation",
-        "operationId": "WorkflowService_StartBatchOperation",
+        "operationId": "StartBatchOperation",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -660,7 +660,7 @@
     "/api/v1/namespaces/{namespace}/batch-operations/{jobId}/stop": {
       "post": {
         "summary": "StopBatchOperation stops a batch operation",
-        "operationId": "WorkflowService_StopBatchOperation",
+        "operationId": "StopBatchOperation",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -707,7 +707,7 @@
     "/api/v1/namespaces/{namespace}/schedules": {
       "get": {
         "summary": "List all schedules in a namespace.",
-        "operationId": "WorkflowService_ListSchedules",
+        "operationId": "ListSchedules",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -755,7 +755,7 @@
     "/api/v1/namespaces/{namespace}/schedules/{scheduleId}": {
       "get": {
         "summary": "Returns the schedule description and current state of an existing schedule.",
-        "operationId": "WorkflowService_DescribeSchedule",
+        "operationId": "DescribeSchedule",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -792,7 +792,7 @@
       },
       "delete": {
         "summary": "Deletes a schedule, removing it from the system.",
-        "operationId": "WorkflowService_DeleteSchedule",
+        "operationId": "DeleteSchedule",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -836,7 +836,7 @@
       },
       "post": {
         "summary": "Creates a new schedule.",
-        "operationId": "WorkflowService_CreateSchedule",
+        "operationId": "CreateSchedule",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -883,7 +883,7 @@
     "/api/v1/namespaces/{namespace}/schedules/{scheduleId}/matching-times": {
       "get": {
         "summary": "Lists matching times within a range.",
-        "operationId": "WorkflowService_ListScheduleMatchingTimes",
+        "operationId": "ListScheduleMatchingTimes",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -937,7 +937,7 @@
     "/api/v1/namespaces/{namespace}/schedules/{scheduleId}/patch": {
       "post": {
         "summary": "Makes a specific change to a schedule or triggers an immediate action.",
-        "operationId": "WorkflowService_PatchSchedule",
+        "operationId": "PatchSchedule",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -984,7 +984,7 @@
     "/api/v1/namespaces/{namespace}/schedules/{scheduleId}/update": {
       "post": {
         "summary": "Changes the configuration or state of an existing schedule.",
-        "operationId": "WorkflowService_UpdateSchedule",
+        "operationId": "UpdateSchedule",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1031,7 +1031,7 @@
     "/api/v1/namespaces/{namespace}/task-queues/{taskQueue.name}": {
       "get": {
         "summary": "DescribeTaskQueue returns information about the target task queue.",
-        "operationId": "WorkflowService_DescribeTaskQueue",
+        "operationId": "DescribeTaskQueue",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1108,7 +1108,7 @@
     "/api/v1/namespaces/{namespace}/task-queues/{taskQueue}/worker-build-id-compatibility": {
       "get": {
         "summary": "Fetches the worker build id versioning sets for a task queue.",
-        "operationId": "WorkflowService_GetWorkerBuildIdCompatibility",
+        "operationId": "GetWorkerBuildIdCompatibility",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1154,7 +1154,7 @@
     "/api/v1/namespaces/{namespace}/update": {
       "post": {
         "summary": "UpdateNamespace is used to update the information and configuration of a registered\nnamespace.",
-        "operationId": "WorkflowService_UpdateNamespace",
+        "operationId": "UpdateNamespace",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1194,7 +1194,7 @@
       "get": {
         "summary": "Fetches task reachability to determine whether a worker may be retired.\nThe request may specify task queues to query for or let the server fetch all task queues mapped to the given\nbuild IDs.",
         "description": "When requesting a large number of task queues or all task queues associated with the given build ids in a\nnamespace, all task queues will be listed in the response but some of them may not contain reachability\ninformation due to a server enforced limit. When reaching the limit, task queues that reachability information\ncould not be retrieved for will be marked with a single TASK_REACHABILITY_UNSPECIFIED entry. The caller may issue\nanother call to get the reachability for those task queues.\n\nOpen source users can adjust this limit by setting the server's dynamic config value for\n`limit.reachabilityTaskQueueScan` with the caveat that this call can strain the visibility store.",
-        "operationId": "WorkflowService_GetWorkerTaskReachability",
+        "operationId": "GetWorkerTaskReachability",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1262,7 +1262,7 @@
     "/api/v1/namespaces/{namespace}/workflow-count": {
       "get": {
         "summary": "CountWorkflowExecutions is a visibility API to count of workflow executions in a specific namespace.",
-        "operationId": "WorkflowService_CountWorkflowExecutions",
+        "operationId": "CountWorkflowExecutions",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1299,7 +1299,7 @@
     "/api/v1/namespaces/{namespace}/workflows": {
       "get": {
         "summary": "ListWorkflowExecutions is a visibility API to list workflow executions in a specific namespace.",
-        "operationId": "WorkflowService_ListWorkflowExecutions",
+        "operationId": "ListWorkflowExecutions",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1350,7 +1350,7 @@
     "/api/v1/namespaces/{namespace}/workflows/{execution.workflowId}": {
       "get": {
         "summary": "DescribeWorkflowExecution returns information about the specified workflow execution.",
-        "operationId": "WorkflowService_DescribeWorkflowExecution",
+        "operationId": "DescribeWorkflowExecution",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1393,7 +1393,7 @@
     "/api/v1/namespaces/{namespace}/workflows/{execution.workflowId}/history": {
       "get": {
         "summary": "GetWorkflowExecutionHistory returns the history of specified workflow execution. Fails with\n`NotFound` if the specified workflow execution is unknown to the service.",
-        "operationId": "WorkflowService_GetWorkflowExecutionHistory",
+        "operationId": "GetWorkflowExecutionHistory",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1477,7 +1477,7 @@
     "/api/v1/namespaces/{namespace}/workflows/{execution.workflowId}/history-reverse": {
       "get": {
         "summary": "GetWorkflowExecutionHistoryReverse returns the history of specified workflow execution in reverse \norder (starting from last event). Fails with`NotFound` if the specified workflow execution is \nunknown to the service.",
-        "operationId": "WorkflowService_GetWorkflowExecutionHistoryReverse",
+        "operationId": "GetWorkflowExecutionHistoryReverse",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1534,7 +1534,7 @@
     "/api/v1/namespaces/{namespace}/workflows/{execution.workflowId}/query/{query.queryType}": {
       "post": {
         "summary": "QueryWorkflow requests a query be executed for a specified workflow execution.",
-        "operationId": "WorkflowService_QueryWorkflow",
+        "operationId": "QueryWorkflow",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1587,7 +1587,7 @@
       "post": {
         "summary": "RequestCancelWorkflowExecution is called by workers when they want to request cancellation of\na workflow execution.",
         "description": "This results in a new `WORKFLOW_EXECUTION_CANCEL_REQUESTED` event being written to the\nworkflow history and a new workflow task created for the workflow. It returns success if the requested\nworkflow is already closed. It fails with 'NotFound' if the requested workflow doesn't exist.",
-        "operationId": "WorkflowService_RequestCancelWorkflowExecution",
+        "operationId": "RequestCancelWorkflowExecution",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1632,7 +1632,7 @@
     "/api/v1/namespaces/{namespace}/workflows/{workflowExecution.workflowId}/reset": {
       "post": {
         "summary": "ResetWorkflowExecution will reset an existing workflow execution to a specified\n`WORKFLOW_TASK_COMPLETED` event (exclusive). It will immediately terminate the current\nexecution instance.\nTODO: Does exclusive here mean *just* the completed event, or also WFT started? Otherwise the task is doomed to time out?",
-        "operationId": "WorkflowService_ResetWorkflowExecution",
+        "operationId": "ResetWorkflowExecution",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1678,7 +1678,7 @@
       "post": {
         "summary": "SignalWorkflowExecution is used to send a signal to a running workflow execution.",
         "description": "This results in a `WORKFLOW_EXECUTION_SIGNALED` event recorded in the history and a workflow\ntask being created for the execution.",
-        "operationId": "WorkflowService_SignalWorkflowExecution",
+        "operationId": "SignalWorkflowExecution",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1730,7 +1730,7 @@
     "/api/v1/namespaces/{namespace}/workflows/{workflowExecution.workflowId}/terminate": {
       "post": {
         "summary": "TerminateWorkflowExecution terminates an existing workflow execution by recording a\n`WORKFLOW_EXECUTION_TERMINATED` event in the history and immediately terminating the\nexecution instance.",
-        "operationId": "WorkflowService_TerminateWorkflowExecution",
+        "operationId": "TerminateWorkflowExecution",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1775,7 +1775,7 @@
     "/api/v1/namespaces/{namespace}/workflows/{workflowExecution.workflowId}/update/{request.input.name}": {
       "post": {
         "summary": "Invokes the specified update function on user workflow code.",
-        "operationId": "WorkflowService_UpdateWorkflowExecution",
+        "operationId": "UpdateWorkflowExecution",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1829,7 +1829,7 @@
       "post": {
         "summary": "StartWorkflowExecution starts a new workflow execution.",
         "description": "It will create the execution with a `WORKFLOW_EXECUTION_STARTED` event in its history and\nalso schedule the first workflow task. Returns `WorkflowExecutionAlreadyStarted`, if an\ninstance already exists with same workflow id.",
-        "operationId": "WorkflowService_StartWorkflowExecution",
+        "operationId": "StartWorkflowExecution",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1875,7 +1875,7 @@
       "post": {
         "summary": "SignalWithStartWorkflowExecution is used to ensure a signal is sent to a workflow, even if\nit isn't yet started.",
         "description": "If the workflow is running, a `WORKFLOW_EXECUTION_SIGNALED` event is recorded in the history\nand a workflow task is generated.\n\nIf the workflow is not running or not found, then the workflow is created with\n`WORKFLOW_EXECUTION_STARTED` and `WORKFLOW_EXECUTION_SIGNALED` events in its history, and a\nworkflow task is generated.",
-        "operationId": "WorkflowService_SignalWithStartWorkflowExecution",
+        "operationId": "SignalWithStartWorkflowExecution",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1927,7 +1927,7 @@
     "/api/v1/system-info": {
       "get": {
         "summary": "GetSystemInfo returns information about the system.",
-        "operationId": "WorkflowService_GetSystemInfo",
+        "operationId": "GetSystemInfo",
         "responses": {
           "200": {
             "description": "A successful response.",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -11,7 +11,7 @@ paths:
       tags:
         - WorkflowService
       description: GetClusterInfo returns information about temporal cluster
-      operationId: WorkflowService_GetClusterInfo
+      operationId: GetClusterInfo
       responses:
         "200":
           description: OK
@@ -30,7 +30,7 @@ paths:
       tags:
         - WorkflowService
       description: ListNamespaces returns the information and configuration for all namespaces.
-      operationId: WorkflowService_ListNamespaces
+      operationId: ListNamespaces
       parameters:
         - name: pageSize
           in: query
@@ -73,7 +73,7 @@ paths:
          like workflow executions, task queues, etc. A Namespace acts as a sandbox and provides
          isolation for all resources within the namespace. All resources belongs to exactly one
          namespace.
-      operationId: WorkflowService_RegisterNamespace
+      operationId: RegisterNamespace
       requestBody:
         content:
           application/json:
@@ -98,7 +98,7 @@ paths:
       tags:
         - WorkflowService
       description: DescribeNamespace returns the information and configuration for a registered namespace.
-      operationId: WorkflowService_DescribeNamespace
+      operationId: DescribeNamespace
       parameters:
         - name: namespace
           in: path
@@ -132,7 +132,7 @@ paths:
          This results in a new `ACTIVITY_TASK_CANCELED` event being written to the workflow history
          and a new workflow task created for the workflow. Fails with `NotFound` if the task token is
          no longer valid due to activity timeout, already being completed, or never having existed.
-      operationId: WorkflowService_RespondActivityTaskCanceled
+      operationId: RespondActivityTaskCanceled
       parameters:
         - name: namespace
           in: path
@@ -168,7 +168,7 @@ paths:
 
          (-- api-linter: core::0136::prepositions=disabled
              aip.dev/not-precedent: "By" is used to indicate request type. --)
-      operationId: WorkflowService_RespondActivityTaskCanceledById
+      operationId: RespondActivityTaskCanceledById
       parameters:
         - name: namespace
           in: path
@@ -206,7 +206,7 @@ paths:
          This results in a new `ACTIVITY_TASK_COMPLETED` event being written to the workflow history
          and a new workflow task created for the workflow. Fails with `NotFound` if the task token is
          no longer valid due to activity timeout, already being completed, or never having existed.
-      operationId: WorkflowService_RespondActivityTaskCompleted
+      operationId: RespondActivityTaskCompleted
       parameters:
         - name: namespace
           in: path
@@ -242,7 +242,7 @@ paths:
 
          (-- api-linter: core::0136::prepositions=disabled
              aip.dev/not-precedent: "By" is used to indicate request type. --)
-      operationId: WorkflowService_RespondActivityTaskCompletedById
+      operationId: RespondActivityTaskCompletedById
       parameters:
         - name: namespace
           in: path
@@ -279,7 +279,7 @@ paths:
          This results in a new `ACTIVITY_TASK_FAILED` event being written to the workflow history and
          a new workflow task created for the workflow. Fails with `NotFound` if the task token is no
          longer valid due to activity timeout, already being completed, or never having existed.
-      operationId: WorkflowService_RespondActivityTaskFailed
+      operationId: RespondActivityTaskFailed
       parameters:
         - name: namespace
           in: path
@@ -315,7 +315,7 @@ paths:
 
          (-- api-linter: core::0136::prepositions=disabled
              aip.dev/not-precedent: "By" is used to indicate request type. --)
-      operationId: WorkflowService_RespondActivityTaskFailedById
+      operationId: RespondActivityTaskFailedById
       parameters:
         - name: namespace
           in: path
@@ -353,7 +353,7 @@ paths:
          then it will be marked as timed out and an `ACTIVITY_TASK_TIMED_OUT` event will be written to
          the workflow history. Calling `RecordActivityTaskHeartbeat` will fail with `NotFound` in
          such situations, in that event, the SDK should request cancellation of the activity.
-      operationId: WorkflowService_RecordActivityTaskHeartbeat
+      operationId: RecordActivityTaskHeartbeat
       parameters:
         - name: namespace
           in: path
@@ -389,7 +389,7 @@ paths:
 
          (-- api-linter: core::0136::prepositions=disabled
              aip.dev/not-precedent: "By" is used to indicate request type. --)
-      operationId: WorkflowService_RecordActivityTaskHeartbeatById
+      operationId: RecordActivityTaskHeartbeatById
       parameters:
         - name: namespace
           in: path
@@ -421,7 +421,7 @@ paths:
       tags:
         - WorkflowService
       description: ListArchivedWorkflowExecutions is a visibility API to list archived workflow executions in a specific namespace.
-      operationId: WorkflowService_ListArchivedWorkflowExecutions
+      operationId: ListArchivedWorkflowExecutions
       parameters:
         - name: namespace
           in: path
@@ -460,7 +460,7 @@ paths:
       tags:
         - WorkflowService
       description: ListBatchOperations returns a list of batch operations
-      operationId: WorkflowService_ListBatchOperations
+      operationId: ListBatchOperations
       parameters:
         - name: namespace
           in: path
@@ -498,7 +498,7 @@ paths:
       tags:
         - WorkflowService
       description: DescribeBatchOperation returns the information about a batch operation
-      operationId: WorkflowService_DescribeBatchOperation
+      operationId: DescribeBatchOperation
       parameters:
         - name: namespace
           in: path
@@ -529,7 +529,7 @@ paths:
       tags:
         - WorkflowService
       description: StartBatchOperation starts a new batch operation
-      operationId: WorkflowService_StartBatchOperation
+      operationId: StartBatchOperation
       parameters:
         - name: namespace
           in: path
@@ -567,7 +567,7 @@ paths:
       tags:
         - WorkflowService
       description: StopBatchOperation stops a batch operation
-      operationId: WorkflowService_StopBatchOperation
+      operationId: StopBatchOperation
       parameters:
         - name: namespace
           in: path
@@ -605,7 +605,7 @@ paths:
       tags:
         - WorkflowService
       description: List all schedules in a namespace.
-      operationId: WorkflowService_ListSchedules
+      operationId: ListSchedules
       parameters:
         - name: namespace
           in: path
@@ -643,7 +643,7 @@ paths:
       tags:
         - WorkflowService
       description: Returns the schedule description and current state of an existing schedule.
-      operationId: WorkflowService_DescribeSchedule
+      operationId: DescribeSchedule
       parameters:
         - name: namespace
           in: path
@@ -674,7 +674,7 @@ paths:
       tags:
         - WorkflowService
       description: Creates a new schedule.
-      operationId: WorkflowService_CreateSchedule
+      operationId: CreateSchedule
       parameters:
         - name: namespace
           in: path
@@ -711,7 +711,7 @@ paths:
       tags:
         - WorkflowService
       description: Deletes a schedule, removing it from the system.
-      operationId: WorkflowService_DeleteSchedule
+      operationId: DeleteSchedule
       parameters:
         - name: namespace
           in: path
@@ -748,7 +748,7 @@ paths:
       tags:
         - WorkflowService
       description: Lists matching times within a range.
-      operationId: WorkflowService_ListScheduleMatchingTimes
+      operationId: ListScheduleMatchingTimes
       parameters:
         - name: namespace
           in: path
@@ -791,7 +791,7 @@ paths:
       tags:
         - WorkflowService
       description: Makes a specific change to a schedule or triggers an immediate action.
-      operationId: WorkflowService_PatchSchedule
+      operationId: PatchSchedule
       parameters:
         - name: namespace
           in: path
@@ -829,7 +829,7 @@ paths:
       tags:
         - WorkflowService
       description: Changes the configuration or state of an existing schedule.
-      operationId: WorkflowService_UpdateSchedule
+      operationId: UpdateSchedule
       parameters:
         - name: namespace
           in: path
@@ -867,7 +867,7 @@ paths:
       tags:
         - OperatorService
       description: ListSearchAttributes returns comprehensive information about search attributes.
-      operationId: OperatorService_ListSearchAttributes
+      operationId: ListSearchAttributes
       parameters:
         - name: namespace
           in: path
@@ -892,7 +892,7 @@ paths:
       tags:
         - WorkflowService
       description: Fetches the worker build id versioning sets for a task queue.
-      operationId: WorkflowService_GetWorkerBuildIdCompatibility
+      operationId: GetWorkerBuildIdCompatibility
       parameters:
         - name: namespace
           in: path
@@ -931,7 +931,7 @@ paths:
       tags:
         - WorkflowService
       description: DescribeTaskQueue returns information about the target task queue.
-      operationId: WorkflowService_DescribeTaskQueue
+      operationId: DescribeTaskQueue
       parameters:
         - name: namespace
           in: path
@@ -999,7 +999,7 @@ paths:
       description: |-
         UpdateNamespace is used to update the information and configuration of a registered
          namespace.
-      operationId: WorkflowService_UpdateNamespace
+      operationId: UpdateNamespace
       parameters:
         - name: namespace
           in: path
@@ -1042,7 +1042,7 @@ paths:
 
          Open source users can adjust this limit by setting the server's dynamic config value for
          `limit.reachabilityTaskQueueScan` with the caveat that this call can strain the visibility store.
-      operationId: WorkflowService_GetWorkerTaskReachability
+      operationId: GetWorkerTaskReachability
       parameters:
         - name: namespace
           in: path
@@ -1108,7 +1108,7 @@ paths:
       tags:
         - WorkflowService
       description: CountWorkflowExecutions is a visibility API to count of workflow executions in a specific namespace.
-      operationId: WorkflowService_CountWorkflowExecutions
+      operationId: CountWorkflowExecutions
       parameters:
         - name: namespace
           in: path
@@ -1137,7 +1137,7 @@ paths:
       tags:
         - WorkflowService
       description: ListWorkflowExecutions is a visibility API to list workflow executions in a specific namespace.
-      operationId: WorkflowService_ListWorkflowExecutions
+      operationId: ListWorkflowExecutions
       parameters:
         - name: namespace
           in: path
@@ -1176,7 +1176,7 @@ paths:
       tags:
         - WorkflowService
       description: DescribeWorkflowExecution returns information about the specified workflow execution.
-      operationId: WorkflowService_DescribeWorkflowExecution
+      operationId: DescribeWorkflowExecution
       parameters:
         - name: namespace
           in: path
@@ -1216,7 +1216,7 @@ paths:
       description: |-
         GetWorkflowExecutionHistory returns the history of specified workflow execution. Fails with
          `NotFound` if the specified workflow execution is unknown to the service.
-      operationId: WorkflowService_GetWorkflowExecutionHistory
+      operationId: GetWorkflowExecutionHistory
       parameters:
         - name: namespace
           in: path
@@ -1290,7 +1290,7 @@ paths:
       tags:
         - WorkflowService
       description: "GetWorkflowExecutionHistoryReverse returns the history of specified workflow execution in reverse \n order (starting from last event). Fails with`NotFound` if the specified workflow execution is \n unknown to the service."
-      operationId: WorkflowService_GetWorkflowExecutionHistoryReverse
+      operationId: GetWorkflowExecutionHistoryReverse
       parameters:
         - name: namespace
           in: path
@@ -1338,7 +1338,7 @@ paths:
       tags:
         - WorkflowService
       description: QueryWorkflow requests a query be executed for a specified workflow execution.
-      operationId: WorkflowService_QueryWorkflow
+      operationId: QueryWorkflow
       parameters:
         - name: namespace
           in: path
@@ -1384,7 +1384,7 @@ paths:
          It will create the execution with a `WORKFLOW_EXECUTION_STARTED` event in its history and
          also schedule the first workflow task. Returns `WorkflowExecutionAlreadyStarted`, if an
          instance already exists with same workflow id.
-      operationId: WorkflowService_StartWorkflowExecution
+      operationId: StartWorkflowExecution
       parameters:
         - name: namespace
           in: path
@@ -1432,7 +1432,7 @@ paths:
 
          (-- api-linter: core::0136::prepositions=disabled
              aip.dev/not-precedent: "With" is used to indicate combined operation. --)
-      operationId: WorkflowService_SignalWithStartWorkflowExecution
+      operationId: SignalWithStartWorkflowExecution
       parameters:
         - name: namespace
           in: path
@@ -1480,7 +1480,7 @@ paths:
          This results in a new `WORKFLOW_EXECUTION_CANCEL_REQUESTED` event being written to the
          workflow history and a new workflow task created for the workflow. It returns success if the requested
          workflow is already closed. It fails with 'NotFound' if the requested workflow doesn't exist.
-      operationId: WorkflowService_RequestCancelWorkflowExecution
+      operationId: RequestCancelWorkflowExecution
       parameters:
         - name: namespace
           in: path
@@ -1520,7 +1520,7 @@ paths:
          `WORKFLOW_TASK_COMPLETED` event (exclusive). It will immediately terminate the current
          execution instance.
          TODO: Does exclusive here mean *just* the completed event, or also WFT started? Otherwise the task is doomed to time out?
-      operationId: WorkflowService_ResetWorkflowExecution
+      operationId: ResetWorkflowExecution
       parameters:
         - name: namespace
           in: path
@@ -1560,7 +1560,7 @@ paths:
 
          This results in a `WORKFLOW_EXECUTION_SIGNALED` event recorded in the history and a workflow
          task being created for the execution.
-      operationId: WorkflowService_SignalWorkflowExecution
+      operationId: SignalWorkflowExecution
       parameters:
         - name: namespace
           in: path
@@ -1605,7 +1605,7 @@ paths:
         TerminateWorkflowExecution terminates an existing workflow execution by recording a
          `WORKFLOW_EXECUTION_TERMINATED` event in the history and immediately terminating the
          execution instance.
-      operationId: WorkflowService_TerminateWorkflowExecution
+      operationId: TerminateWorkflowExecution
       parameters:
         - name: namespace
           in: path
@@ -1641,7 +1641,7 @@ paths:
       tags:
         - WorkflowService
       description: Invokes the specified update function on user workflow code.
-      operationId: WorkflowService_UpdateWorkflowExecution
+      operationId: UpdateWorkflowExecution
       parameters:
         - name: namespace
           in: path
@@ -1683,7 +1683,7 @@ paths:
       tags:
         - WorkflowService
       description: GetSystemInfo returns information about the system.
-      operationId: WorkflowService_GetSystemInfo
+      operationId: GetSystemInfo
       responses:
         "200":
           description: OK

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -3,19 +3,7 @@
 
 openapi: 3.0.3
 info:
-  title: WorkflowService API
-  description: |-
-    WorkflowService API defines how Temporal SDKs and other clients interact with the Temporal server
-     to create and interact with workflows and activities.
-
-     Users are expected to call `StartWorkflowExecution` to create a new workflow execution.
-
-     To drive workflows, a worker using a Temporal SDK must exist which regularly polls for workflow
-     and activity tasks from the service. For each workflow task, the sdk must process the
-     (incremental or complete) event history and respond back with any newly generated commands.
-
-     For each activity task, the worker is expected to execute the user's code which implements that
-     activity, responding with completion or failure.
+  title: ""
   version: 0.0.1
 paths:
   /api/v1/cluster-info:
@@ -868,6 +856,31 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/UpdateScheduleResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/search-attributes:
+    get:
+      tags:
+        - OperatorService
+      description: ListSearchAttributes returns comprehensive information about search attributes.
+      operationId: OperatorService_ListSearchAttributes
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListSearchAttributesResponse'
         default:
           description: Default error response
           content:
@@ -3155,6 +3168,44 @@ components:
         nextPageToken:
           type: string
           format: bytes
+    ListSearchAttributesResponse:
+      type: object
+      properties:
+        customAttributes:
+          type: object
+          additionalProperties:
+            enum:
+              - INDEXED_VALUE_TYPE_UNSPECIFIED
+              - INDEXED_VALUE_TYPE_TEXT
+              - INDEXED_VALUE_TYPE_KEYWORD
+              - INDEXED_VALUE_TYPE_INT
+              - INDEXED_VALUE_TYPE_DOUBLE
+              - INDEXED_VALUE_TYPE_BOOL
+              - INDEXED_VALUE_TYPE_DATETIME
+              - INDEXED_VALUE_TYPE_KEYWORD_LIST
+            type: string
+            format: enum
+          description: Mapping between custom (user-registered) search attribute name to its IndexedValueType.
+        systemAttributes:
+          type: object
+          additionalProperties:
+            enum:
+              - INDEXED_VALUE_TYPE_UNSPECIFIED
+              - INDEXED_VALUE_TYPE_TEXT
+              - INDEXED_VALUE_TYPE_KEYWORD
+              - INDEXED_VALUE_TYPE_INT
+              - INDEXED_VALUE_TYPE_DOUBLE
+              - INDEXED_VALUE_TYPE_BOOL
+              - INDEXED_VALUE_TYPE_DATETIME
+              - INDEXED_VALUE_TYPE_KEYWORD_LIST
+            type: string
+            format: enum
+          description: Mapping between system (predefined) search attribute name to its IndexedValueType.
+        storageSchema:
+          type: object
+          additionalProperties:
+            type: string
+          description: Mapping from the attribute name to the visibility storage native type.
     ListWorkflowExecutionsResponse:
       type: object
       properties:
@@ -6207,7 +6258,25 @@ components:
         Represents the identifier used by a workflow author to define the workflow. Typically, the
          name of a function. This is sometimes referred to as the workflow's "name"
 tags:
+  - name: OperatorService
+    description: |-
+      OperatorService API defines how Temporal SDKs and other clients interact with the Temporal server
+       to perform administrative functions like registering a search attribute or a namespace.
+       APIs in this file could be not compatible with Temporal Cloud, hence it's usage in SDKs should be limited by
+       designated APIs that clearly state that they shouldn't be used by the main Application (Workflows & Activities) framework.
   - name: WorkflowService
+    description: |-
+      WorkflowService API defines how Temporal SDKs and other clients interact with the Temporal server
+       to create and interact with workflows and activities.
+
+       Users are expected to call `StartWorkflowExecution` to create a new workflow execution.
+
+       To drive workflows, a worker using a Temporal SDK must exist which regularly polls for workflow
+       and activity tasks from the service. For each workflow task, the sdk must process the
+       (incremental or complete) event history and respond back with any newly generated commands.
+
+       For each activity task, the worker is expected to execute the user's code which implements that
+       activity, responding with completion or failure.
 description: |-
   Arbitrary payload data in an unconstrained format.
   This may be activity input parameters, a workflow result, a memo, etc.


### PR DESCRIPTION
**What changed?**

We didn't generate the necessary docs for the OperatorService because our needs differ from how `protogen` works, so we now resort to calling `protoc` manually just to generate HTTP docs.

We also no longer prefix operations with their service's name.

**Why?**

We discussed it and decided we didn't want those cluttering up our api docs (cc @lorensr)

**Breaking changes**

Nope!