### PR TITLE
Cloud API

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,5 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 *                       @temporalio/server @temporalio/sdk
-api/temporal/api/sdk/*  @temporalio/sdk
+/temporal/api/sdk/      @temporalio/sdk
+/temporal/api/cloud/    @temporalio/saas @temporalio/sdk

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,8 @@ http-api-docs:
 		--openapiv2_out=openapi \
         --openapiv2_opt=allow_merge=true,merge_file_name=openapiv2,simple_operation_ids=true \
 		temporal/api/workflowservice/v1/* \
-		temporal/api/operatorservice/v1/*
+		temporal/api/operatorservice/v1/* \
+		temporal/api/cloud/cloudservice/v1/*
 
 	jq --rawfile desc $(OAPI_OUT)/payload_description.txt < $(OAPI_OUT)/openapiv2.swagger.json '.definitions.v1Payload={description: $$desc}' > $(OAPI_OUT)/v2.tmp
 	mv -f $(OAPI_OUT)/v2.tmp $(OAPI_OUT)/openapiv2.json

--- a/api-linter.yaml
+++ b/api-linter.yaml
@@ -3,7 +3,10 @@
   disabled_rules:
     - "core::0122::name-suffix" # Allow fields to have a "_name" suffix -- https://linter.aip.dev/122/name-suffix
     - "core::0140::uri" # We use "URL" instead of "URI" in many places. -- https://linter.aip.dev/140/uri
+    - "core::0142::time-field-names" # We allow terms like "created". -- https://linter.aip.dev/142/time-field-names
     - "core::0192::has-comments" # Don't require comments on every field. -- https://linter.aip.dev/192/has-comments
+    - "core::0203::immutable" # Don't force Google field behavior annotations. -- https://linter.aip.dev/203
+    - "core::0203::optional" # Don't force Google field behavior annotations. -- https://linter.aip.dev/203
 
 - included_paths:
     - "**/message.proto"
@@ -13,6 +16,7 @@
 - included_paths:
     - "**/workflowservice/v1/request_response.proto"
     - "**/operatorservice/v1/request_response.proto"
+    - "**/cloudservice/v1/request_response.proto"
   disabled_rules:
     - "core::0131::request-name-behavior" # We don't add non-HTTP annotations -- https://linter.aip.dev/131/request-name-behavior
     - "core::0131::request-name-reference" # We don't add non-HTTP annotations -- https://linter.aip.dev/131/request-name-reference
@@ -41,6 +45,7 @@
 - included_paths:
     - "**/workflowservice/v1/service.proto"
     - "**/operatorservice/v1/service.proto"
+    - "**/cloudservice/v1/service.proto"
   disabled_rules:
     - "core::0127::resource-name-extraction" # We extract specific fields in URL since the gRPC API predates the HTTP API -- https://linter.aip.dev/127/resource-name-extraction
 

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -10,6 +10,9 @@
     },
     {
       "name": "OperatorService"
+    },
+    {
+      "name": "CloudService"
     }
   ],
   "consumes": [
@@ -19,6 +22,571 @@
     "application/json"
   ],
   "paths": {
+    "/api/v1/cloud/namespaces": {
+      "get": {
+        "summary": "Get all namespaces",
+        "operationId": "GetNamespaces",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetNamespacesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "description": "The requested size of the page to retrieve.\nCannot exceed 1000. \nOptional, defaults to 100.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "description": "The page token if this is continuing from another response.\nOptional, defaults to empty.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "description": "Filter namespaces by their name.\nOptional, defaults to empty.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "CloudService"
+        ]
+      },
+      "post": {
+        "summary": "Create a new namespace",
+        "operationId": "CreateNamespace",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1CreateNamespaceResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateNamespaceRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CloudService"
+        ]
+      }
+    },
+    "/api/v1/cloud/namespaces/{namespace}": {
+      "get": {
+        "summary": "Get a namespace",
+        "operationId": "GetNamespace",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetNamespaceResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "The namespace to get.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "CloudService"
+        ]
+      },
+      "delete": {
+        "summary": "Delete a namespace",
+        "operationId": "DeleteNamespace",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/cloudcloudservicev1DeleteNamespaceResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "The namespace to delete.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceVersion",
+            "description": "The version of the namespace for which this delete is intended for.\nThe latest version can be found in the namespace status.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "asyncOperationId",
+            "description": "The id to use for this async operation.\nOptional, if not provided a random id will be generated.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "CloudService"
+        ]
+      },
+      "post": {
+        "summary": "Update a namespace",
+        "operationId": "UpdateNamespace",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/cloudcloudservicev1UpdateNamespaceResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "The namespace to update.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CloudServiceUpdateNamespaceBody"
+            }
+          }
+        ],
+        "tags": [
+          "CloudService"
+        ]
+      }
+    },
+    "/api/v1/cloud/namespaces/{namespace}/rename-custom-search-attribute": {
+      "post": {
+        "summary": "Rename an existing customer search attribute",
+        "operationId": "RenameCustomSearchAttribute",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RenameCustomSearchAttributeResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "The namespace to rename the custom search attribute for.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CloudServiceRenameCustomSearchAttributeBody"
+            }
+          }
+        ],
+        "tags": [
+          "CloudService"
+        ]
+      }
+    },
+    "/api/v1/cloud/namespaces/{namespace}/users/{userId}/access": {
+      "post": {
+        "summary": "Set a user's access to a namespace",
+        "operationId": "SetUserNamespaceAccess",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1SetUserNamespaceAccessResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "The namespace to set permissions for",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "userId",
+            "description": "The id of the user to set permissions for",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CloudServiceSetUserNamespaceAccessBody"
+            }
+          }
+        ],
+        "tags": [
+          "CloudService"
+        ]
+      }
+    },
+    "/api/v1/cloud/operations/{asyncOperationId}": {
+      "get": {
+        "summary": "Get the latest information on an async operation",
+        "operationId": "GetAsyncOperation",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetAsyncOperationResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "asyncOperationId",
+            "description": "The id of the async operation to get",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "CloudService"
+        ]
+      }
+    },
+    "/api/v1/cloud/regions": {
+      "get": {
+        "summary": "Get all regions",
+        "operationId": "GetRegions",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetRegionsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "CloudService"
+        ]
+      }
+    },
+    "/api/v1/cloud/regions/{region}": {
+      "get": {
+        "summary": "Get a region",
+        "operationId": "GetRegion",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetRegionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "region",
+            "description": "The id of the region to get.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "CloudService"
+        ]
+      }
+    },
+    "/api/v1/cloud/users": {
+      "get": {
+        "summary": "Gets all known users",
+        "operationId": "GetUsers",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetUsersResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "description": "The requested size of the page to retrieve - optional.\nCannot exceed 1000. Defaults to 100.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "description": "The page token if this is continuing from another response - optional.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "email",
+            "description": "Filter users by email address - optional.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "namespace",
+            "description": "Filter users by the namespace they have access to - optional.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "CloudService"
+        ]
+      },
+      "post": {
+        "summary": "Create a user",
+        "operationId": "CreateUser",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1CreateUserResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateUserRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CloudService"
+        ]
+      }
+    },
+    "/api/v1/cloud/users/{userId}": {
+      "get": {
+        "summary": "Get a user",
+        "operationId": "GetUser",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetUserResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "description": "The id of the user to get",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "CloudService"
+        ]
+      },
+      "delete": {
+        "summary": "Delete a user",
+        "operationId": "DeleteUser",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1DeleteUserResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "description": "The id of the user to delete",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceVersion",
+            "description": "The version of the user for which this delete is intended for\nThe latest version can be found in the GetUser operation response",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "asyncOperationId",
+            "description": "The id to use for this async operation - optional",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "CloudService"
+        ]
+      },
+      "post": {
+        "summary": "Update a user",
+        "operationId": "UpdateUser",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1UpdateUserResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "description": "The id of the user to update",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CloudServiceUpdateUserBody"
+            }
+          }
+        ],
+        "tags": [
+          "CloudService"
+        ]
+      }
+    },
     "/api/v1/cluster-info": {
       "get": {
         "summary": "GetClusterInfo returns information about temporal cluster",
@@ -1193,7 +1761,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1UpdateNamespaceResponse"
+              "$ref": "#/definitions/apiworkflowservicev1UpdateNamespaceResponse"
             }
           },
           "default": {
@@ -1215,7 +1783,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/WorkflowServiceUpdateNamespaceBody"
+              "$ref": "#/definitions/v1WorkflowServiceUpdateNamespaceBody"
             }
           }
         ],
@@ -2004,6 +2572,61 @@
         }
       }
     },
+    "CloudServiceRenameCustomSearchAttributeBody": {
+      "type": "object",
+      "properties": {
+        "existingCustomSearchAttributeName": {
+          "type": "string",
+          "description": "The existing name of the custom search attribute to be renamed."
+        },
+        "newCustomSearchAttributeName": {
+          "type": "string",
+          "description": "The new name of the custom search attribute."
+        },
+        "resourceVersion": {
+          "type": "string",
+          "description": "The version of the namespace for which this update is intended for.\nThe latest version can be found in the namespace status."
+        },
+        "asyncOperationId": {
+          "type": "string",
+          "description": "The id to use for this async operation.\nOptional, if not provided a random id will be generated."
+        }
+      }
+    },
+    "CloudServiceSetUserNamespaceAccessBody": {
+      "type": "object",
+      "properties": {
+        "access": {
+          "$ref": "#/definitions/v1NamespaceAccess",
+          "title": "The namespace access to assign the user"
+        },
+        "resourceVersion": {
+          "type": "string",
+          "title": "The version of the user for which this update is intended for\nThe latest version can be found in the GetUser operation response"
+        },
+        "asyncOperationId": {
+          "type": "string",
+          "title": "The id to use for this async operation - optional"
+        }
+      }
+    },
+    "CloudServiceUpdateUserBody": {
+      "type": "object",
+      "properties": {
+        "spec": {
+          "$ref": "#/definitions/v1UserSpec",
+          "title": "The new user specification"
+        },
+        "resourceVersion": {
+          "type": "string",
+          "title": "The version of the user for which this update is intended for\nThe latest version can be found in the GetUser operation response"
+        },
+        "asyncOperationId": {
+          "type": "string",
+          "title": "The id to use for this async operation - optional"
+        }
+      }
+    },
     "CountWorkflowExecutionsResponseAggregationGroup": {
       "type": "object",
       "properties": {
@@ -2684,30 +3307,6 @@
         }
       }
     },
-    "WorkflowServiceUpdateNamespaceBody": {
-      "type": "object",
-      "properties": {
-        "updateInfo": {
-          "$ref": "#/definitions/v1UpdateNamespaceInfo"
-        },
-        "config": {
-          "$ref": "#/definitions/v1NamespaceConfig"
-        },
-        "replicationConfig": {
-          "$ref": "#/definitions/v1NamespaceReplicationConfig"
-        },
-        "securityToken": {
-          "type": "string"
-        },
-        "deleteBadBinary": {
-          "type": "string"
-        },
-        "promoteNamespace": {
-          "type": "boolean",
-          "description": "promote local namespace to global namespace. Ignored if namespace is already global namespace."
-        }
-      }
-    },
     "WorkflowServiceUpdateScheduleBody": {
       "type": "object",
       "properties": {
@@ -2868,6 +3467,15 @@
       },
       "description": "A response indicating that the handler has successfully processed a request."
     },
