### PR TITLE
Make it easier to see linter issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ grpc-install:
 api-linter-install:
 	printf $(COLOR) "Install/update api-linter..."
 	go install github.com/googleapis/api-linter/cmd/api-linter@v1.32.3
+	go install github.com/itchyny/gojq/cmd/gojq@v0.12.14
 
 buf-install:
 	printf $(COLOR) "Install/update buf..."
@@ -94,7 +95,7 @@ buf-install:
 ##### Linters #####
 api-linter:
 	printf $(COLOR) "Run api-linter..."
-	@api-linter --set-exit-status $(PROTO_IMPORTS) --config $(PROTO_ROOT)/api-linter.yaml --output-format json $(PROTO_FILES) | jq -r 'map(select(.problems != []) | . as $$file | .problems[] | {rule: .rule_doc_uri, location: "\($$file.file_path):\(.location.start_position.line_number)"}) | group_by(.rule) | .[] | .[0].rule + ":\n" + (map("\t" + .location) | join("\n"))'
+	@api-linter --set-exit-status $(PROTO_IMPORTS) --config $(PROTO_ROOT)/api-linter.yaml --output-format json $(PROTO_FILES) | gojq -r 'map(select(.problems != []) | . as $$file | .problems[] | {rule: .rule_doc_uri, location: "\($$file.file_path):\(.location.start_position.line_number)"}) | group_by(.rule) | .[] | .[0].rule + ":\n" + (map("\t" + .location) | join("\n"))'
 
 $(STAMPDIR):
 	mkdir $@


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I changed the format of the api-linter to:
- Only show the rule URL and location
- Make the location a clickable link
- Group violations by rule

<!-- Tell your future self why have you made these changes -->
**Why?**
The output previously was not very easy to parse:

Before:

<img width="678" alt="Screenshot 2024-03-13 at 12 55 27 PM" src="https://github.com/temporalio/api/assets/5942963/6129711d-a4f5-4fe6-bd0d-041d82b4ae1a">
<img width="505" alt="Screenshot 2024-03-13 at 12 55 39 PM" src="https://github.com/temporalio/api/assets/5942963/3d65e615-85ac-437c-93d8-0cb5b9905e98">

After:

<img width="554" alt="Screenshot 2024-03-13 at 12 54 45 PM" src="https://github.com/temporalio/api/assets/5942963/69d36cd2-a834-4c30-8c9f-e60bac1da8e7">


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**

