### PR TITLE
Add a flag to the API payload to force a completion of activity

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -2298,6 +2298,10 @@
         "identity": {
           "type": "string",
           "title": "The identity of the worker/client"
+        },
+        "forceCompletion": {
+          "type": "boolean",
+          "title": "Toggle to force a completion of an activity\nWhen set as true, worker will complete an activity no matter if there is any pending activites"
         }
       }
     },
@@ -2345,6 +2349,10 @@
         "identity": {
           "type": "string",
           "title": "The identity of the worker/client"
+        },
+        "forceCompletion": {
+          "type": "boolean",
+          "title": "Toggle to force a completion of an activity\nWhen set as true, worker will complete an activity no matter if there is any pending activites"
         }
       }
     },
@@ -2400,6 +2408,10 @@
         "lastHeartbeatDetails": {
           "$ref": "#/definitions/v1Payloads",
           "title": "Additional details to be stored as last activity heartbeat"
+        },
+        "forceCompletion": {
+          "type": "boolean",
+          "title": "Toggle to force a completion of an activity\nWhen set as true, worker will complete an activity no matter if there is any pending activites"
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -4061,6 +4061,11 @@ components:
         identity:
           type: string
           description: The identity of the worker/client
+        forceCompletion:
+          type: boolean
+          description: |-
+            Toggle to force a completion of an activity
+             When set as true, worker will complete an activity no matter if there is any pending activites
     RespondActivityTaskCanceledByIdResponse:
       type: object
       properties: {}
@@ -4112,6 +4117,11 @@ components:
         identity:
           type: string
           description: The identity of the worker/client
+        forceCompletion:
+          type: boolean
+          description: |-
+            Toggle to force a completion of an activity
+             When set as true, worker will complete an activity no matter if there is any pending activites
     RespondActivityTaskCompletedByIdResponse:
       type: object
       properties: {}
@@ -4167,6 +4177,11 @@ components:
           allOf:
             - $ref: '#/components/schemas/Payloads'
           description: Additional details to be stored as last activity heartbeat
+        forceCompletion:
+          type: boolean
+          description: |-
+            Toggle to force a completion of an activity
+             When set as true, worker will complete an activity no matter if there is any pending activites
     RespondActivityTaskFailedByIdResponse:
       type: object
       properties:

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -499,6 +499,9 @@ message RespondActivityTaskCompletedByIdRequest {
     temporal.api.common.v1.Payloads result = 5;
     // The identity of the worker/client
     string identity = 6;
+    // Toggle to force a completion of an activity
+    // When set as true, worker will complete an activity no matter if there is any pending activites
+    bool force_completion = 7;
 }
 
 message RespondActivityTaskCompletedByIdResponse {
@@ -541,6 +544,9 @@ message RespondActivityTaskFailedByIdRequest {
     string identity = 6;
     // Additional details to be stored as last activity heartbeat
     temporal.api.common.v1.Payloads last_heartbeat_details = 7;
+    // Toggle to force a completion of an activity
+    // When set as true, worker will complete an activity no matter if there is any pending activites
+    bool force_completion = 8;
 }
 
 message RespondActivityTaskFailedByIdResponse {
@@ -579,6 +585,9 @@ message RespondActivityTaskCanceledByIdRequest {
     temporal.api.common.v1.Payloads details = 5;
     // The identity of the worker/client
     string identity = 6;
+    // Toggle to force a completion of an activity
+    // When set as true, worker will complete an activity no matter if there is any pending activites
+    bool force_completion = 7;
 }
 
 message RespondActivityTaskCanceledByIdResponse {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

This is the first PR for the change request in this [issue](https://github.com/temporalio/temporal/issues/987)

Add a `bool` flag in `RespondActivityTask*` payload to control the behavior when `CompleteActivityByID ` is called.

<!-- Tell your future self why have you made these changes -->
**Why?**
In async workflow, a bug or transit issue may cause an activity to fail. This will continuously fail a callback of some other process as the previous activity is backing off. With this change, we introduce a flag to let the server know we want to force the completion of the activity even if it is backing off in order to unblock the workflow.

Please refer to the [issue](https://github.com/temporalio/temporal/issues/987) for more discussions.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
We need to think about the backward compatibility with this change. It is safe for the change in this PR. But in the following change (which may include the update on the client SDK), we need to be careful about backward compatibility as we need to ask for the flag information from an external system.

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