+    "apioperatorservicev1DeleteNamespaceResponse": {
+      "type": "object",
+      "properties": {
+        "deletedNamespace": {
+          "type": "string",
+          "description": "Temporary namespace name that is used during reclaim resources step."
+        }
+      }
+    },
     "apiupdatev1Request": {
       "type": "object",
       "properties": {
@@ -2879,6 +3487,45 @@
         }
       },
       "title": "The client request that triggers a workflow execution update"
+    },
+    "apiworkflowservicev1UpdateNamespaceResponse": {
+      "type": "object",
+      "properties": {
+        "namespaceInfo": {
+          "$ref": "#/definitions/v1NamespaceInfo"
+        },
+        "config": {
+          "$ref": "#/definitions/v1NamespaceConfig"
+        },
+        "replicationConfig": {
+          "$ref": "#/definitions/v1NamespaceReplicationConfig"
+        },
+        "failoverVersion": {
+          "type": "string",
+          "format": "int64"
+        },
+        "isGlobalNamespace": {
+          "type": "boolean"
+        }
+      }
+    },
+    "cloudcloudservicev1DeleteNamespaceResponse": {
+      "type": "object",
+      "properties": {
+        "asyncOperation": {
+          "$ref": "#/definitions/v1AsyncOperation",
+          "description": "The async operation."
+        }
+      }
+    },
+    "cloudcloudservicev1UpdateNamespaceResponse": {
+      "type": "object",
+      "properties": {
+        "asyncOperation": {
+          "$ref": "#/definitions/v1AsyncOperation",
+          "description": "The async operation."
+        }
+      }
     },
     "protobufAny": {
       "type": "object",
@@ -2915,6 +3562,50 @@
             "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
+        }
+      }
+    },
+    "v1AWSPrivateLinkInfo": {
+      "type": "object",
+      "properties": {
+        "allowedPrincipalArns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The list of principal arns that are allowed to access the namespace on the private link."
+        },
+        "vpcEndpointServiceNames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The list of vpc endpoint service names that are associated with the namespace."
+        }
+      }
+    },
+    "v1Access": {
+      "type": "object",
+      "properties": {
+        "accountAccess": {
+          "$ref": "#/definitions/v1AccountAccess",
+          "title": "The account access"
+        },
+        "namespaceAccesses": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/v1NamespaceAccess"
+          },
+          "title": "The map of namespace accesses\nThe key is the namespace name and the value is the access to the namespace"
+        }
+      }
+    },
+    "v1AccountAccess": {
+      "type": "object",
+      "properties": {
+        "role": {
+          "type": "string",
+          "title": "The role on the account, should be one of [admin, developer, read]\nadmin - gives full access the account, including users and namespaces\ndeveloper - gives access to create namespaces on the account\nread - gives read only access to the account"
         }
       }
     },
@@ -3213,6 +3904,45 @@
         "ARCHIVAL_STATE_ENABLED"
       ],
       "default": "ARCHIVAL_STATE_UNSPECIFIED"
+    },
+    "v1AsyncOperation": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "The operation id"
+        },
+        "state": {
+          "type": "string",
+          "title": "The current state of this operation\nPossible values are: pending, in_progress, failed, cancelled, fulfilled"
+        },
+        "checkDuration": {
+          "type": "string",
+          "title": "The recommended duration to check back for an update in the operation's state"
+        },
+        "operationType": {
+          "type": "string",
+          "title": "The type of operation being performed"
+        },
+        "operationInput": {
+          "$ref": "#/definitions/protobufAny",
+          "title": "The input to the operation being performed"
+        },
+        "failureReason": {
+          "type": "string",
+          "title": "If the operation failed, the reason for the failure"
+        },
+        "startedTime": {
+          "type": "string",
+          "format": "date-time",
+          "title": "The date and time when the operation initiated"
+        },
+        "finishedTime": {
+          "type": "string",
+          "format": "date-time",
+          "title": "The date and time when the operation completed"
+        }
+      }
     },
     "v1BackfillRequest": {
       "type": "object",
@@ -3552,6 +4282,27 @@
         }
       }
     },
+    "v1CertificateFilterSpec": {
+      "type": "object",
+      "properties": {
+        "commonName": {
+          "type": "string",
+          "description": "The common_name in the certificate.\nOptional, default is empty."
+        },
+        "organization": {
+          "type": "string",
+          "description": "The organization in the certificate.\nOptional, default is empty."
+        },
+        "organizationalUnit": {
+          "type": "string",
+          "description": "The organizational_unit in the certificate.\nOptional, default is empty."
+        },
+        "subjectAlternativeName": {
+          "type": "string",
+          "description": "The subject_alternative_name in the certificate.\nOptional, default is empty."
+        }
+      }
+    },
     "v1ChildWorkflowExecutionCanceledEventAttributes": {
       "type": "object",
       "properties": {
@@ -3758,6 +4509,23 @@
         }
       }
     },
+    "v1CloudServiceUpdateNamespaceBody": {
+      "type": "object",
+      "properties": {
+        "spec": {
+          "$ref": "#/definitions/v1NamespaceSpec",
+          "description": "The new namespace specification."
+        },
+        "resourceVersion": {
+          "type": "string",
+          "description": "The version of the namespace for which this update is intended for.\nThe latest version can be found in the namespace status."
+        },
+        "asyncOperationId": {
+          "type": "string",
+          "description": "The id to use for this async operation.\nOptional, if not provided a random id will be generated."
+        }
+      }
+    },
     "v1ClusterMetadata": {
       "type": "object",
       "properties": {
@@ -3794,6 +4562,23 @@
       "properties": {
         "clusterName": {
           "type": "string"
+        }
+      }
+    },
+    "v1CodecServerSpec": {
+      "type": "object",
+      "properties": {
+        "endpoint": {
+          "type": "string",
+          "description": "The codec server endpoint."
+        },
+        "passAccessToken": {
+          "type": "boolean",
+          "description": "Whether to pass the user access token with your endpoint."
+        },
+        "includeCrossOriginCredentials": {
+          "type": "boolean",
+          "description": "Whether to include cross-origin credentials."
         }
       }
     },
@@ -3982,6 +4767,32 @@
         }
       }
     },
+    "v1CreateNamespaceRequest": {
+      "type": "object",
+      "properties": {
+        "spec": {
+          "$ref": "#/definitions/v1NamespaceSpec",
+          "description": "The namespace specification."
+        },
+        "asyncOperationId": {
+          "type": "string",
+          "description": "The id to use for this async operation.\nOptional, if not provided a random id will be generated."
+        }
+      }
+    },
+    "v1CreateNamespaceResponse": {
+      "type": "object",
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "description": "The namespace that was created."
+        },
+        "asyncOperation": {
+          "$ref": "#/definitions/v1AsyncOperation",
+          "description": "The async operation."
+        }
+      }
+    },
     "v1CreateNexusIncomingServiceResponse": {
       "type": "object",
       "properties": {
@@ -4009,6 +4820,32 @@
         }
       }
     },
+    "v1CreateUserRequest": {
+      "type": "object",
+      "properties": {
+        "spec": {
+          "$ref": "#/definitions/v1UserSpec",
+          "title": "The spec for the user to invite"
+        },
+        "asyncOperationId": {
+          "type": "string",
+          "title": "The id to use for this async operation - optional"
+        }
+      }
+    },
+    "v1CreateUserResponse": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "title": "The id of the user that was invited"
+        },
+        "asyncOperation": {
+          "$ref": "#/definitions/v1AsyncOperation",
+          "title": "The async operation"
+        }
+      }
+    },
     "v1DataBlob": {
       "type": "object",
       "properties": {
@@ -4021,15 +4858,6 @@
         }
       }
     },
-    "v1DeleteNamespaceResponse": {
-      "type": "object",
-      "properties": {
-        "deletedNamespace": {
-          "type": "string",
-          "description": "Temporary namespace name that is used during reclaim resources step."
-        }
-      }
-    },
     "v1DeleteNexusIncomingServiceResponse": {
       "type": "object"
     },
@@ -4038,6 +4866,15 @@
     },
     "v1DeleteScheduleResponse": {
       "type": "object"
+    },
+    "v1DeleteUserResponse": {
+      "type": "object",
+      "properties": {
+        "asyncOperation": {
+          "$ref": "#/definitions/v1AsyncOperation",
+          "title": "The async operation"
+        }
+      }
     },
     "v1DeleteWorkflowExecutionResponse": {
       "type": "object"
@@ -4209,6 +5046,19 @@
       ],
       "default": "ENCODING_TYPE_UNSPECIFIED"
     },
+    "v1Endpoints": {
+      "type": "object",
+      "properties": {
+        "webAddress": {
+          "type": "string",
+          "description": "The web ui address."
+        },
+        "grpcAddress": {
+          "type": "string",
+          "description": "The grpc hostport address that the temporal workers, clients and tctl connect to."
+        }
+      }
+    },
     "v1EventType": {
       "type": "string",
       "enum": [
@@ -4332,6 +5182,15 @@
       },
       "title": "Represents a historical replication status of a Namespace"
     },
+    "v1GetAsyncOperationResponse": {
+      "type": "object",
+      "properties": {
+        "asyncOperation": {
+          "$ref": "#/definitions/v1AsyncOperation",
+          "title": "The async operation"
+        }
+      }
+    },
     "v1GetClusterInfoResponse": {
       "type": "object",
       "properties": {
@@ -4367,6 +5226,32 @@
       },
       "description": "GetClusterInfoResponse contains information about Temporal cluster."
     },
+    "v1GetNamespaceResponse": {
+      "type": "object",
+      "properties": {
+        "namespace": {
+          "$ref": "#/definitions/v1Namespace",
+          "description": "The namespace."
+        }
+      }
+    },
+    "v1GetNamespacesResponse": {
+      "type": "object",
+      "properties": {
+        "namespaces": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1Namespace"
+          },
+          "description": "The list of namespaces in ascending name order."
+        },
+        "nextPageToken": {
+          "type": "string",
+          "description": "The next page's token."
+        }
+      }
+    },
     "v1GetNexusIncomingServiceResponse": {
       "type": "object",
       "properties": {
@@ -4380,6 +5265,28 @@
       "properties": {
         "service": {
           "$ref": "#/definitions/v1OutgoingService"
+        }
+      }
+    },
+    "v1GetRegionResponse": {
+      "type": "object",
+      "properties": {
+        "region": {
+          "$ref": "#/definitions/v1Region",
+          "description": "The temporal cloud region."
+        }
+      }
+    },
+    "v1GetRegionsResponse": {
+      "type": "object",
+      "properties": {
+        "regions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1Region"
+          },
+          "description": "The temporal cloud regions."
         }
       }
     },
@@ -4452,6 +5359,32 @@
         }
       },
       "description": "System capability details."
