### PR TITLE
add inherited_build_id to ExecutionInfo

### DIFF
--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -66,7 +66,7 @@ message TaskQueueTypeInfo {
     temporal.api.enums.v1.TaskQueueType type = 1;
     // Unversioned workers (with `useVersioning=false`) are reported in unversioned result even if they set a Build ID.
     repeated PollerInfo pollers = 2;
-    BacklogInfo backlog_info = 3;
+    // BacklogInfo backlog_info = 3;
 }
 
 // For workflow task queues, we only report the normal queue metrics, not sticky queues. This means the stats

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -65,6 +65,9 @@ message WorkflowExecutionInfo {
     // Assigned build ID can also change in the middle of a execution if Compatible Redirect Rules are applied to
     // this execution.
     string assigned_build_id = 17;
+    // Build ID inherited from a previous/parent execution. If present, assigned_build_id will be set to this, instead
+    // of using the assignment rules.
+    string inherited_build_id = 18;
 }
 
 message WorkflowExecutionConfig {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -887,7 +887,7 @@ message DescribeTaskQueueRequest {
     // Task queue types to report info about. If not specified, all types are considered.
     repeated temporal.api.enums.v1.TaskQueueType task_queue_types = 9;
     // Report backlog info for the requested task queue types and versions
-    bool report_backlog_info = 10;
+    // bool report_backlog_info = 10;
     // Report list of pollers for requested task queue types and versions
     bool report_pollers = 11;
     // Report task reachability for the requested versions


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add `inherited_build_id` to `WorkflowExecutionInfo`.
- Remove Backlog Info fields from `DescribeTaskQueue` until it's implemented.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Inherited Build ID can be useful to show in UI for CaN and Child WFs
- Backlog Info may not arrive with new WV pre-release, so keeping it out of the public API for now.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**

