### PR TITLE
Change Namespace data map to contain bytes

### DIFF
--- a/temporal/api/namespace/v1/message.proto
+++ b/temporal/api/namespace/v1/message.proto
@@ -43,7 +43,7 @@ message NamespaceInfo {
     string description = 3;
     string owner_email = 4;
     // A key-value map for any customized purpose.
-    map<string, string> data = 5;
+    map<string, bytes> data = 5;
     string id = 6;
     // All capabilities the namespace supports.
     Capabilities capabilities = 7;
@@ -92,7 +92,7 @@ message UpdateNamespaceInfo {
     // A key-value map for any customized purpose.
     // If data already exists on the namespace, 
     // this will merge with the existing key values. 
-    map<string, string> data = 3;
+    map<string, bytes> data = 3;
     // New namespace state, server will reject if transition is not allowed.
     // Allowed transitions are:
     //  Registered -> [ Deleted | Deprecated | Handover ]

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -69,7 +69,7 @@ message RegisterNamespaceRequest {
     repeated temporal.api.replication.v1.ClusterReplicationConfig clusters = 5;
     string active_cluster_name = 6;
     // A key-value map for any customized purpose.
-    map<string, string> data = 7;
+    map<string, bytes> data = 7;
     string security_token = 8;
     bool is_global_namespace = 9;
     // If unspecified (ARCHIVAL_STATE_UNSPECIFIED) then default server configuration is used.


### PR DESCRIPTION
**What changed?**
The namespace data map now has `bytes` values rather than `string`.

**Why?**

We embed binary data (cast to strings) here in a few places, and that can cause google/protobuf to yell at us for having string data that's invalid UTF-8. Protobuf strings and bytes are wire-compatible


**Breaking changes**

This will change all code generated by protoc plugins to use the language's type for raw bytes. I have paired Go API and server PRs that will go along with this change