+    },
+    "v1GetUserResponse": {
+      "type": "object",
+      "properties": {
+        "user": {
+          "$ref": "#/definitions/v1User",
+          "title": "The user"
+        }
+      }
+    },
+    "v1GetUsersResponse": {
+      "type": "object",
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1User"
+          },
+          "title": "The list of users in ascending ids order"
+        },
+        "nextPageToken": {
+          "type": "string",
+          "title": "The next page's token"
+        }
+      }
     },
     "v1GetWorkerBuildIdCompatibilityResponse": {
       "type": "object",
@@ -4835,6 +5768,31 @@
       },
       "description": "IntervalSpec matches times that can be expressed as:\nepoch + n * interval + phase\nwhere n is an integer.\nphase defaults to zero if missing. interval is required.\nBoth interval and phase must be non-negative and are truncated to the nearest\nsecond before any calculations.\nFor example, an interval of 1 hour with phase of zero would match every hour,\non the hour. The same interval but a phase of 19 minutes would match every\nxx:19:00. An interval of 28 days with phase zero would match\n2022-02-17T00:00:00Z (among other times). The same interval with a phase of 3\ndays, 5 hours, and 23 minutes would match 2022-02-20T05:23:00Z instead."
     },
+    "v1Invitation": {
+      "type": "object",
+      "properties": {
+        "createdTime": {
+          "type": "string",
+          "format": "date-time",
+          "title": "The date and time when the user was created"
+        },
+        "expiredTime": {
+          "type": "string",
+          "format": "date-time",
+          "title": "The date and time when the invitation expires or has expired"
+        }
+      }
+    },
+    "v1Limits": {
+      "type": "object",
+      "properties": {
+        "actionsPerSecondLimit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of actions per second (APS) that is currently allowed for the namespace.\nThe namespace may be throttled if its APS exceeds the limit."
+        }
+      }
+    },
     "v1ListArchivedWorkflowExecutionsResponse": {
       "type": "object",
       "properties": {
@@ -5156,6 +6114,87 @@
         }
       }
     },
+    "v1MtlsAuthSpec": {
+      "type": "object",
+      "properties": {
+        "acceptedClientCa": {
+          "type": "string",
+          "description": "The base64 encoded ca cert(s) in PEM format that the clients can use for authentication and authorization.\nThis must only be one value, but the CA can have a chain.\n"
+        },
+        "certificateFilters": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1CertificateFilterSpec"
+          },
+          "description": "Certificate filters which, if specified, only allow connections from client certificates whose distinguished name properties match at least one of the filters.\nThis allows limiting access to specific end-entity certificates.\nOptional, default is empty."
+        }
+      }
+    },
+    "v1Namespace": {
+      "type": "object",
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "description": "The namespace identifier."
+        },
+        "resourceVersion": {
+          "type": "string",
+          "description": "The current version of the namespace specification.\nThe next update operation will have to include this version."
+        },
+        "spec": {
+          "$ref": "#/definitions/v1NamespaceSpec",
+          "description": "The namespace specification."
+        },
+        "state": {
+          "type": "string",
+          "description": "The current state of the namespace."
+        },
+        "asyncOperationId": {
+          "type": "string",
+          "description": "The id of the async operation that is creating/updating/deleting the namespace, if any."
+        },
+        "endpoints": {
+          "$ref": "#/definitions/v1Endpoints",
+          "description": "The endpoints for the namespace."
+        },
+        "activeRegion": {
+          "type": "string",
+          "description": "The currently active region for the namespace."
+        },
+        "limits": {
+          "$ref": "#/definitions/v1Limits",
+          "description": "The limits set on the namespace currently."
+        },
+        "privateConnectivities": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1PrivateConnectivity"
+          },
+          "description": "The private connectivities for the namespace, if any."
+        },
+        "createdTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date and time when the namespace was created."
+        },
+        "lastModifiedTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date and time when the namespace was last modified.\nWill not be set if the namespace has never been modified."
+        }
+      }
+    },
+    "v1NamespaceAccess": {
+      "type": "object",
+      "properties": {
+        "permission": {
+          "type": "string",
+          "title": "The permission to the namespace, should be one of [admin, write, read]\nadmin - gives full access to the namespace, including assigning namespace access to other users\nwrite - gives write access to the namespace configuration and workflows within the namespace\nread - gives read only access to the namespace configuration and workflows within the namespace"
+        }
+      }
+    },
     "v1NamespaceConfig": {
       "type": "object",
       "properties": {
@@ -5265,6 +6304,42 @@
         },
         "state": {
           "$ref": "#/definitions/v1ReplicationState"
+        }
+      }
+    },
+    "v1NamespaceSpec": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name to use for the namespace.\nThis will create a namespace that's available at '<name>.<account>.tmprl.cloud:7233'.\nThe name is immutable. Once set, it cannot be changed."
+        },
+        "regions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The ids of the regions where the namespace should be available.\nSpecifying more than one region makes the namespace \"global\", which is currently a preview only feature with restricted access.\nPlease reach out to Temporal support for more information on global namespaces.\nWhen provisioned the global namespace will be active on the first region in the list and passive on the rest.\nNumber of supported regions is 2. \nThe regions is immutable. Once set, it cannot be changed."
+        },
+        "retentionDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of days the workflows data will be retained for.\nChanges to the retention period may impact your storage costs.\nAny changes to the retention period will be applied to all new running workflows."
+        },
+        "mtlsAuth": {
+          "$ref": "#/definitions/v1MtlsAuthSpec",
+          "description": "The mtls authentication and authorization to enforce on the namespace."
+        },
+        "customSearchAttributes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The custom search attributes to use for the namespace.\nThe name of the attribute is the key and the type is the value.\nSupported attribute types: text, keyword, int, double, bool, datetime, keyword_list.\nNOTE: currently deleting a search attribute is not supported.\nOptional, default is empty."
+        },
+        "codecServer": {
+          "$ref": "#/definitions/v1CodecServerSpec",
+          "description": "Codec server spec used by UI to decode payloads for all users interacting with this namespace.\nOptional, default is unset."
         }
       }
     },
@@ -5731,6 +6806,19 @@
         }
       }
     },
+    "v1PrivateConnectivity": {
+      "type": "object",
+      "properties": {
+        "region": {
+          "type": "string",
+          "description": "The id of the region where the private connectivity applies."
+        },
+        "awsPrivateLink": {
+          "$ref": "#/definitions/v1AWSPrivateLinkInfo",
+          "description": "The AWS PrivateLink info.\nThis will only be set for an aws region."
+        }
+      }
+    },
     "v1ProtocolMessageCommandAttributes": {
       "type": "object",
       "properties": {
@@ -5838,6 +6926,27 @@
         }
       }
     },
+    "v1Region": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The id of the temporal cloud region."
+        },
+        "cloudProvider": {
+          "type": "string",
+          "description": "The name of the cloud provider that's hosting the region.\nCurrently only \"aws\" is supported."
+        },
+        "cloudProviderRegion": {
+          "type": "string",
+          "description": "The region identifier as defined by the cloud provider."
+        },
+        "location": {
+          "type": "string",
+          "description": "The human readable location of the region."
+        }
+      }
+    },
     "v1RegisterNamespaceRequest": {
       "type": "object",
       "properties": {
@@ -5916,6 +7025,15 @@
     },
     "v1RemoveSearchAttributesResponse": {
       "type": "object"
+    },
+    "v1RenameCustomSearchAttributeResponse": {
+      "type": "object",
+      "properties": {
+        "asyncOperation": {
+          "$ref": "#/definitions/v1AsyncOperation",
+          "description": "The async operation."
+        }
+      }
     },
     "v1ReplicationState": {
       "type": "string",
@@ -6679,6 +7797,15 @@
         }
       }
     },
+    "v1SetUserNamespaceAccessResponse": {
+      "type": "object",
+      "properties": {
+        "asyncOperation": {
+          "$ref": "#/definitions/v1AsyncOperation",
+          "title": "The async operation"
+        }
+      }
+    },
     "v1Severity": {
       "type": "string",
       "enum": [
@@ -7421,27 +8548,6 @@
         }
       }
     },
-    "v1UpdateNamespaceResponse": {
-      "type": "object",
-      "properties": {
-        "namespaceInfo": {
-          "$ref": "#/definitions/v1NamespaceInfo"
-        },
-        "config": {
-          "$ref": "#/definitions/v1NamespaceConfig"
-        },
-        "replicationConfig": {
-          "$ref": "#/definitions/v1NamespaceReplicationConfig"
-        },
-        "failoverVersion": {
-          "type": "string",
-          "format": "int64"
-        },
-        "isGlobalNamespace": {
-          "type": "boolean"
-        }
-      }
-    },
     "v1UpdateNexusIncomingServiceResponse": {
       "type": "object",
       "properties": {
@@ -7483,6 +8589,15 @@
     },
     "v1UpdateScheduleResponse": {
       "type": "object"
+    },
+    "v1UpdateUserResponse": {
+      "type": "object",
+      "properties": {
+        "asyncOperation": {
+          "$ref": "#/definitions/v1AsyncOperation",
+          "title": "The async operation"
+        }
+      }
     },
     "v1UpdateWorkerBuildIdCompatibilityResponse": {
       "type": "object"
@@ -7533,6 +8648,58 @@
         },
         "searchAttributes": {
           "$ref": "#/definitions/v1SearchAttributes"
+        }
+      }
+    },
+    "v1User": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "The id of the user"
+        },
+        "resourceVersion": {
+          "type": "string",
+          "title": "The current version of the user specification\nThe next update operation will have to include this version"
+        },
+        "spec": {
+          "$ref": "#/definitions/v1UserSpec",
+          "title": "The user specification"
+        },
+        "state": {
+          "type": "string",
+          "title": "The current state of the user"
+        },
+        "asyncOperationId": {
+          "type": "string",
+          "title": "The id of the async operation that is creating/updating/deleting the user, if any"
+        },
+        "invitation": {
+          "$ref": "#/definitions/v1Invitation",
+          "title": "The details of the open invitation sent to the user, if any"
+        },
+        "createdTime": {
+          "type": "string",
+          "format": "date-time",
+          "title": "The date and time when the user was created"
+        },
+        "lastModifiedTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date and time when the user was last modified\nWill not be set if the user has never been modified."
+        }
+      }
+    },
+    "v1UserSpec": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "title": "The email address associated to the user"
+        },
+        "access": {
+          "$ref": "#/definitions/v1Access",
+          "title": "The access to assigned to the user"
         }
       }
     },
@@ -8207,6 +9374,30 @@
         }
       },
       "title": "Answer to a `WorkflowQuery`"
