### PR TITLE
Add `TaskQueueVersionGroup` message

### DIFF
--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -54,6 +54,26 @@ message TaskQueueMetadata {
     google.protobuf.DoubleValue max_tasks_per_second = 1;
 }
 
+// Used to describe a group of versions the caller is interested in.
+message TaskQueueVersionGroup {
+    // Optional. If not provided, the result for the default Build ID will be returned. The default Build ID is the one
+    // mentioned in the first unconditional Assignment Rule. If there is no default Build ID, the result for the
+    // unversioned queue will be returned.
+    // (-- api-linter: core::0140::prepositions --)
+    oneof versions {
+        BuildIdList build_ids = 6;
+        // Explicitly ask for the unversioned queue.
+        bool unversioned = 7;
+        // Ask for all active versions (including unversioned). A version is considered active if it has had new
+        // tasks or polls recently.
+        bool all_active = 8;
+    }
+
+    message BuildIdList {
+        repeated string build_ids = 1;
+    }
+}
+
 message TaskQueueVersionInfo {
     // Empty means unversioned.
     string build_id = 1;

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -875,27 +875,18 @@ message DescribeTaskQueueRequest {
     // mentioned in the first unconditional Assignment Rule. If there is no default Build ID, the result for the
     // unversioned queue will be returned.
     // (-- api-linter: core::0140::prepositions --)
-    oneof versions {
-        BuildIdList build_ids = 6;
-        // Explicitly ask for the unversioned queue.
-        bool unversioned = 7;
-        // Ask for all active versions (including unversioned). A version is considered active if it has had new
-        // tasks or polls recently.
-        bool all_active = 8;
-    }
+    temporal.api.taskqueue.v1.TaskQueueVersionGroup versions = 6;
 
     // Task queue types to report info about. If not specified, all types are considered.
-    repeated temporal.api.enums.v1.TaskQueueType task_queue_types = 9;
+    repeated temporal.api.enums.v1.TaskQueueType task_queue_types = 7;
     // Report backlog info for the requested task queue types and versions
-    // bool report_backlog_info = 10;
+    // bool report_backlog_info = 8;
     // Report list of pollers for requested task queue types and versions
-    bool report_pollers = 11;
+    bool report_pollers = 9;
     // Report task reachability for the requested versions
-    bool report_task_reachability = 12;
+    bool report_task_reachability = 10;
 
-    message BuildIdList {
-        repeated string build_ids = 1;
-    }
+
 }
 
 message DescribeTaskQueueResponse {


### PR DESCRIPTION
Use new TaskQueueVersionGroup message in api repo to specify which versions are of interest in a way that can be reused by server protos.
