### PR TITLE
Adding support for as-is for scheduled workflow id

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -6247,6 +6247,10 @@
         "pauseOnFailure": {
           "type": "boolean",
           "description": "If true, and a workflow run fails or times out, turn on \"paused\".\nThis applies after retry policies: the full chain of retries must fail to\ntrigger a pause here."
+        },
+        "keepOriginalWorkflowId": {
+          "type": "boolean",
+          "description": "If true, and the action would start a workflow, a timestamp will not be\nappended to the scheduled workflow id."
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -4397,6 +4397,11 @@ components:
             If true, and a workflow run fails or times out, turn on "paused".
              This applies after retry policies: the full chain of retries must fail to
              trigger a pause here.
+        keepOriginalWorkflowId:
+          type: boolean
+          description: |-
+            If true, and the action would start a workflow, a timestamp will not be
+             appended to the scheduled workflow id.
     ScheduleSpec:
       type: object
       properties:

--- a/temporal/api/schedule/v1/message.proto
+++ b/temporal/api/schedule/v1/message.proto
@@ -243,6 +243,10 @@ message SchedulePolicies {
     // This applies after retry policies: the full chain of retries must fail to
     // trigger a pause here.
     bool pause_on_failure = 3;
+
+    // If true, and the action would start a workflow, a timestamp will not be
+    // appended to the scheduled workflow id.
+    bool keep_original_workflow_id = 4;
 }
 
 message ScheduleAction {
@@ -254,8 +258,6 @@ message ScheduleAction {
         // it may have a timestamp appended for uniqueness.
         temporal.api.workflow.v1.NewWorkflowExecutionInfo start_workflow = 1;
     }
-    // If true, schedule will not append timestamp to the scheduled workflow id.
-    bool keep_original_workflow_id = 2;
 }
 
 message ScheduleActionResult {

--- a/temporal/api/schedule/v1/message.proto
+++ b/temporal/api/schedule/v1/message.proto
@@ -254,6 +254,8 @@ message ScheduleAction {
         // it may have a timestamp appended for uniqueness.
         temporal.api.workflow.v1.NewWorkflowExecutionInfo start_workflow = 1;
     }
+    // If true, schedule will not append timestamp to the scheduled workflow id.
+    bool keep_original_workflow_id = 2;
 }
 
 message ScheduleActionResult {


### PR DESCRIPTION
**What changed?**
Added support for as-is for scheduled workflow ID.

**Why?**
Users asked for the ability to run scheduled workflow without adding a timestamp to the scheduled workflow ID.


**Breaking changes**
No