+    },
+    "v1WorkflowServiceUpdateNamespaceBody": {
+      "type": "object",
+      "properties": {
+        "updateInfo": {
+          "$ref": "#/definitions/v1UpdateNamespaceInfo"
+        },
+        "config": {
+          "$ref": "#/definitions/v1NamespaceConfig"
+        },
+        "replicationConfig": {
+          "$ref": "#/definitions/v1NamespaceReplicationConfig"
+        },
+        "securityToken": {
+          "type": "string"
+        },
+        "deleteBadBinary": {
+          "type": "string"
+        },
+        "promoteNamespace": {
+          "type": "boolean",
+          "description": "promote local namespace to global namespace. Ignored if namespace is already global namespace."
+        }
+      }
     },
     "v1WorkflowTaskCompletedEventAttributes": {
       "type": "object",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -6,6 +6,468 @@ info:
   title: ""
   version: 0.0.1
 paths:
+  /api/v1/cloud/namespaces:
+    get:
+      tags:
+        - CloudService
+      description: Get all namespaces
+      operationId: GetNamespaces
+      parameters:
+        - name: pageSize
+          in: query
+          description: "The requested size of the page to retrieve.\n Cannot exceed 1000. \n Optional, defaults to 100."
+          schema:
+            type: integer
+            format: int32
+        - name: pageToken
+          in: query
+          description: |-
+            The page token if this is continuing from another response.
+             Optional, defaults to empty.
+          schema:
+            type: string
+        - name: name
+          in: query
+          description: |-
+            Filter namespaces by their name.
+             Optional, defaults to empty.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetNamespacesResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+    post:
+      tags:
+        - CloudService
+      description: Create a new namespace
+      operationId: CreateNamespace
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateNamespaceRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateNamespaceResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/cloud/namespaces/{namespace}:
+    get:
+      tags:
+        - CloudService
+      description: Get a namespace
+      operationId: GetNamespace
+      parameters:
+        - name: namespace
+          in: path
+          description: The namespace to get.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetNamespaceResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+    post:
+      tags:
+        - CloudService
+      description: Update a namespace
+      operationId: UpdateNamespace
+      parameters:
+        - name: namespace
+          in: path
+          description: The namespace to update.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateNamespaceRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateNamespaceResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+    delete:
+      tags:
+        - CloudService
+      description: Delete a namespace
+      operationId: DeleteNamespace
+      parameters:
+        - name: namespace
+          in: path
+          description: The namespace to delete.
+          required: true
+          schema:
+            type: string
+        - name: resourceVersion
+          in: query
+          description: |-
+            The version of the namespace for which this delete is intended for.
+             The latest version can be found in the namespace status.
+          schema:
+            type: string
+        - name: asyncOperationId
+          in: query
+          description: |-
+            The id to use for this async operation.
+             Optional, if not provided a random id will be generated.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteNamespaceResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/cloud/namespaces/{namespace}/rename-custom-search-attribute:
+    post:
+      tags:
+        - CloudService
+      description: Rename an existing customer search attribute
+      operationId: RenameCustomSearchAttribute
+      parameters:
+        - name: namespace
+          in: path
+          description: The namespace to rename the custom search attribute for.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RenameCustomSearchAttributeRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenameCustomSearchAttributeResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/cloud/namespaces/{namespace}/users/{userId}/access:
+    post:
+      tags:
+        - CloudService
+      description: Set a user's access to a namespace
+      operationId: SetUserNamespaceAccess
+      parameters:
+        - name: namespace
+          in: path
+          description: The namespace to set permissions for
+          required: true
+          schema:
+            type: string
+        - name: userId
+          in: path
+          description: The id of the user to set permissions for
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetUserNamespaceAccessRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SetUserNamespaceAccessResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/cloud/operations/{asyncOperationId}:
+    get:
+      tags:
+        - CloudService
+      description: Get the latest information on an async operation
+      operationId: GetAsyncOperation
+      parameters:
+        - name: asyncOperationId
+          in: path
+          description: The id of the async operation to get
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetAsyncOperationResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/cloud/regions:
+    get:
+      tags:
+        - CloudService
+      description: Get all regions
+      operationId: GetRegions
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetRegionsResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/cloud/regions/{region}:
+    get:
+      tags:
+        - CloudService
+      description: Get a region
+      operationId: GetRegion
+      parameters:
+        - name: region
+          in: path
+          description: The id of the region to get.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetRegionResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/cloud/users:
+    get:
+      tags:
+        - CloudService
+      description: Gets all known users
+      operationId: GetUsers
+      parameters:
+        - name: pageSize
+          in: query
+          description: |-
+            The requested size of the page to retrieve - optional.
+             Cannot exceed 1000. Defaults to 100.
+          schema:
+            type: integer
+            format: int32
+        - name: pageToken
+          in: query
+          description: The page token if this is continuing from another response - optional.
+          schema:
+            type: string
+        - name: email
+          in: query
+          description: Filter users by email address - optional.
+          schema:
+            type: string
+        - name: namespace
+          in: query
+          description: Filter users by the namespace they have access to - optional.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetUsersResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+    post:
+      tags:
+        - CloudService
+      description: Create a user
+      operationId: CreateUser
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateUserRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateUserResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/cloud/users/{userId}:
+    get:
+      tags:
+        - CloudService
+      description: Get a user
+      operationId: GetUser
+      parameters:
+        - name: userId
+          in: path
+          description: The id of the user to get
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetUserResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+    post:
+      tags:
+        - CloudService
+      description: Update a user
+      operationId: UpdateUser
+      parameters:
+        - name: userId
+          in: path
+          description: The id of the user to update
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateUserRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateUserResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+    delete:
+      tags:
+        - CloudService
+      description: Delete a user
+      operationId: DeleteUser
+      parameters:
+        - name: userId
+          in: path
+          description: The id of the user to delete
+          required: true
+          schema:
+            type: string
+        - name: resourceVersion
+          in: query
+          description: |-
+            The version of the user for which this delete is intended for
+             The latest version can be found in the GetUser operation response
+          schema:
+            type: string
+        - name: asyncOperationId
+          in: query
+          description: The id to use for this async operation - optional
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteUserResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
   /api/v1/cluster-info:
     get:
       tags:
@@ -1699,6 +2161,43 @@ paths:
                 $ref: '#/components/schemas/Status'
 components:
   schemas:
+    AWSPrivateLinkInfo:
+      type: object
+      properties:
+        allowedPrincipalArns:
+          type: array
+          items:
+            type: string
+          description: The list of principal arns that are allowed to access the namespace on the private link.
+        vpcEndpointServiceNames:
+          type: array
+          items:
+            type: string
+          description: The list of vpc endpoint service names that are associated with the namespace.
+    Access:
+      type: object
+      properties:
+        accountAccess:
+          allOf:
+            - $ref: '#/components/schemas/AccountAccess'
+          description: The account access
+        namespaceAccesses:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/NamespaceAccess'
+          description: |-
+            The map of namespace accesses
+             The key is the namespace name and the value is the access to the namespace
+    AccountAccess:
+      type: object
+      properties:
+        role:
+          type: string
+          description: |-
+            The role on the account, should be one of [admin, developer, read]
+             admin - gives full access the account, including users and namespaces
+             developer - gives access to create namespaces on the account
+             read - gives read only access to the account
     ActivityFailureInfo:
       type: object
       properties:
@@ -1976,6 +2475,39 @@ components:
              defined by the policy.
              ATTENTION: this value will be ignored if set for failures produced by
              the workflow.
+    AsyncOperation:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The operation id
+        state:
+          type: string
+          description: |-
+            The current state of this operation
+             Possible values are: pending, in_progress, failed, cancelled, fulfilled
+        checkDuration:
+          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+          type: string
+          description: The recommended duration to check back for an update in the operation's state
+        operationType:
+          type: string
+          description: The type of operation being performed
+        operationInput:
+          allOf:
+            - $ref: '#/components/schemas/GoogleProtobufAny'
+          description: The input to the operation being performed
+        failureReason:
+          type: string
+          description: If the operation failed, the reason for the failure
+        startedTime:
+          type: string
+          description: The date and time when the operation initiated
+          format: date-time
+        finishedTime:
+          type: string
+          description: The date and time when the operation completed
+          format: date-time
     BackfillRequest:
       type: object
       properties:
@@ -2260,6 +2792,29 @@ components:
       properties:
         details:
           $ref: '#/components/schemas/Payloads'
+    CertificateFilterSpec:
+      type: object
+      properties:
+        commonName:
+          type: string
+          description: |-
+            The common_name in the certificate.
+             Optional, default is empty.
+        organization:
+          type: string
+          description: |-
+            The organization in the certificate.
+             Optional, default is empty.
+        organizationalUnit:
+          type: string
+          description: |-
+            The organizational_unit in the certificate.
+             Optional, default is empty.
+        subjectAlternativeName:
+          type: string
+          description: |-
+            The subject_alternative_name in the certificate.
+             Optional, default is empty.
     ChildWorkflowExecutionCanceledEventAttributes:
       type: object
       properties:
@@ -2439,6 +2994,18 @@ components:
       properties:
         clusterName:
           type: string
+    CodecServerSpec:
+      type: object
+      properties:
+        endpoint:
+          type: string
+          description: The codec server endpoint.
+        passAccessToken:
+          type: boolean
+          description: Whether to pass the user access token with your endpoint.
+        includeCrossOriginCredentials:
+          type: boolean
+          description: Whether to include cross-origin credentials.
     CompatibleVersionSet:
       type: object
       properties:
@@ -2477,6 +3044,28 @@ components:
             $ref: '#/components/schemas/Payload'
         count:
           type: string
+    CreateNamespaceRequest:
+      type: object
+      properties:
+        spec:
+          allOf:
+            - $ref: '#/components/schemas/NamespaceSpec'
+          description: The namespace specification.
+        asyncOperationId:
+          type: string
+          description: |-
+            The id to use for this async operation.
+             Optional, if not provided a random id will be generated.
+    CreateNamespaceResponse:
+      type: object
+      properties:
+        namespace:
+          type: string
+          description: The namespace that was created.
+        asyncOperation:
+          allOf:
+            - $ref: '#/components/schemas/AsyncOperation'
+          description: The async operation.
     CreateScheduleRequest:
       type: object
       properties:
@@ -2512,6 +3101,26 @@ components:
         conflictToken:
           type: string
           format: bytes
+    CreateUserRequest:
+      type: object
+      properties:
+        spec:
+          allOf:
+            - $ref: '#/components/schemas/UserSpec'
+          description: The spec for the user to invite
+        asyncOperationId:
+          type: string
+          description: The id to use for this async operation - optional
+    CreateUserResponse:
+      type: object
+      properties:
+        userId:
+          type: string
+          description: The id of the user that was invited
+        asyncOperation:
+          allOf:
+            - $ref: '#/components/schemas/AsyncOperation'
+          description: The async operation
     DataBlob:
       type: object
       properties:
@@ -2525,9 +3134,22 @@ components:
         data:
           type: string
           format: bytes
+    DeleteNamespaceResponse:
+      type: object
+      properties:
+        deletedNamespace:
+          type: string
+          description: Temporary namespace name that is used during reclaim resources step.
     DeleteScheduleResponse:
       type: object
       properties: {}
+    DeleteUserResponse:
+      type: object
+      properties:
+        asyncOperation:
+          allOf:
+            - $ref: '#/components/schemas/AsyncOperation'
+          description: The async operation
     DescribeBatchOperationResponse:
       type: object
       properties:
@@ -2658,6 +3280,15 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CallbackInfo'
+    Endpoints:
+      type: object
+      properties:
+        webAddress:
+          type: string
+          description: The web ui address.
+        grpcAddress:
+          type: string
+          description: The grpc hostport address that the temporal workers, clients and tctl connect to.
     ExternalWorkflowExecutionCancelRequestedEventAttributes:
       type: object
       properties:
@@ -2737,6 +3368,13 @@ components:
           $ref: '#/components/schemas/ActivityFailureInfo'
         childWorkflowExecutionFailureInfo:
           $ref: '#/components/schemas/ChildWorkflowExecutionFailureInfo'
+    GetAsyncOperationResponse:
+      type: object
+      properties:
+        asyncOperation:
+          allOf:
+            - $ref: '#/components/schemas/AsyncOperation'
+          description: The async operation
     GetClusterInfoResponse:
       type: object
       properties:
@@ -2763,6 +3401,39 @@ components:
         visibilityStore:
           type: string
       description: GetClusterInfoResponse contains information about Temporal cluster.
+    GetNamespaceResponse:
+      type: object
+      properties:
+        namespace:
+          allOf:
+            - $ref: '#/components/schemas/Namespace'
+          description: The namespace.
+    GetNamespacesResponse:
+      type: object
+      properties:
+        namespaces:
+          type: array
+          items:
+            $ref: '#/components/schemas/Namespace'
+          description: The list of namespaces in ascending name order.
+        nextPageToken:
+          type: string
+          description: The next page's token.
+    GetRegionResponse:
+      type: object
+      properties:
+        region:
+          allOf:
+            - $ref: '#/components/schemas/Region'
+          description: The temporal cloud region.
+    GetRegionsResponse:
+      type: object
+      properties:
+        regions:
+          type: array
+          items:
+            $ref: '#/components/schemas/Region'
+          description: The temporal cloud regions.
     GetSystemInfoResponse:
       type: object
       properties:
@@ -2817,6 +3488,24 @@ components:
           type: boolean
           description: True if the server supports count group by execution status
       description: System capability details.
+    GetUserResponse:
+      type: object
+      properties:
+        user:
+          allOf:
+            - $ref: '#/components/schemas/User'
+          description: The user
+    GetUsersResponse:
+      type: object
+      properties:
+        users:
+          type: array
+          items:
+            $ref: '#/components/schemas/User'
+          description: The list of users in ascending ids order
+        nextPageToken:
+          type: string
+          description: The next page's token
     GetWorkerBuildIdCompatibilityResponse:
       type: object
       properties:
@@ -3107,6 +3796,26 @@ components:
          xx:19:00. An interval of 28 days with phase zero would match
          2022-02-17T00:00:00Z (among other times). The same interval with a phase of 3
          days, 5 hours, and 23 minutes would match 2022-02-20T05:23:00Z instead.
+    Invitation:
+      type: object
+      properties:
+        createdTime:
+          type: string
+          description: The date and time when the user was created
+          format: date-time
+        expiredTime:
+          type: string
+          description: The date and time when the invitation expires or has expired
+          format: date-time
+    Limits:
+      type: object
+      properties:
+        actionsPerSecondLimit:
+          type: integer
+          description: |-
+            The number of actions per second (APS) that is currently allowed for the namespace.
+             The namespace may be throttled if its APS exceeds the limit.
+          format: int32
     ListArchivedWorkflowExecutionsResponse:
       type: object
       properties:
@@ -3280,6 +3989,79 @@ components:
                  aip.dev/not-precedent: Negative values make no sense to represent. --)
           format: uint32
       description: Metadata relevant for metering purposes
