### PR TITLE
Add root workflow execution to WorkflowExecutionStartedEventAttributes

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -7848,6 +7848,10 @@
         "executionDuration": {
           "type": "string",
           "description": "Workflow execution duration is defined as difference between close time and execution time.\nThis field is only populated if the workflow is closed."
+        },
+        "rootExecution": {
+          "$ref": "#/definitions/v1WorkflowExecution",
+          "description": "Contains information about the root workflow execution.\nThe root workflow execution is defined as follows:\n1. A workflow without parent workflow is its own root workflow.\n2. A workflow that has a parent workflow has the same root workflow as its parent workflow.\nNote: workflows continued as new or reseted may or may not have parents, check examples below.\n\nExamples:\n  Scenario 1: Workflow W1 starts child workflow W2, and W2 starts child workflow W3.\n    - The root workflow of all three workflows is W1.\n  Scenario 2: Workflow W1 starts child workflow W2, and W2 continued as new W3.\n    - The root workflow of all three workflows is W1.\n  Scenario 3: Workflow W1 continued as new W2.\n    - The root workflow of W1 is W1 and the root workflow of W2 is W2.\n  Scenario 4: Workflow W1 starts child workflow W2, and W2 is reseted, creating W3\n    - The root workflow of all three workflows is W1.\n  Scenario 5: Workflow W1 is reseted, creating W2.\n    - The root workflow of W1 is W1 and the root workflow of W2 is W2."
         }
       }
     },
@@ -7999,6 +8003,10 @@
             "$ref": "#/definitions/v1Callback"
           },
           "description": "Completion callbacks attached when this workflow was started."
+        },
+        "rootWorkflowExecution": {
+          "$ref": "#/definitions/v1WorkflowExecution",
+          "description": "Contains information about the root workflow execution.\nThe root workflow execution is defined as follows:\n1. A workflow without parent workflow is its own root workflow.\n2. A workflow that has a parent workflow has the same root workflow as its parent workflow.\nNote: workflows continued as new or reseted may or may not have parents, check examples below.\n\nExamples:\n  Scenario 1: Workflow W1 starts child workflow W2, and W2 starts child workflow W3.\n    - The root workflow of all three workflows is W1.\n  Scenario 2: Workflow W1 starts child workflow W2, and W2 continued as new W3.\n    - The root workflow of all three workflows is W1.\n  Scenario 3: Workflow W1 continued as new W2.\n    - The root workflow of W1 is W1 and the root workflow of W2 is W2.\n  Scenario 4: Workflow W1 starts child workflow W2, and W2 is reseted, creating W3\n    - The root workflow of all three workflows is W1.\n  Scenario 5: Workflow W1 is reseted, creating W2.\n    - The root workflow of W1 is W1 and the root workflow of W2 is W2."
         }
       },
       "title": "Always the first event in workflow history"

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -5766,6 +5766,27 @@ components:
           description: |-
             Workflow execution duration is defined as difference between close time and execution time.
              This field is only populated if the workflow is closed.
+        rootExecution:
+          allOf:
+            - $ref: '#/components/schemas/WorkflowExecution'
+          description: |-
+            Contains information about the root workflow execution.
+             The root workflow execution is defined as follows:
+             1. A workflow without parent workflow is its own root workflow.
+             2. A workflow that has a parent workflow has the same root workflow as its parent workflow.
+             Note: workflows continued as new or reseted may or may not have parents, check examples below.
+
+             Examples:
+               Scenario 1: Workflow W1 starts child workflow W2, and W2 starts child workflow W3.
+                 - The root workflow of all three workflows is W1.
+               Scenario 2: Workflow W1 starts child workflow W2, and W2 continued as new W3.
+                 - The root workflow of all three workflows is W1.
+               Scenario 3: Workflow W1 continued as new W2.
+                 - The root workflow of W1 is W1 and the root workflow of W2 is W2.
+               Scenario 4: Workflow W1 starts child workflow W2, and W2 is reseted, creating W3
+                 - The root workflow of all three workflows is W1.
+               Scenario 5: Workflow W1 is reseted, creating W2.
+                 - The root workflow of W1 is W1 and the root workflow of W2 is W2.
     WorkflowExecutionSignaledEventAttributes:
       type: object
       properties:
@@ -5908,6 +5929,27 @@ components:
           items:
             $ref: '#/components/schemas/Callback'
           description: Completion callbacks attached when this workflow was started.
