### PR TITLE
Do not reuse NexusIncomingService for CreateOrUpdate request

### DIFF
--- a/temporal/api/nexus/v1/message.proto
+++ b/temporal/api/nexus/v1/message.proto
@@ -120,13 +120,13 @@ message Response {
 
 // A binding from a service name to namespace, task queue, and metadata for dispatching incoming Nexus requests.
 message IncomingService {
-    // Data version for this service. Must match current version on update or set to 0 to create a new service.
+    // Data version for this service, incremented for every mutation.
     int64 version = 1;
     // Service name, unique for this cluster.
     // The service name is used to address this service.
     // By default, when using Nexus over HTTP, the service name is matched against the base URL path.
     // E.g. the URL /my-service would match a service named "my-service".
-    // The name can contain any characters and is escaped when matched against a URL.
+    // The name must match `[a-zA-Z_][a-zA-Z0-9_]*`and is escaped when matched against a URL.
     string name = 2;
     // Namespace to route requests to.
     string namespace = 3;

--- a/temporal/api/operatorservice/v1/request_response.proto
+++ b/temporal/api/operatorservice/v1/request_response.proto
@@ -33,6 +33,7 @@ option csharp_namespace = "Temporalio.Api.OperatorService.V1";
 
 import "temporal/api/enums/v1/common.proto";
 import "temporal/api/nexus/v1/message.proto";
+import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 
 // (-- Search Attribute --)
@@ -139,8 +140,23 @@ message GetNexusIncomingServiceResponse {
     temporal.api.nexus.v1.IncomingService service = 1;
 }
 
+// (-- api-linter: core::0133::request-unknown-fields=disabled
+//     aip.dev/not-precedent: CreateOrUpdateNexusIncomingServiceResponse RPC doesn't follow Google API format. --)
 message CreateOrUpdateNexusIncomingServiceRequest {
-    temporal.api.nexus.v1.IncomingService service = 1;
+    // Data version for this service. Must match current version on update or set to 0 to create a new service.
+    int64 version = 1;
+    // Service name, unique for this cluster.
+    // The service name is used to address this service.
+    // By default, when using Nexus over HTTP, the service name is matched against the base URL path.
+    // E.g. the URL /my-service would match a service named "my-service".
+    // The name must match `[a-zA-Z_][a-zA-Z0-9_]*`and is escaped when matched against a URL.
+    string name = 2;
+    // Namespace to route requests to.
+    string namespace = 3;
+    // Task queue to route requests to.
+    string task_queue = 4;
+    // Generic service metadata that is available to the server's authorizer.
+    map<string, google.protobuf.Any> metadata = 5;
 }
 
 message CreateOrUpdateNexusIncomingServiceResponse {

--- a/temporal/api/operatorservice/v1/service.proto
+++ b/temporal/api/operatorservice/v1/service.proto
@@ -98,7 +98,7 @@ service OperatorService {
     rpc DeleteNexusIncomingService(DeleteNexusIncomingServiceRequest) returns (DeleteNexusIncomingServiceResponse) {
     }
 
-    // List all nexus incoming service names. Use next_page_token in the response for pagination.
+    // List all Nexus incoming services in the cluster. Use next_page_token in the response for pagination.
     rpc ListNexusIncomingServices(ListNexusIncomingServicesRequest) returns (ListNexusIncomingServicesResponse) {
     }
 }


### PR DESCRIPTION
**What changed?**

In description

**Why?**

Will allow us to add more fields in the response that are server set and should not be accepted in create or update requests.

**Breaking changes**

It's breaking but was never used.