+    MtlsAuthSpec:
+      type: object
+      properties:
+        acceptedClientCa:
+          type: string
+          description: |-
+            The base64 encoded ca cert(s) in PEM format that the clients can use for authentication and authorization.
+             This must only be one value, but the CA can have a chain.
+        certificateFilters:
+          type: array
+          items:
+            $ref: '#/components/schemas/CertificateFilterSpec'
+          description: |-
+            Certificate filters which, if specified, only allow connections from client certificates whose distinguished name properties match at least one of the filters.
+             This allows limiting access to specific end-entity certificates.
+             Optional, default is empty.
+    Namespace:
+      type: object
+      properties:
+        namespace:
+          type: string
+          description: The namespace identifier.
+        resourceVersion:
+          type: string
+          description: |-
+            The current version of the namespace specification.
+             The next update operation will have to include this version.
+        spec:
+          allOf:
+            - $ref: '#/components/schemas/NamespaceSpec'
+          description: The namespace specification.
+        state:
+          type: string
+          description: The current state of the namespace.
+        asyncOperationId:
+          type: string
+          description: The id of the async operation that is creating/updating/deleting the namespace, if any.
+        endpoints:
+          allOf:
+            - $ref: '#/components/schemas/Endpoints'
+          description: The endpoints for the namespace.
+        activeRegion:
+          type: string
+          description: The currently active region for the namespace.
+        limits:
+          allOf:
+            - $ref: '#/components/schemas/Limits'
+          description: The limits set on the namespace currently.
+        privateConnectivities:
+          type: array
+          items:
+            $ref: '#/components/schemas/PrivateConnectivity'
+          description: The private connectivities for the namespace, if any.
+        createdTime:
+          type: string
+          description: The date and time when the namespace was created.
+          format: date-time
+        lastModifiedTime:
+          type: string
+          description: |-
+            The date and time when the namespace was last modified.
+             Will not be set if the namespace has never been modified.
+          format: date-time
+    NamespaceAccess:
+      type: object
+      properties:
+        permission:
+          type: string
+          description: |-
+            The permission to the namespace, should be one of [admin, write, read]
+             admin - gives full access to the namespace, including assigning namespace access to other users
+             write - gives write access to the namespace configuration and workflows within the namespace
+             read - gives read only access to the namespace configuration and workflows within the namespace
     NamespaceConfig:
       type: object
       properties:
@@ -3375,6 +4157,47 @@ components:
             - REPLICATION_STATE_HANDOVER
           type: string
           format: enum
+    NamespaceSpec:
+      type: object
+      properties:
+        name:
+          type: string
+          description: |-
+            The name to use for the namespace.
+             This will create a namespace that's available at '<name>.<account>.tmprl.cloud:7233'.
+             The name is immutable. Once set, it cannot be changed.
+        regions:
+          type: array
+          items:
+            type: string
+          description: "The ids of the regions where the namespace should be available.\n Specifying more than one region makes the namespace \"global\", which is currently a preview only feature with restricted access.\n Please reach out to Temporal support for more information on global namespaces.\n When provisioned the global namespace will be active on the first region in the list and passive on the rest.\n Number of supported regions is 2. \n The regions is immutable. Once set, it cannot be changed."
+        retentionDays:
+          type: integer
+          description: |-
+            The number of days the workflows data will be retained for.
+             Changes to the retention period may impact your storage costs.
+             Any changes to the retention period will be applied to all new running workflows.
+          format: int32
+        mtlsAuth:
+          allOf:
+            - $ref: '#/components/schemas/MtlsAuthSpec'
+          description: The mtls authentication and authorization to enforce on the namespace.
+        customSearchAttributes:
+          type: object
+          additionalProperties:
+            type: string
+          description: |-
+            The custom search attributes to use for the namespace.
+             The name of the attribute is the key and the type is the value.
+             Supported attribute types: text, keyword, int, double, bool, datetime, keyword_list.
+             NOTE: currently deleting a search attribute is not supported.
+             Optional, default is empty.
+        codecServer:
+          allOf:
+            - $ref: '#/components/schemas/CodecServerSpec'
+          description: |-
+            Codec server spec used by UI to decode payloads for all users interacting with this namespace.
+             Optional, default is unset.
     NewWorkflowExecutionInfo:
       type: object
       properties:
@@ -3649,6 +4472,18 @@ components:
           description: |-
             If a worker has opted into the worker versioning feature while polling, its capabilities will
              appear here.
+    PrivateConnectivity:
+      type: object
+      properties:
+        region:
+          type: string
+          description: The id of the region where the private connectivity applies.
+        awsPrivateLink:
+          allOf:
+            - $ref: '#/components/schemas/AWSPrivateLinkInfo'
+          description: |-
+            The AWS PrivateLink info.
+             This will only be set for an aws region.
     QueryRejected:
       type: object
       properties:
@@ -3765,6 +4600,23 @@ components:
           description: |-
             Will be set to true if the activity has been asked to cancel itself. The SDK should then
              notify the activity of cancellation if it is still running.
+    Region:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The id of the temporal cloud region.
+        cloudProvider:
+          type: string
+          description: |-
+            The name of the cloud provider that's hosting the region.
+             Currently only "aws" is supported.
+        cloudProviderRegion:
+          type: string
+          description: The region identifier as defined by the cloud provider.
+        location:
+          type: string
+          description: The human readable location of the region.
     RegisterNamespaceRequest:
       type: object
       properties:
@@ -3826,6 +4678,35 @@ components:
         notes:
           type: string
       description: ReleaseInfo contains information about specific version of temporal.
+    RenameCustomSearchAttributeRequest:
+      type: object
+      properties:
+        namespace:
+          type: string
+          description: The namespace to rename the custom search attribute for.
+        existingCustomSearchAttributeName:
+          type: string
+          description: The existing name of the custom search attribute to be renamed.
+        newCustomSearchAttributeName:
+          type: string
+          description: The new name of the custom search attribute.
+        resourceVersion:
+          type: string
+          description: |-
+            The version of the namespace for which this update is intended for.
+             The latest version can be found in the namespace status.
+        asyncOperationId:
+          type: string
+          description: |-
+            The id to use for this async operation.
+             Optional, if not provided a random id will be generated.
+    RenameCustomSearchAttributeResponse:
+      type: object
+      properties:
+        asyncOperation:
+          allOf:
+            - $ref: '#/components/schemas/AsyncOperation'
+          description: The async operation.
     Request:
       type: object
       properties:
@@ -4595,6 +5476,34 @@ components:
       properties:
         nonRetryable:
           type: boolean
+    SetUserNamespaceAccessRequest:
+      type: object
+      properties:
+        namespace:
+          type: string
+          description: The namespace to set permissions for
+        userId:
+          type: string
+          description: The id of the user to set permissions for
+        access:
+          allOf:
+            - $ref: '#/components/schemas/NamespaceAccess'
+          description: The namespace access to assign the user
+        resourceVersion:
+          type: string
+          description: |-
+            The version of the user for which this update is intended for
+             The latest version can be found in the GetUser operation response
+        asyncOperationId:
+          type: string
+          description: The id to use for this async operation - optional
+    SetUserNamespaceAccessResponse:
+      type: object
+      properties:
+        asyncOperation:
+          allOf:
+            - $ref: '#/components/schemas/AsyncOperation'
+          description: The async operation
     SignalExternalWorkflowExecutionFailedEventAttributes:
       type: object
       properties:
@@ -5414,6 +6323,31 @@ components:
     UpdateScheduleResponse:
       type: object
       properties: {}
+    UpdateUserRequest:
+      type: object
+      properties:
+        userId:
+          type: string
+          description: The id of the user to update
+        spec:
+          allOf:
+            - $ref: '#/components/schemas/UserSpec'
+          description: The new user specification
+        resourceVersion:
+          type: string
+          description: |-
+            The version of the user for which this update is intended for
+             The latest version can be found in the GetUser operation response
+        asyncOperationId:
+          type: string
+          description: The id to use for this async operation - optional
+    UpdateUserResponse:
+      type: object
+      properties:
+        asyncOperation:
+          allOf:
+            - $ref: '#/components/schemas/AsyncOperation'
+          description: The async operation
     UpdateWorkflowExecutionRequest:
       type: object
       properties:
