### PR TITLE
Add redirect_counter field to task started events and more

### DIFF
--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -196,7 +196,7 @@ message WorkflowTaskStartedEventAttributes {
     temporal.api.common.v1.WorkerVersionStamp worker_version = 6;
     // internally used by server to properly reapply build ID redirects to an execution
     // when rebuilding it from events.
-    int32 redirect_counter = 7;
+    int64 redirect_counter = 7;
 }
 
 message WorkflowTaskCompletedEventAttributes {
@@ -314,7 +314,7 @@ message ActivityTaskStartedEventAttributes {
     temporal.api.common.v1.WorkerVersionStamp worker_version = 6;
     // internally used by server to properly reapply build ID redirects to an execution
     // when rebuilding it from events.
-    int32 redirect_counter = 7;
+    int64 redirect_counter = 7;
 }
 
 message ActivityTaskCompletedEventAttributes {

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -194,6 +194,9 @@ message WorkflowTaskStartedEventAttributes {
     int64 history_size_bytes = 5;
     // Version info of the worker to whom this task was dispatched.
     temporal.api.common.v1.WorkerVersionStamp worker_version = 6;
+    // internally used by server to properly reapply build ID redirects to an execution
+    // when rebuilding it from events.
+    int32 redirect_counter = 7;
 }
 
 message WorkflowTaskCompletedEventAttributes {
@@ -208,7 +211,7 @@ message WorkflowTaskCompletedEventAttributes {
     // Version info of the worker who processed this workflow task. If present, the `build_id` field
     // within is also used as `binary_checksum`, which may be omitted in that case (it may also be
     // populated to preserve compatibility).
-    // Deprecated. Use the info inside the corresponding ActivityTaskStartedEvent
+    // Deprecated. Use the info inside the corresponding WorkflowTaskStartedEvent
     temporal.api.common.v1.WorkerVersionStamp worker_version = 5;
     // Data the SDK wishes to record for itself, but server need not interpret, and does not
     // directly impact workflow state.
@@ -248,7 +251,7 @@ message WorkflowTaskFailedEventAttributes {
     // Version info of the worker who processed this workflow task. If present, the `build_id` field
     // within is also used as `binary_checksum`, which may be omitted in that case (it may also be
     // populated to preserve compatibility).
-    // Deprecated. Use the info inside the corresponding ActivityTaskStartedEvent
+    // Deprecated. Use the info inside the corresponding WorkflowTaskStartedEvent
     temporal.api.common.v1.WorkerVersionStamp worker_version = 10;
 }
 
@@ -309,6 +312,9 @@ message ActivityTaskStartedEventAttributes {
     temporal.api.failure.v1.Failure last_failure = 5;
     // Version info of the worker to whom this task was dispatched.
     temporal.api.common.v1.WorkerVersionStamp worker_version = 6;
+    // internally used by server to properly reapply build ID redirects to an execution
+    // when rebuilding it from events.
+    int32 redirect_counter = 7;
 }
 
 message ActivityTaskCompletedEventAttributes {

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -194,9 +194,9 @@ message WorkflowTaskStartedEventAttributes {
     int64 history_size_bytes = 5;
     // Version info of the worker to whom this task was dispatched.
     temporal.api.common.v1.WorkerVersionStamp worker_version = 6;
-    // internally used by server to properly reapply build ID redirects to an execution
+    // Used by server internally to properly reapply build ID redirects to an execution
     // when rebuilding it from events.
-    int64 redirect_counter = 7;
+    int64 build_id_redirect_counter = 7;
 }
 
 message WorkflowTaskCompletedEventAttributes {
@@ -312,9 +312,9 @@ message ActivityTaskStartedEventAttributes {
     temporal.api.failure.v1.Failure last_failure = 5;
     // Version info of the worker to whom this task was dispatched.
     temporal.api.common.v1.WorkerVersionStamp worker_version = 6;
-    // internally used by server to properly reapply build ID redirects to an execution
+    // Used by server internally to properly reapply build ID redirects to an execution
     // when rebuilding it from events.
-    int64 redirect_counter = 7;
+    int64 build_id_redirect_counter = 7;
 }
 
 message ActivityTaskCompletedEventAttributes {

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -54,31 +54,21 @@ message TaskQueueMetadata {
     google.protobuf.DoubleValue max_tasks_per_second = 1;
 }
 
-// Used to describe a group of versions the caller is interested in.
-message TaskQueueVersionGroup {
-    // Optional. If not provided, the result for the default Build ID will be returned. The default Build ID is the one
-    // mentioned in the first unconditional Assignment Rule. If there is no default Build ID, the result for the
-    // unversioned queue will be returned.
-    // (-- api-linter: core::0140::prepositions --)
-    oneof versions {
-        BuildIdList build_ids = 6;
-        // Explicitly ask for the unversioned queue.
-        bool unversioned = 7;
-        // Ask for all active versions (including unversioned). A version is considered active if it has had new
-        // tasks or polls recently.
-        bool all_active = 8;
-    }
-
-    message BuildIdList {
-        repeated string build_ids = 1;
-    }
+// Used for specifying versions the caller is interested in.
+message TaskQueueVersionSelection {
+    // Include specific Build IDs.
+    repeated string build_ids = 1;
+    // Include the unversioned queue.
+    bool unversioned = 2;
+    // Include all active versions. A version is considered active if it has had new
+    // tasks or polls recently.
+    bool all_active = 3;
 }
 
 message TaskQueueVersionInfo {
     // Empty means unversioned.
     string build_id = 1;
     repeated TaskQueueTypeInfo types_info = 3;
-    // Only applicable to versioned workers (workers with `useVersioning=true`).
     temporal.api.enums.v1.BuildIdTaskReachability task_reachability = 4;
 }
 
@@ -166,9 +156,6 @@ message BuildIdReachability {
 message RampByPercentage {
     // Acceptable range is [0,100).
     float ramp_percentage = 1;
-}
-
-message RampByWorkerRatio {
 }
 
 // These rules assign a Build ID to Unassigned Workflow Executions and

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1299,10 +1299,14 @@ message UpdateWorkerVersioningRulesRequest {
 }
 
 message UpdateWorkerVersioningRulesResponse {
+    repeated temporal.api.taskqueue.v1.TimestampedBuildIdAssignmentRule assignment_rules = 1;
+    repeated temporal.api.taskqueue.v1.TimestampedCompatibleBuildIdRedirectRule compatible_redirect_rules = 2;
+
     // This value can be passed back to UpdateWorkerVersioningRulesRequest to
     // ensure that the rules were not modified between the two updates, which
     // could lead to lost updates and other confusion.
-    bytes conflict_token = 1;
+    bytes conflict_token = 3;
+
 }
 
 message GetWorkerVersioningRulesRequest {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -875,7 +875,7 @@ message DescribeTaskQueueRequest {
     // mentioned in the first unconditional Assignment Rule. If there is no default Build ID, the result for the
     // unversioned queue will be returned.
     // (-- api-linter: core::0140::prepositions --)
-    temporal.api.taskqueue.v1.TaskQueueVersionGroup versions = 6;
+    temporal.api.taskqueue.v1.TaskQueueVersionSelection versions = 6;
 
     // Task queue types to report info about. If not specified, all types are considered.
     repeated temporal.api.enums.v1.TaskQueueType task_queue_types = 7;

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1306,7 +1306,6 @@ message UpdateWorkerVersioningRulesResponse {
     // ensure that the rules were not modified between the two updates, which
     // could lead to lost updates and other confusion.
     bytes conflict_token = 3;
-
 }
 
 message GetWorkerVersioningRulesRequest {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add `redirect_counter` field to task started events.
- Rename TaskQueueVersionGroup to TaskQueueVersionSelection and get rid of the `oneof`.

<!-- Tell your future self why have you made these changes -->
**Why?**
- `redirect_counter` is used by server to synchronize build ID redirects when rebuilding history. it is needed to make sure we reapply the redirects correctly for workflows with concurrent activities.
- Regarding TaskQueueVersionSelection, in some scenarios caller may want to specify more than one option. For example, the operator may want to get the result for a fixed list of build IDs plus any active build IDs that may be missing from its radar. Or if it wants to get the results for some build IDs and "unversioned" together.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
