### PR TITLE
Add reset reapply exclude types for batch reset

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -2948,7 +2948,7 @@
         },
         "resetReapplyType": {
           "$ref": "#/definitions/v1ResetReapplyType",
-          "title": "Event types to be reapplied (deprecated)\nDefault: RESET_REAPPLY_TYPE_ALL_ELIGIBLE"
+          "title": "Event types to be reapplied (deprecated)\nDefault: RESET_REAPPLY_TYPE_SIGNAL"
         },
         "resetReapplyExcludeTypes": {
           "type": "array",
@@ -7223,11 +7223,18 @@
         },
         "resetReapplyType": {
           "$ref": "#/definitions/v1ResetReapplyType",
-          "description": "History event reapply options."
+          "title": "Event types to be reapplied (deprecated)\nDefault: RESET_REAPPLY_TYPE_SIGNAL"
         },
         "currentRunOnly": {
           "type": "boolean",
           "title": "If true, limit the reset to only within the current run. (Applies to build_id targets and\npossibly others in the future.)"
+        },
+        "resetReapplyExcludeTypes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/v1ResetReapplyExcludeType"
+          },
+          "title": "Event types not to be reapplied"
         }
       },
       "description": "Describes where and how to reset a workflow, used for batch reset currently\nand may be used for single-workflow reset later."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -5049,13 +5049,25 @@ components:
             - RESET_REAPPLY_TYPE_NONE
             - RESET_REAPPLY_TYPE_ALL_ELIGIBLE
           type: string
-          description: History event reapply options.
+          description: |-
+            Event types to be reapplied (deprecated)
+             Default: RESET_REAPPLY_TYPE_SIGNAL
           format: enum
         currentRunOnly:
           type: boolean
           description: |-
             If true, limit the reset to only within the current run. (Applies to build_id targets and
              possibly others in the future.)
+        resetReapplyExcludeTypes:
+          type: array
+          items:
+            enum:
+              - RESET_REAPPLY_EXCLUDE_TYPE_UNSPECIFIED
+              - RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL
+              - RESET_REAPPLY_EXCLUDE_TYPE_UPDATE
+            type: string
+            format: enum
+          description: Event types not to be reapplied
       description: |-
         Describes where and how to reset a workflow, used for batch reset currently
          and may be used for single-workflow reset later.
@@ -5124,7 +5136,7 @@ components:
           type: string
           description: |-
             Event types to be reapplied (deprecated)
-             Default: RESET_REAPPLY_TYPE_ALL_ELIGIBLE
+             Default: RESET_REAPPLY_TYPE_SIGNAL
           format: enum
         resetReapplyExcludeTypes:
           type: array

--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -170,12 +170,16 @@ message ResetOptions {
         string build_id = 4;
     }
 
-    // History event reapply options.
+    // Event types to be reapplied (deprecated)
+    // Default: RESET_REAPPLY_TYPE_SIGNAL
     temporal.api.enums.v1.ResetReapplyType reset_reapply_type = 10;
 
     // If true, limit the reset to only within the current run. (Applies to build_id targets and
     // possibly others in the future.)
     bool current_run_only = 11;
+
+    // Event types not to be reapplied
+    repeated temporal.api.enums.v1.ResetReapplyExcludeType reset_reapply_exclude_types = 12;
 }
 
 // Callback to attach to various events in the system, e.g. workflow run completion.

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -695,7 +695,7 @@ message ResetWorkflowExecutionRequest {
     // Used to de-dupe reset requests
     string request_id = 5;
     // Event types to be reapplied (deprecated)
-    // Default: RESET_REAPPLY_TYPE_ALL_ELIGIBLE
+    // Default: RESET_REAPPLY_TYPE_SIGNAL
     temporal.api.enums.v1.ResetReapplyType reset_reapply_type = 6;
     // Event types not to be reapplied
     repeated temporal.api.enums.v1.ResetReapplyExcludeType reset_reapply_exclude_types = 7;


### PR DESCRIPTION
**What changed?**
Support the new reset reapply exclude types for batch reset


**Why?**
It was accidentally omitted in https://github.com/temporalio/temporal/pull/5688, when we added the new field for non-batch reset.


**Breaking changes**
No