+        rootWorkflowExecution:
+          allOf:
+            - $ref: '#/components/schemas/WorkflowExecution'
+          description: |-
+            Contains information about the root workflow execution.
+             The root workflow execution is defined as follows:
+             1. A workflow without parent workflow is its own root workflow.
+             2. A workflow that has a parent workflow has the same root workflow as its parent workflow.
+             Note: workflows continued as new or reseted may or may not have parents, check examples below.
+
+             Examples:
+               Scenario 1: Workflow W1 starts child workflow W2, and W2 starts child workflow W3.
+                 - The root workflow of all three workflows is W1.
+               Scenario 2: Workflow W1 starts child workflow W2, and W2 continued as new W3.
+                 - The root workflow of all three workflows is W1.
+               Scenario 3: Workflow W1 continued as new W2.
+                 - The root workflow of W1 is W1 and the root workflow of W2 is W2.
+               Scenario 4: Workflow W1 starts child workflow W2, and W2 is reseted, creating W3
+                 - The root workflow of all three workflows is W1.
+               Scenario 5: Workflow W1 is reseted, creating W2.
+                 - The root workflow of W1 is W1 and the root workflow of W2 is W2.
       description: Always the first event in workflow history
     WorkflowExecutionTerminatedEventAttributes:
       type: object

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -107,6 +107,25 @@ message WorkflowExecutionStartedEventAttributes {
 
     // Completion callbacks attached when this workflow was started.
     repeated temporal.api.common.v1.Callback completion_callbacks = 30;
+
+    // Contains information about the root workflow execution.
+    // The root workflow execution is defined as follows:
+    // 1. A workflow without parent workflow is its own root workflow.
+    // 2. A workflow that has a parent workflow has the same root workflow as its parent workflow.
+    // Note: workflows continued as new or reseted may or may not have parents, check examples below.
+    //
+    // Examples:
+    //   Scenario 1: Workflow W1 starts child workflow W2, and W2 starts child workflow W3.
+    //     - The root workflow of all three workflows is W1.
+    //   Scenario 2: Workflow W1 starts child workflow W2, and W2 continued as new W3.
+    //     - The root workflow of all three workflows is W1.
+    //   Scenario 3: Workflow W1 continued as new W2.
+    //     - The root workflow of W1 is W1 and the root workflow of W2 is W2.
+    //   Scenario 4: Workflow W1 starts child workflow W2, and W2 is reseted, creating W3
+    //     - The root workflow of all three workflows is W1.
+    //   Scenario 5: Workflow W1 is reseted, creating W2.
+    //     - The root workflow of W1 is W1 and the root workflow of W2 is W2.
+    temporal.api.common.v1.WorkflowExecution root_workflow_execution = 31;
 }
 
 message WorkflowExecutionCompletedEventAttributes {

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -61,6 +61,24 @@ message WorkflowExecutionInfo {
     // Workflow execution duration is defined as difference between close time and execution time.
     // This field is only populated if the workflow is closed.
     google.protobuf.Duration execution_duration = 17;
+    // Contains information about the root workflow execution.
+    // The root workflow execution is defined as follows:
+    // 1. A workflow without parent workflow is its own root workflow.
+    // 2. A workflow that has a parent workflow has the same root workflow as its parent workflow.
+    // Note: workflows continued as new or reseted may or may not have parents, check examples below.
+    //
+    // Examples:
+    //   Scenario 1: Workflow W1 starts child workflow W2, and W2 starts child workflow W3.
+    //     - The root workflow of all three workflows is W1.
+    //   Scenario 2: Workflow W1 starts child workflow W2, and W2 continued as new W3.
+    //     - The root workflow of all three workflows is W1.
+    //   Scenario 3: Workflow W1 continued as new W2.
+    //     - The root workflow of W1 is W1 and the root workflow of W2 is W2.
+    //   Scenario 4: Workflow W1 starts child workflow W2, and W2 is reseted, creating W3
+    //     - The root workflow of all three workflows is W1.
+    //   Scenario 5: Workflow W1 is reseted, creating W2.
+    //     - The root workflow of W1 is W1 and the root workflow of W2 is W2.
+    temporal.api.common.v1.WorkflowExecution root_execution = 18;
 }
 
 message WorkflowExecutionConfig {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add fields for root workflow execution.

The root workflow execution is defined as follows:
1. A workflow without parent workflow is its own root workflow.
2. A workflow that has a parent workflow has the same root workflow as its parent workflow.

Examples:
- Scenario 1: Workflow W1 starts child workflow W2, and W2 starts child workflow W3.
  - The root workflow of all three workflows is W1.
- Scenario 2: Workflow W1 starts child workflow W2, and W2 continued as new W3.
  - The root workflow of all three workflows is W1.
- Scenario 3: Workflow W1 continued as W2.
  - The root workflow of W1 is W1 and the root workflow of W2 is W2.


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**