@@ -5486,6 +6420,51 @@ components:
           description: The `WORKFLOW_TASK_COMPLETED` event which this command was reported with
         searchAttributes:
           $ref: '#/components/schemas/SearchAttributes'
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The id of the user
+        resourceVersion:
+          type: string
+          description: |-
+            The current version of the user specification
+             The next update operation will have to include this version
+        spec:
+          allOf:
+            - $ref: '#/components/schemas/UserSpec'
+          description: The user specification
+        state:
+          type: string
+          description: The current state of the user
+        asyncOperationId:
+          type: string
+          description: The id of the async operation that is creating/updating/deleting the user, if any
+        invitation:
+          allOf:
+            - $ref: '#/components/schemas/Invitation'
+          description: The details of the open invitation sent to the user, if any
+        createdTime:
+          type: string
+          description: The date and time when the user was created
+          format: date-time
+        lastModifiedTime:
+          type: string
+          description: |-
+            The date and time when the user was last modified
+             Will not be set if the user has never been modified.
+          format: date-time
+    UserSpec:
+      type: object
+      properties:
+        email:
+          type: string
+          description: The email address associated to the user
+        access:
+          allOf:
+            - $ref: '#/components/schemas/Access'
+          description: The access to assigned to the user
     VersionInfo:
       type: object
       properties:
@@ -6279,6 +7258,7 @@ components:
         Represents the identifier used by a workflow author to define the workflow. Typically, the
          name of a function. This is sometimes referred to as the workflow's "name"
 tags:
+  - name: CloudService
   - name: OperatorService
     description: |-
       OperatorService API defines how Temporal SDKs and other clients interact with the Temporal server

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -2506,9 +2506,6 @@ components:
           description: Memo and search attributes to attach to the schedule itself.
         searchAttributes:
           $ref: '#/components/schemas/SearchAttributes'
-      description: |-
-        (-- api-linter: core::0203::optional=disabled
-             aip.dev/not-precedent: field_behavior annotation not available in our gogo fork --)
     CreateScheduleResponse:
       type: object
       properties:
@@ -5426,10 +5423,7 @@ components:
         workflowExecution:
           allOf:
             - $ref: '#/components/schemas/WorkflowExecution'
-          description: |-
-            The target workflow id and (optionally) a specific run thereof
-             (-- api-linter: core::0203::optional=disabled
-                 aip.dev/not-precedent: false positive triggered by the word "optional" --)
+          description: The target workflow id and (optionally) a specific run thereof
         firstExecutionRunId:
           type: string
           description: |-

--- a/temporal/api/cloud/cloudservice/v1/request_response.proto
+++ b/temporal/api/cloud/cloudservice/v1/request_response.proto
@@ -1,0 +1,258 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+syntax = "proto3";
+
+package temporal.api.cloud.cloudservice.v1;
+
+option go_package = "go.temporal.io/api/cloud/cloudservice/v1;cloudservice";
+option java_package = "io.temporal.api.cloud.cloudservice.v1";
+option java_multiple_files = true;
+option java_outer_classname = "RequestResponseProto";
+option ruby_package = "Temporalio::Api::Cloud::CloudService::V1";
+option csharp_namespace = "Temporalio.Api.Cloud.CloudService.V1";
+
+import "temporal/api/cloud/operation/v1/message.proto";
+import "temporal/api/cloud/identity/v1/message.proto";
+import "temporal/api/cloud/namespace/v1/message.proto";
+import "temporal/api/cloud/region/v1/message.proto";
+
+message GetUsersRequest {
+    // The requested size of the page to retrieve - optional.
+    // Cannot exceed 1000. Defaults to 100. 
+    int32 page_size = 1;
+    // The page token if this is continuing from another response - optional.
+    string page_token = 2;
+    // Filter users by email address - optional.
+    string email = 3;
+    // Filter users by the namespace they have access to - optional.
+    string namespace = 4;
+}
+
+message GetUsersResponse {
+    // The list of users in ascending ids order
+    repeated temporal.api.cloud.identity.v1.User users = 1;
+    // The next page's token
+    string next_page_token = 2;
+}
+
+message GetUserRequest {
+    // The id of the user to get
+    string user_id = 1;
+}
+
+message GetUserResponse {
+    // The user
+    temporal.api.cloud.identity.v1.User user = 1;
+}
+
+message CreateUserRequest {
+    // The spec for the user to invite
+    temporal.api.cloud.identity.v1.UserSpec spec = 1;
+    // The id to use for this async operation - optional
+    string async_operation_id = 2;
+}
+
+message CreateUserResponse {
+    // The id of the user that was invited
+    string user_id = 1;
+    // The async operation
+    temporal.api.cloud.operation.v1.AsyncOperation async_operation = 2;
+}
+
+message UpdateUserRequest {
+    // The id of the user to update
+    string user_id = 1;
+    // The new user specification
+    temporal.api.cloud.identity.v1.UserSpec spec = 2;
+    // The version of the user for which this update is intended for
+    // The latest version can be found in the GetUser operation response
+    string resource_version = 3;
+    // The id to use for this async operation - optional
+    string async_operation_id = 4;
+}
+
+message UpdateUserResponse {
+    // The async operation
+    temporal.api.cloud.operation.v1.AsyncOperation async_operation = 1;
+}
+
+message DeleteUserRequest {
+    // The id of the user to delete
+    string user_id = 1;
+    // The version of the user for which this delete is intended for
+    // The latest version can be found in the GetUser operation response
+    string resource_version = 2;
+    // The id to use for this async operation - optional
+    string async_operation_id = 3;
+}
+
+message DeleteUserResponse {
+    // The async operation
+    temporal.api.cloud.operation.v1.AsyncOperation async_operation = 1;
+}
+
+message SetUserNamespaceAccessRequest {
+    // The namespace to set permissions for
+    string namespace = 1;
+    // The id of the user to set permissions for
+    string user_id = 2;
+    // The namespace access to assign the user
+    temporal.api.cloud.identity.v1.NamespaceAccess access = 3;
+    // The version of the user for which this update is intended for
+    // The latest version can be found in the GetUser operation response
+    string resource_version = 4;
+    // The id to use for this async operation - optional
+    string async_operation_id = 5;
+}
+
+message SetUserNamespaceAccessResponse {
+    // The async operation
+    temporal.api.cloud.operation.v1.AsyncOperation async_operation = 1;
+}
+
+message GetAsyncOperationRequest {
+    // The id of the async operation to get
+    string async_operation_id = 1;
+}
+
+message GetAsyncOperationResponse {
+    // The async operation
+    temporal.api.cloud.operation.v1.AsyncOperation async_operation = 1;
+}
+
+message CreateNamespaceRequest {
+    // The namespace specification.
+    temporal.api.cloud.namespace.v1.NamespaceSpec spec = 2;
+    // The id to use for this async operation.
+    // Optional, if not provided a random id will be generated.
+    string async_operation_id = 3;
+}
+
+message CreateNamespaceResponse {
+    // The namespace that was created.
+    string namespace = 1;
+    // The async operation.
+    temporal.api.cloud.operation.v1.AsyncOperation async_operation = 2;
+}
+
+message GetNamespacesRequest {
+    // The requested size of the page to retrieve.
+    // Cannot exceed 1000. 
+    // Optional, defaults to 100. 
+    int32 page_size = 1;
+    // The page token if this is continuing from another response.
+    // Optional, defaults to empty.
+    string page_token = 2;
+    // Filter namespaces by their name.
+    // Optional, defaults to empty.
+    string name = 3;
+}
+
+message GetNamespacesResponse {
+    // The list of namespaces in ascending name order.
+    repeated temporal.api.cloud.namespace.v1.Namespace namespaces = 1;
+    // The next page's token.
+    string next_page_token = 2;
+}
+
+message GetNamespaceRequest {
+    // The namespace to get.
+    string namespace = 1;
+}
+
+message GetNamespaceResponse {
+    // The namespace.
+    temporal.api.cloud.namespace.v1.Namespace namespace = 1;
+}
+
+message UpdateNamespaceRequest {
+    // The namespace to update.
+    string namespace = 1;
+    // The new namespace specification.
+    temporal.api.cloud.namespace.v1.NamespaceSpec spec = 2;
+    // The version of the namespace for which this update is intended for.
+    // The latest version can be found in the namespace status.
+    string resource_version = 3;
+    // The id to use for this async operation.
+    // Optional, if not provided a random id will be generated.
+    string async_operation_id = 4;
+}
+
+message UpdateNamespaceResponse {
+    // The async operation.
+    temporal.api.cloud.operation.v1.AsyncOperation async_operation = 1;
+}
+
+message RenameCustomSearchAttributeRequest {
+    // The namespace to rename the custom search attribute for.
+    string namespace = 1;
+    // The existing name of the custom search attribute to be renamed.
+    string existing_custom_search_attribute_name = 2;
+    // The new name of the custom search attribute.
+    string new_custom_search_attribute_name = 3;
+    // The version of the namespace for which this update is intended for.
+    // The latest version can be found in the namespace status.
+    string resource_version = 4;
+    // The id to use for this async operation.
+    // Optional, if not provided a random id will be generated.
+    string async_operation_id = 5;
+}
+
+message RenameCustomSearchAttributeResponse {
+    // The async operation.
+    temporal.api.cloud.operation.v1.AsyncOperation async_operation = 1;
+}
+
+message DeleteNamespaceRequest {
+    // The namespace to delete.
+    string namespace = 1;
+    // The version of the namespace for which this delete is intended for.
+    // The latest version can be found in the namespace status.
+    string resource_version = 2;
+    // The id to use for this async operation.
+    // Optional, if not provided a random id will be generated.
+    string async_operation_id = 3;
+}
+
+message DeleteNamespaceResponse {
+    // The async operation.
+    temporal.api.cloud.operation.v1.AsyncOperation async_operation = 1;
+}
+
+message GetRegionsRequest {
+}
+
+message GetRegionsResponse {
+    // The temporal cloud regions.
+    repeated temporal.api.cloud.region.v1.Region regions = 1;
+}
+
+message GetRegionRequest {
+    // The id of the region to get.
+    string region = 1;
+}
+
+message GetRegionResponse {
+    // The temporal cloud region.
+    temporal.api.cloud.region.v1.Region region = 1;
+}

