### PR TITLE
Fix missing pipefail in api-linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,8 @@ buf-install:
 
 ##### Linters #####
 api-linter:
-	printf $(COLOR) "Run api-linter..."
-	@api-linter --set-exit-status $(PROTO_IMPORTS) --config $(PROTO_ROOT)/api-linter.yaml --output-format json $(PROTO_FILES) | gojq -r 'map(select(.problems != []) | . as $$file | .problems[] | {rule: .rule_doc_uri, location: "\($$file.file_path):\(.location.start_position.line_number)"}) | group_by(.rule) | .[] | .[0].rule + ":\n" + (map("\t" + .location) | join("\n"))'
+	@printf $(COLOR) "Run api-linter..."
+	@./scripts/lint-api.sh $(PROTO_IMPORTS) $(PROTO_ROOT) $(PROTO_FILES)
 
 $(STAMPDIR):
 	mkdir $@

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ buf-install:
 	go install github.com/bufbuild/buf/cmd/buf@v1.27.0
 
 ##### Linters #####
-api-linter:
+api-linter: api-linter-install
 	@printf $(COLOR) "Run api-linter..."
 	@./scripts/lint-api.sh $(PROTO_IMPORTS) $(PROTO_ROOT) $(PROTO_FILES)
 

--- a/scripts/lint-api.sh
+++ b/scripts/lint-api.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+# Usage: ./lint-api.sh [PROTO_IMPORTS] [PROTO_ROOT] [PROTO_FILES]
+
+PROTO_IMPORTS="$1"
+PROTO_ROOT="$2"
+shift 2
+
+api_linter_output=$(api-linter --set-exit-status "$PROTO_IMPORTS" --config "$PROTO_ROOT/api-linter.yaml" --output-format json "$@")
+api_linter_status=$?
+
+# Exit early if api-linter finds no issues
+if [ $api_linter_status -eq 0 ]; then
+    exit 0
+fi
+
+# Continue with the script if issues are found
+# shellcheck disable=SC2016
+jq_expr='
+    map(select(.problems != [])
+        | . as $file
+        | .problems[]
+        | {
+            rule: .rule_doc_uri,
+            location: "\($file.file_path):\(.location.start_position.line_number)"
+        }
+    )
+    | group_by(.rule)
+    | .[]
+    | .[0].rule + ":\n"
+      + (map("\t" + .location) | join("\n"))
+'
+
+gojq_output=$(echo "$api_linter_output" | gojq -r "$jq_expr")
+gojq_status=$?
+
+if [ $gojq_status -ne 0 ]; then
+    echo "gojq processing failed" >&2
+    exit $gojq_status
+fi
+
+echo "$gojq_output"
+exit $api_linter_status


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I moved the `api-linter` code into its own script and made it actually propagate non-zero exit codes fro mthe api-linter before the output is formatted.

<!-- Tell your future self why have you made these changes -->
**Why?**
My previous PR, #368 , introduced an issue where failures in the api-linter would show up in the terminal output, but the exit code would be 0 because we didn't set `-o pipefail` in the shell. This fixes that.

Why not use something like `SHELL=/bin/bash -o pipefail`? Because, we don't want to depend on bash.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**

