### PR TITLE
Clean up versioning protos with the narrowed scope

### DIFF
--- a/temporal/api/command/v1/message.proto
+++ b/temporal/api/command/v1/message.proto
@@ -81,11 +81,8 @@ message ScheduleActivityTaskCommandAttributes {
     // Request to start the activity directly bypassing matching service and worker polling
     // The slot for executing the activity should be reserved when setting this field to true.
     bool request_eager_execution = 12;
-    // Only applicable for activities executing on a Task Queue different from their workflow's.
     // If this is set, the activity would be assigned to the Build ID of the workflow. Otherwise,
     // Assignment rules of the activity's Task Queue will be used to determine the Build ID.
-    // Activities that run on their workflow's Task Queue always use workflow's Build ID.
-    // All activities are subject to redirect rules of their Task Queue.
     bool use_workflow_build_id = 13;
 }
 

--- a/temporal/api/command/v1/message.proto
+++ b/temporal/api/command/v1/message.proto
@@ -81,10 +81,12 @@ message ScheduleActivityTaskCommandAttributes {
     // Request to start the activity directly bypassing matching service and worker polling
     // The slot for executing the activity should be reserved when setting this field to true.
     bool request_eager_execution = 12;
-    // If this is set, the workflow executing this command wishes to start the activity using
-    // a version compatible with the version that this workflow most recently ran on, if such
-    // behavior is possible.
-    bool use_compatible_version = 13;
+    // Only applicable for activities executing on a Task Queue different from their workflow's.
+    // If this is set, the activity would be assigned to the Build ID of the workflow. Otherwise,
+    // Assignment rules of the activity's Task Queue will be used to determine the Build ID.
+    // Activities that run on their workflow's Task Queue always use workflow's Build ID.
+    // All activities are subject to redirect rules of their Task Queue.
+    bool use_workflow_build_id = 13;
 }
 
 message RequestCancelActivityTaskCommandAttributes {
@@ -193,9 +195,9 @@ message ContinueAsNewWorkflowExecutionCommandAttributes {
     temporal.api.common.v1.Header header = 12;
     temporal.api.common.v1.Memo memo = 13;
     temporal.api.common.v1.SearchAttributes search_attributes = 14;
-    // If this is set, the workflow executing this command wishes to continue as new using a version
-    // compatible with the version that this workflow most recently ran on.
-    bool use_compatible_version = 15;
+    // If this is set, the new execution inherits the Build ID of the current execution. Otherwise,
+    // the assignment rules will be used to independently assign a Build ID to the new execution.
+    bool inherit_build_id = 15;
 
     // `workflow_execution_timeout` is omitted as it shouldn't be overridden from within a workflow.
 }
@@ -223,10 +225,9 @@ message StartChildWorkflowExecutionCommandAttributes {
     temporal.api.common.v1.Header header = 14;
     temporal.api.common.v1.Memo memo = 15;
     temporal.api.common.v1.SearchAttributes search_attributes = 16;
-    // If this is set, the workflow executing this command wishes to start the child workflow using
-    // a version compatible with the version that this workflow most recently ran on, if such
-    // behavior is possible.
-    bool use_compatible_version = 17;
+    // If this is set, the child workflow inherits the Build ID of the parent. Otherwise, the assignment
+    // rules of the child's Task Queue will be used to independently assign a Build ID to it.
+    bool inherit_build_id = 17;
 }
 
 message ProtocolMessageCommandAttributes {

--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -127,13 +127,12 @@ message WorkerVersionStamp {
     // An opaque whole-worker identifier. Replaces the deprecated `binary_checksum` field when this
     // message is included in requests which previously used that.
     string build_id = 1;
-    // Set if the worker used a dynamically loadable bundle to process
-    // the task. The bundle could be a WASM blob, JS bundle, etc.
-    string bundle_id = 2;
 
     // If set, the worker is opting in to worker versioning. Otherwise, this is used only as a
     // marker for workflow reset points and the BuildIDs search attribute.
     bool use_versioning = 3;
+
+    // Later, may include bundle id that was used for WASM and/or JS dynamically loadable bundles.
 }
 
 // Identifies the version(s) that a worker is compatible with when polling or identifying itself,

--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -132,7 +132,7 @@ message WorkerVersionStamp {
     // marker for workflow reset points and the BuildIDs search attribute.
     bool use_versioning = 3;
 
-    // Later, may include bundle id that was used for WASM and/or JS dynamically loadable bundles.
+    // Later, may include bundle id that could be used for WASM and/or JS dynamically loadable bundles.
 }
 
 // Identifies the version(s) that a worker is compatible with when polling or identifying itself,

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -159,9 +159,9 @@ message WorkflowExecutionContinuedAsNewEventAttributes {
     temporal.api.common.v1.Header header = 12;
     temporal.api.common.v1.Memo memo = 13;
     temporal.api.common.v1.SearchAttributes search_attributes = 14;
-    // If this is set, the workflow executing this command wishes to continue as new using a version
-    // compatible with the version that this workflow most recently ran on.
-    bool use_compatible_version = 15;
+    // If this is set, the new execution inherits the Build ID of the current execution. Otherwise,
+    // the assignment rules will be used to independently assign a Build ID to the new execution.
+    bool inherit_build_id = 15;
 
     // workflow_execution_timeout is omitted as it shouldn't be overridden from within a workflow.
 }
@@ -290,10 +290,13 @@ message ActivityTaskScheduledEventAttributes {
     // configuration. Retries will happen up to `schedule_to_close_timeout`. To disable retries set
     // retry_policy.maximum_attempts to 1.
     temporal.api.common.v1.RetryPolicy retry_policy = 12;
-    // If this is set, the workflow executing this command wishes to start the activity using
-    // a version compatible with the version that this workflow most recently ran on, if such
-    // behavior is possible.
-    bool use_compatible_version = 13;
+    // Only applicable for activities executing on a Task Queue different from their workflow's.
+    // If this is set, the activity would be assigned to the Build ID of the workflow. Otherwise,
+    // Assignment rules of the activity's Task Queue will be used to determine the Build ID.
+    // Activities that run on their workflow's Task Queue are always assigned to the workflow's
+    // Build ID.
+    // All activities are subject to redirect rules of their Task Queue.
+    bool use_workflow_build_id = 13;
 }
 
 message ActivityTaskStartedEventAttributes {
@@ -593,10 +596,9 @@ message StartChildWorkflowExecutionInitiatedEventAttributes {
     temporal.api.common.v1.Header header = 15;
     temporal.api.common.v1.Memo memo = 16;
     temporal.api.common.v1.SearchAttributes search_attributes = 17;
-    // If this is set, the workflow executing this command wishes to start the child workflow using
-    // a version compatible with the version that this workflow most recently ran on, if such
-    // behavior is possible.
-    bool use_compatible_version = 19;
+    // If this is set, the child workflow inherits the Build ID of the parent. Otherwise, the assignment
+    // rules of the child's Task Queue will be used to independently assign a Build ID to it.
+    bool inherit_build_id = 19;
 }
 
 message StartChildWorkflowExecutionFailedEventAttributes {

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -290,12 +290,8 @@ message ActivityTaskScheduledEventAttributes {
     // configuration. Retries will happen up to `schedule_to_close_timeout`. To disable retries set
     // retry_policy.maximum_attempts to 1.
     temporal.api.common.v1.RetryPolicy retry_policy = 12;
-    // Only applicable for activities executing on a Task Queue different from their workflow's.
     // If this is set, the activity would be assigned to the Build ID of the workflow. Otherwise,
     // Assignment rules of the activity's Task Queue will be used to determine the Build ID.
-    // Activities that run on their workflow's Task Queue are always assigned to the workflow's
-    // Build ID.
-    // All activities are subject to redirect rules of their Task Queue.
     bool use_workflow_build_id = 13;
 }
 

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -126,13 +126,13 @@ message RampByWorkerRatio {
 // Specifically, assignment rules are applied to the following Executions or
 // Activities when they are scheduled in a Task Queue:
 //    - Generally, any new Workflow Execution, except:
-//      - Child Workflows started without overriding their Task Queue or
-//        assignment status.
-//      - Continue-As-New Executions started without overriding assignment
-//        status.
-//      - Workflow Executions started Eagerly.
+//      - When A Child Workflow or a Continue-As-New Execution inherits the
+//        Build ID from its parent/previous execution by setting the
+//        `inherit_build_id` flag.
+//      - Workflow Executions started Eagerly are assigned to the Build ID of
+//        the Starter.
 //    - An Activity that is scheduled on a Task Queue different from the one
-//      their Workflow runs on, without overriding assignment status.
+//      their Workflow runs on, unless the `use_workflow_build_id` flag is set.
 //
 // In absence of (applicable) redirect rules (`CompatibleBuildIdRedirectRule`s)
 // the task will be dispatched to Workers of the Build ID determined by the
@@ -146,21 +146,7 @@ message RampByWorkerRatio {
 // by the user when replacing/deleting these rules (for exceptional cases).
 //
 // During a deployment, one or more additional rules can be added to assign a
-// subset of the tasks to a new Build ID.
-//
-// The subset is defined by:
-//    - Filtering based on Search Attributes. This is useful for Canary
-//      deployments, for example, when only the executions with custom Search
-//      Attribute `TrafficType="CANARY"` should be sent to the new Build ID.
-//    - And/or setting a "ramp". This is useful for gradual shift of the
-//      traffic To the new Build ID. An assignment rule can have one of the
-//      following ramps:
-//      - Ramp by percentage: suitable for Blue/Green and similar deployments,
-//        when you want to send a certain percentage of traffic to the new
-//        Build ID.
-//      - Ramp by worker ratio: suitable for rolling deployments, when you want
-//        to shift more traffic to the new Build ID as the workers being
-//        gradually upgraded.
+// subset of the tasks to a new Build ID based on a "ramp percentage".
 //
 // When there are multiple assignment rules for a Task Queue, the rules are
 // evaluated in order, starting from index 0. The first applicable rule will be
@@ -174,11 +160,8 @@ message RampByWorkerRatio {
 message BuildIdAssignmentRule {
     string target_build_id = 1;
 
-    // Filter executions based on the Search Attributes of this execution.
-    string filter_expression = 2;
-
-    // If a ramp is provided, the tasks that match the hint filter will be
-    // subject to the given ramp.
+    // If a ramp is provided, this rule will be applied only to a sample of
+    // tasks according to the provided percentage.
     // This option can be used only on "terminal" Build IDs (the ones not used
     // as source in any redirect rules).
     oneof ramp {
@@ -186,11 +169,6 @@ message BuildIdAssignmentRule {
         // where you want to send a certain portion of the traffic to the target
         // Build ID.
         RampByPercentage percentage_ramp = 3;
-        // This option is intended for rolling deployments. The ramp percentage
-        // is automatically set as the ratio of the target Build ID's active
-        // workers over all active workers for any Build ID used in the
-        // assignment rules.
-        RampByWorkerRatio worker_ratio_ramp = 4;
     }
 }
 
@@ -207,9 +185,6 @@ message BuildIdAssignmentRule {
 //    newer one.
 //  - Need to hotfix some broken or stuck Workflow Executions.
 //
-// Similar to assignment rule, redirect rules support ramp by worker ratio.
-// They do not currently support ramp by percentage.
-//
 // In steady state, redirect rules are beneficial when dealing with old
 // Executions ran on now-decommissioned Build IDs:
 //  - To redirecting the Workflow Queries to the current (compatible) Build ID.
@@ -221,15 +196,6 @@ message BuildIdAssignmentRule {
 message CompatibleBuildIdRedirectRule {
     string source_build_id = 1;
     string target_build_id = 2;
-
-    // Only the last redirect rule in a chain can have a ramp.
-    oneof ramp {
-        // This option is intended for rolling deployments. When this field is
-        // provided, we redirect a fraction of tasks proportional to the ratio
-        // of the target Build ID's active workers over the source Build ID's
-        // active workers.
-        RampByWorkerRatio worker_ratio_ramp = 3;
-    }
 }
 
 message TimestampedBuildIdAssignmentRule {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1232,14 +1232,11 @@ message UpdateWorkerVersioningRulesRequest {
     // ID and cleanup unnecessary rules possibly created during a gradual
     // rollout. Specifically, this command will make the following changes
     // atomically:
-    //  1. Adds an unconditional assignment rule for the target Build ID at the
-    //     end of the list. An unconditional assignment rule:
-    //      - Has no hint filter
-    //      - Has no ramp
+    //  1. Adds an assignment rule (with full ramp) for the target Build ID at
+    //     the end of the list.
     //  2. Removes all previously added assignment rules to the given target
     //     Build ID (if any).
-    //  3. Removes any *unconditional* assignment rule for other Build IDs.
-    //  4. Removes the ramp of any incoming redirect rules to this Build ID.
+    //  3. Removes any fully-ramped assignment rule for other Build IDs.
     message CommitBuildId {
         string target_build_id = 1;
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Removed the hint filter and worker count based ramp from the Versioning protos for now.
- Renamed `use_compatible_version` flag to `use_workflow_build_id` for activities and to `inherit_build_id` for child and CaN executions. The new names capture the essence of the flag better because they are about whether to use the same build ID or to choose a fresh one based on the assignment rules.
- Removed `bundle_id` from the stamp as it is not used in any SDK or in the server. The user's view is polluted right now with this field. We'll add it later when there is a complete design for how to use it.

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**