--- a/temporal/api/cloud/cloudservice/v1/service.proto
+++ b/temporal/api/cloud/cloudservice/v1/service.proto
@@ -38,21 +38,21 @@ service CloudService {
     // Gets all known users
     rpc GetUsers(GetUsersRequest) returns (GetUsersResponse) {
         option (google.api.http) = {
-            get: "/api/v1/users",
+            get: "/api/v1/cloud/users",
         };
     }
     
     // Get a user
     rpc GetUser(GetUserRequest) returns (GetUserResponse) {
         option (google.api.http) = {
-            get: "/api/v1/users/{user_id}",
+            get: "/api/v1/cloud/users/{user_id}",
         };
     }
 
     // Create a user
     rpc CreateUser(CreateUserRequest) returns (CreateUserResponse) {
         option (google.api.http) = {
-            post: "/api/v1/users",
+            post: "/api/v1/cloud/users",
             body: "*"
         };
     }
@@ -60,7 +60,7 @@ service CloudService {
     // Update a user
     rpc UpdateUser(UpdateUserRequest) returns (UpdateUserResponse) {
         option (google.api.http) = {
-            post: "/api/v1/users/{user_id}",
+            post: "/api/v1/cloud/users/{user_id}",
             body: "*"
         };
     }
@@ -68,14 +68,14 @@ service CloudService {
     // Delete a user
     rpc DeleteUser(DeleteUserRequest) returns (DeleteUserResponse) {
         option (google.api.http) = {
-            delete: "/api/v1/users/{user_id}",
+            delete: "/api/v1/cloud/users/{user_id}",
         };
     }
 
     // Set a user's access to a namespace
     rpc SetUserNamespaceAccess(SetUserNamespaceAccessRequest) returns (SetUserNamespaceAccessResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/users/{user_id}/access",
+            post: "/api/v1/cloud/namespaces/{namespace}/users/{user_id}/access",
             body: "*"
         };
     }
@@ -83,14 +83,14 @@ service CloudService {
     // Get the latest information on an async operation
     rpc GetAsyncOperation(GetAsyncOperationRequest) returns (GetAsyncOperationResponse) {
         option (google.api.http) = {
-            get: "/api/v1/operations/{async_operation_id}",
+            get: "/api/v1/cloud/operations/{async_operation_id}",
         };
     }
 
     // Create a new namespace
     rpc CreateNamespace (CreateNamespaceRequest) returns (CreateNamespaceResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces",
+            post: "/api/v1/cloud/namespaces",
             body: "*"
         };
     }
@@ -98,21 +98,21 @@ service CloudService {
     // Get all namespaces
     rpc GetNamespaces (GetNamespacesRequest)  returns (GetNamespacesResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces",
+            get: "/api/v1/cloud/namespaces",
         };
     }
 
     // Get a namespace
     rpc GetNamespace (GetNamespaceRequest) returns (GetNamespaceResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}",
+            get: "/api/v1/cloud/namespaces/{namespace}",
         };
     }
 
     // Update a namespace
     rpc UpdateNamespace (UpdateNamespaceRequest) returns (UpdateNamespaceResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}",
+            post: "/api/v1/cloud/namespaces/{namespace}",
             body: "*"
         };
     }
@@ -120,7 +120,7 @@ service CloudService {
     // Rename an existing customer search attribute
     rpc RenameCustomSearchAttribute (RenameCustomSearchAttributeRequest) returns (RenameCustomSearchAttributeResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/rename-custom-search-attribute",
+            post: "/api/v1/cloud/namespaces/{namespace}/rename-custom-search-attribute",
             body: "*"
         };
     }
@@ -128,21 +128,21 @@ service CloudService {
     // Delete a namespace
     rpc DeleteNamespace (DeleteNamespaceRequest) returns (DeleteNamespaceResponse) {
         option (google.api.http) = {
-            delete: "/api/v1/namespaces/{namespace}",
+            delete: "/api/v1/cloud/namespaces/{namespace}",
         };
     }
 
     // Get all regions
     rpc GetRegions (GetRegionsRequest) returns (GetRegionsResponse) {
         option (google.api.http) = {
-            get: "/api/v1/regions",
+            get: "/api/v1/cloud/regions",
         };
     }
 
     // Get a region
     rpc GetRegion (GetRegionRequest) returns (GetRegionResponse) {
         option (google.api.http) = {
-            get: "/api/v1/regions/{region}",
+            get: "/api/v1/cloud/regions/{region}",
         };
     }
 }

--- a/temporal/api/cloud/cloudservice/v1/service.proto
+++ b/temporal/api/cloud/cloudservice/v1/service.proto
@@ -1,0 +1,148 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+syntax = "proto3";
+
+package temporal.api.cloud.cloudservice.v1;
+
+option go_package = "go.temporal.io/api/cloud/cloudservice/v1;cloudservice";
+option java_package = "io.temporal.api.cloud.cloudservice.v1";
+option java_multiple_files = true;
+option java_outer_classname = "ServiceProto";
+option ruby_package = "Temporalio::Api::Cloud::CloudService::V1";
+option csharp_namespace = "Temporalio.Api.Cloud.CloudService.V1";
+
+import "temporal/api/cloud/cloudservice/v1/request_response.proto";
+import "google/api/annotations.proto";
+
+service CloudService {
+    // Gets all known users
+    rpc GetUsers(GetUsersRequest) returns (GetUsersResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/users",
+        };
+    }
+    
+    // Get a user
+    rpc GetUser(GetUserRequest) returns (GetUserResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/users/{user_id}",
+        };
+    }
+
+    // Create a user
+    rpc CreateUser(CreateUserRequest) returns (CreateUserResponse) {
+        option (google.api.http) = {
+            post: "/api/v1/users",
+            body: "*"
+        };
+    }
+
+    // Update a user
+    rpc UpdateUser(UpdateUserRequest) returns (UpdateUserResponse) {
+        option (google.api.http) = {
+            post: "/api/v1/users/{user_id}",
+            body: "*"
+        };
+    }
+
+    // Delete a user
+    rpc DeleteUser(DeleteUserRequest) returns (DeleteUserResponse) {
+        option (google.api.http) = {
+            delete: "/api/v1/users/{user_id}",
+        };
+    }
+
+    // Set a user's access to a namespace
+    rpc SetUserNamespaceAccess(SetUserNamespaceAccessRequest) returns (SetUserNamespaceAccessResponse) {
+        option (google.api.http) = {
+            post: "/api/v1/namespaces/{namespace}/users/{user_id}/access",
+            body: "*"
+        };
+    }
+
+    // Get the latest information on an async operation
+    rpc GetAsyncOperation(GetAsyncOperationRequest) returns (GetAsyncOperationResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/operations/{async_operation_id}",
+        };
+    }
+
+    // Create a new namespace
+    rpc CreateNamespace (CreateNamespaceRequest) returns (CreateNamespaceResponse) {
+        option (google.api.http) = {
+            post: "/api/v1/namespaces",
+            body: "*"
+        };
+    }
+    
+    // Get all namespaces
+    rpc GetNamespaces (GetNamespacesRequest)  returns (GetNamespacesResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/namespaces",
+        };
+    }
+
+    // Get a namespace
+    rpc GetNamespace (GetNamespaceRequest) returns (GetNamespaceResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/namespaces/{namespace}",
+        };
+    }
+
+    // Update a namespace
+    rpc UpdateNamespace (UpdateNamespaceRequest) returns (UpdateNamespaceResponse) {
+        option (google.api.http) = {
+            post: "/api/v1/namespaces/{namespace}",
+            body: "*"
+        };
+    }
+
+    // Rename an existing customer search attribute
+    rpc RenameCustomSearchAttribute (RenameCustomSearchAttributeRequest) returns (RenameCustomSearchAttributeResponse) {
+        option (google.api.http) = {
+            post: "/api/v1/namespaces/{namespace}/rename-custom-search-attribute",
+            body: "*"
+        };
+    }
+
+    // Delete a namespace
+    rpc DeleteNamespace (DeleteNamespaceRequest) returns (DeleteNamespaceResponse) {
+        option (google.api.http) = {
+            delete: "/api/v1/namespaces/{namespace}",
+        };
+    }
+
+    // Get all regions
+    rpc GetRegions (GetRegionsRequest) returns (GetRegionsResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/regions",
+        };
+    }
+
+    // Get a region
+    rpc GetRegion (GetRegionRequest) returns (GetRegionResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/regions/{region}",
+        };
+    }
+}

--- a/temporal/api/cloud/identity/v1/message.proto
+++ b/temporal/api/cloud/identity/v1/message.proto
@@ -1,0 +1,93 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+syntax = "proto3";
+
+package temporal.api.cloud.identity.v1;
+
+option go_package = "go.temporal.io/api/cloud/identity/v1;identity";
+option java_package = "io.temporal.api.cloud.identity.v1";
+option java_multiple_files = true;
+option java_outer_classname = "MessageProto";
+option ruby_package = "Temporalio::Api::Cloud::Identity::V1";
+option csharp_namespace = "Temporalio.Api.Cloud.Identity.V1";
+
+import "google/protobuf/timestamp.proto";
+
+message AccountAccess {
+    // The role on the account, should be one of [admin, developer, read]
+    // admin - gives full access the account, including users and namespaces
+    // developer - gives access to create namespaces on the account
+    // read - gives read only access to the account
+    string role = 1;
+}
+
+message NamespaceAccess {
+    // The permission to the namespace, should be one of [admin, write, read]
+    // admin - gives full access to the namespace, including assigning namespace access to other users
+    // write - gives write access to the namespace configuration and workflows within the namespace
+    // read - gives read only access to the namespace configuration and workflows within the namespace
+    string permission = 1;
+}
+
+message Access {
+    // The account access
+    AccountAccess account_access = 1;
+    // The map of namespace accesses
+    // The key is the namespace name and the value is the access to the namespace
+    map<string, NamespaceAccess> namespace_accesses = 2;
+}
+
+message UserSpec {
+    // The email address associated to the user
+    string email = 1;
+    // The access to assigned to the user
+    Access access = 2;
+}
+
+message Invitation {
+    // The date and time when the user was created
+    google.protobuf.Timestamp created_time = 1;
+    // The date and time when the invitation expires or has expired
+    google.protobuf.Timestamp expired_time = 2;
+}
+
+message User {
+    // The id of the user
+    string id = 1;
+    // The current version of the user specification
+    // The next update operation will have to include this version
+    string resource_version = 2;
+    // The user specification
+    UserSpec spec = 3;
+    // The current state of the user
+    string state = 4;
+    // The id of the async operation that is creating/updating/deleting the user, if any
+    string async_operation_id = 5;
+    // The details of the open invitation sent to the user, if any
+    Invitation invitation = 6;
+    // The date and time when the user was created
+    google.protobuf.Timestamp created_time = 7;
+    // The date and time when the user was last modified
+    // Will not be set if the user has never been modified.
+    google.protobuf.Timestamp last_modified_time = 8;
+}

