### PR TITLE
Update TaskQueueTypeInfo to have BacklogInfo

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -7818,6 +7818,9 @@
             "$ref": "#/definitions/v1PollerInfo"
           },
           "description": "Unversioned workers (with `useVersioning=false`) are reported in unversioned result even if they set a Build ID."
+        },
+        "backlogInfo": {
+          "$ref": "#/definitions/v1BacklogInfo"
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -5590,6 +5590,8 @@ components:
           items:
             $ref: '#/components/schemas/PollerInfo'
           description: Unversioned workers (with `useVersioning=false`) are reported in unversioned result even if they set a Build ID.
+        backlogInfo:
+          $ref: '#/components/schemas/BacklogInfo'
     TaskQueueVersionInfo:
       type: object
       properties:

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -74,6 +74,7 @@ message TaskQueueVersionInfo {
 message TaskQueueTypeInfo {
     // Unversioned workers (with `useVersioning=false`) are reported in unversioned result even if they set a Build ID.
     repeated PollerInfo pollers = 1;
+    BacklogInfo backlog_info = 3;
 }
 
 // For workflow task queues, we only report the normal queue metrics, not sticky queues. This means the stats


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Updated the proto for `TaskQueueTypeInfo` to have `BacklogInfo`. This was already added by @carlydf but was removed when versioning-2 was merged with master since it was not being used.

I intend on using this for functional tests.