--- a/temporal/api/cloud/namespace/v1/message.proto
+++ b/temporal/api/cloud/namespace/v1/message.proto
@@ -1,0 +1,155 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+syntax = "proto3";
+
+package temporal.api.cloud.namespace.v1;
+
+option go_package = "go.temporal.io/api/cloud/namespace/v1;namespace";
+option java_package = "io.temporal.api.cloud.namespace.v1";
+option java_multiple_files = true;
+option java_outer_classname = "MessageProto";
+option ruby_package = "Temporalio::Api::Cloud::Namespace::V1";
+option csharp_namespace = "Temporalio.Api.Cloud.Namespace.V1";
+
+import "google/protobuf/timestamp.proto";
+
+message CertificateFilterSpec {
+    // The common_name in the certificate.
+    // Optional, default is empty.
+    string common_name = 1;
+    // The organization in the certificate.
+    // Optional, default is empty.
+    string organization = 2;
+    // The organizational_unit in the certificate.
+    // Optional, default is empty.
+    string organizational_unit = 3;
+    // The subject_alternative_name in the certificate.
+    // Optional, default is empty.
+    string subject_alternative_name = 4;
+}
+
+message MtlsAuthSpec {
+    // The base64 encoded ca cert(s) in PEM format that the clients can use for authentication and authorization.
+    // This must only be one value, but the CA can have a chain.
+    //
+    // (-- api-linter: core::0140::base64=disabled --)
+    string accepted_client_ca = 1;
+    // Certificate filters which, if specified, only allow connections from client certificates whose distinguished name properties match at least one of the filters.
+    // This allows limiting access to specific end-entity certificates.
+    // Optional, default is empty.
+    repeated CertificateFilterSpec certificate_filters = 2;
+}
+
+message CodecServerSpec {
+    // The codec server endpoint.
+    string endpoint = 1;
+    // Whether to pass the user access token with your endpoint.
+    bool pass_access_token = 2;
+    // Whether to include cross-origin credentials.
+    bool include_cross_origin_credentials = 3;
+}
+
+message NamespaceSpec {
+    // The name to use for the namespace.
+    // This will create a namespace that's available at '<name>.<account>.tmprl.cloud:7233'.
+    // The name is immutable. Once set, it cannot be changed.
+    string name = 1;
+    // The ids of the regions where the namespace should be available.
+    // Specifying more than one region makes the namespace "global", which is currently a preview only feature with restricted access.
+    // Please reach out to Temporal support for more information on global namespaces.
+    // When provisioned the global namespace will be active on the first region in the list and passive on the rest.
+    // Number of supported regions is 2. 
+    // The regions is immutable. Once set, it cannot be changed.
+    repeated string regions = 2;
+    // The number of days the workflows data will be retained for.
+    // Changes to the retention period may impact your storage costs.
+    // Any changes to the retention period will be applied to all new running workflows.
+    int32 retention_days = 3;
+    // The mtls authentication and authorization to enforce on the namespace.
+    MtlsAuthSpec mtls_auth = 4;
+    // The custom search attributes to use for the namespace.
+    // The name of the attribute is the key and the type is the value.
+    // Supported attribute types: text, keyword, int, double, bool, datetime, keyword_list.
+    // NOTE: currently deleting a search attribute is not supported.
+    // Optional, default is empty.
+    map<string, string> custom_search_attributes = 5;
+    // Codec server spec used by UI to decode payloads for all users interacting with this namespace.
+    // Optional, default is unset.
+    CodecServerSpec codec_server = 6;
+}
+
+message Endpoints {
+    // The web ui address.
+    string web_address = 1;
+    // The grpc hostport address that the temporal workers, clients and tctl connect to.
+    string grpc_address = 2;
+}
+
+message Limits {
+    // The number of actions per second (APS) that is currently allowed for the namespace.
+    // The namespace may be throttled if its APS exceeds the limit.
+    int32 actions_per_second_limit = 1;
+}
+
+message AWSPrivateLinkInfo {
+    // The list of principal arns that are allowed to access the namespace on the private link.
+    repeated string allowed_principal_arns = 1;
+    // The list of vpc endpoint service names that are associated with the namespace.
+    repeated string vpc_endpoint_service_names = 2;
+}
+
+
+message PrivateConnectivity {
+    // The id of the region where the private connectivity applies.
+    string region = 1;
+    // The AWS PrivateLink info.
+    // This will only be set for an aws region.
+    AWSPrivateLinkInfo aws_private_link = 2;
+}
+
+message Namespace {
+    // The namespace identifier.
+    string namespace = 1;
+    // The current version of the namespace specification.
+    // The next update operation will have to include this version.
+    string resource_version = 2;
+    // The namespace specification.
+    NamespaceSpec spec = 3;
+    // The current state of the namespace.
+    string state = 4;
+    // The id of the async operation that is creating/updating/deleting the namespace, if any.
+    string async_operation_id = 5;
+    // The endpoints for the namespace.
+    Endpoints endpoints = 6;
+    // The currently active region for the namespace.
+    string active_region = 7;
+    // The limits set on the namespace currently.
+    Limits limits = 8;
+    // The private connectivities for the namespace, if any.
+    repeated PrivateConnectivity private_connectivities = 9;
+    // The date and time when the namespace was created.
+    google.protobuf.Timestamp created_time = 10;
+    // The date and time when the namespace was last modified.
+    // Will not be set if the namespace has never been modified.
+    google.protobuf.Timestamp last_modified_time = 11;
+}

--- a/temporal/api/cloud/operation/v1/message.proto
+++ b/temporal/api/cloud/operation/v1/message.proto
@@ -1,0 +1,58 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+syntax = "proto3";
+
+package temporal.api.cloud.operation.v1;
+
+option go_package = "go.temporal.io/api/cloud/operation/v1;operation";
+option java_package = "io.temporal.api.cloud.operation.v1";
+option java_multiple_files = true;
+option java_outer_classname = "MessageProto";
+option ruby_package = "Temporalio::Api::Cloud::Operation::V1";
+option csharp_namespace = "Temporalio.Api.Cloud.Operation.V1";
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/any.proto";
+
+message AsyncOperation {
+    // The operation id
+    string id = 1;
+    // The current state of this operation
+    // Possible values are: pending, in_progress, failed, cancelled, fulfilled
+    string state = 2;
+    // The recommended duration to check back for an update in the operation's state
+    google.protobuf.Duration check_duration = 3;
+    // The type of operation being performed
+    string operation_type = 4;
+    // The input to the operation being performed
+    //
+    // (-- api-linter: core::0146::any=disabled --)
+    google.protobuf.Any operation_input = 5;
+    // If the operation failed, the reason for the failure
+    string failure_reason = 6;
+    // The date and time when the operation initiated
+    google.protobuf.Timestamp started_time = 7;
+    // The date and time when the operation completed
+    google.protobuf.Timestamp finished_time = 8;
+}

--- a/temporal/api/cloud/region/v1/message.proto
+++ b/temporal/api/cloud/region/v1/message.proto
@@ -1,0 +1,44 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+syntax = "proto3";
+
+package temporal.api.cloud.region.v1;
+
+option go_package = "go.temporal.io/api/cloud/region/v1;region";
+option java_package = "io.temporal.api.cloud.region.v1";
+option java_multiple_files = true;
+option java_outer_classname = "MessageProto";
+option ruby_package = "Temporalio::Api::Cloud::Region::V1";
+option csharp_namespace = "Temporalio.Api.Cloud.Region.V1";
+
+message Region {
+    // The id of the temporal cloud region.
+    string id = 1;
+    // The name of the cloud provider that's hosting the region.
+    // Currently only "aws" is supported.
+    string cloud_provider = 2;
+    // The region identifier as defined by the cloud provider.
+    string cloud_provider_region = 3;
+    // The human readable location of the region.
+    string location = 4;
+}

--- a/temporal/api/failure/v1/message.proto
+++ b/temporal/api/failure/v1/message.proto
@@ -107,7 +107,6 @@ message Failure {
     //     by the user-provided PayloadCodec
     //
     // - If there's demand, we could allow overriding the default SDK implementation to encode other opaque Failure attributes.
-    // (-- api-linter: core::0203::optional=disabled --)
     temporal.api.common.v1.Payload encoded_attributes = 20;
     Failure cause = 4;
     oneof failure_info {

--- a/temporal/api/nexus/v1/message.proto
+++ b/temporal/api/nexus/v1/message.proto
@@ -130,14 +130,10 @@ message IncomingService {
     IncomingServiceSpec spec = 3;
 
     // The date and time when the service was created.
-    // (-- api-linter: core::0142::time-field-names=disabled
-    //     aip.dev/not-precedent: Not following linter rules. --)
     google.protobuf.Timestamp created_time = 4;
 
     // The date and time when the service was last modified.
     // Will not be set if the service has never been modified.
-    // (-- api-linter: core::0142::time-field-names=disabled
-    //     aip.dev/not-precedent: Not following linter rules. --)
     google.protobuf.Timestamp last_modified_time = 5;
 
     // Server exposed URL prefix for invocation of operations on this service.
@@ -169,14 +165,10 @@ message OutgoingService {
     OutgoingServiceSpec spec = 3;
 
     // The date and time when the service was created.
-    // (-- api-linter: core::0142::time-field-names=disabled
-    //     aip.dev/not-precedent: Not following linter rules. --)
     google.protobuf.Timestamp created_time = 4;
 
     // The date and time when the service was last modified.
     // Will not be set if the service has never been modified.
-    // (-- api-linter: core::0142::time-field-names=disabled
-    //     aip.dev/not-precedent: Not following linter rules. --)
     google.protobuf.Timestamp last_modified_time = 5;
 }
 

--- a/temporal/api/schedule/v1/message.proto
+++ b/temporal/api/schedule/v1/message.proto
@@ -20,8 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// (-- api-linter: core::0203::optional=disabled
-//     aip.dev/not-precedent: field_behavior annotation not available in our gogo fork --)
 // (-- api-linter: core::0203::input-only=disabled
 //     aip.dev/not-precedent: field_behavior annotation not available in our gogo fork --)
 

--- a/temporal/api/sdk/v1/workflow_metadata.proto
+++ b/temporal/api/sdk/v1/workflow_metadata.proto
@@ -37,7 +37,6 @@ message WorkflowMetadata {
   WorkflowDefinition definition = 1;
 }
 
-// (-- api-linter: core::0203::optional=disabled --)
 message WorkflowDefinition {
   // A name scoped by the task queue that maps to this workflow definition.
   // If missing, this workflow is a dynamic workflow.
@@ -53,7 +52,6 @@ message WorkflowDefinition {
 
 // (-- api-linter: core::0123::resource-annotation=disabled
 //     aip.dev/not-precedent: The `name` field is optional. --)
-// (-- api-linter: core::0203::optional=disabled --)
 message WorkflowInteractionDefinition {
   // An optional name for the handler. If missing, it represents
   // a dynamic handler that processes any interactions not handled by others.

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -970,8 +970,6 @@ message ListTaskQueuePartitionsResponse {
     repeated temporal.api.taskqueue.v1.TaskQueuePartitionMetadata workflow_task_queue_partitions = 2;
 }
 
-// (-- api-linter: core::0203::optional=disabled
-//     aip.dev/not-precedent: field_behavior annotation not available in our gogo fork --)
 message CreateScheduleRequest {
     // The namespace the schedule should be created in.
     string namespace = 1;
@@ -1219,8 +1217,6 @@ message UpdateWorkflowExecutionRequest {
     // The namespace name of the target workflow
     string namespace = 1;
     // The target workflow id and (optionally) a specific run thereof
-    // (-- api-linter: core::0203::optional=disabled
-    //     aip.dev/not-precedent: false positive triggered by the word "optional" --)
     temporal.api.common.v1.WorkflowExecution workflow_execution = 2;
     // If set, this call will error if the most recent (if no run id is set on
     // `workflow_execution`), or specified (if it is) workflow execution is not


### PR DESCRIPTION
**What changed?**

* Copied cloud protos from https://github.com/temporalio/api-cloud
* Updated cloud protos to have license headers
* Updated cloud protos to have language-specific options
* Updated cloud service to have base HTTP URLs of `/api/v1/cloud`
* Updated OpenAPI definitions to include cloud service
* Disabled API lint checks globally
* Updated some protos to disable some API lint checks
* Added CODEOWNERS for saas for the cloud directory