### PR TITLE
Removed /api/v1 prefix for HTTP paths

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -19,7 +19,7 @@
     "application/json"
   ],
   "paths": {
-    "/api/v1/cluster-info": {
+    "/cluster-info": {
       "get": {
         "summary": "GetClusterInfo returns information about temporal cluster",
         "operationId": "GetClusterInfo",
@@ -42,7 +42,7 @@
         ]
       }
     },
-    "/api/v1/namespaces": {
+    "/namespaces": {
       "get": {
         "summary": "ListNamespaces returns the information and configuration for all namespaces.",
         "operationId": "ListNamespaces",
@@ -120,7 +120,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}": {
+    "/namespaces/{namespace}": {
       "get": {
         "summary": "DescribeNamespace returns the information and configuration for a registered namespace.",
         "operationId": "DescribeNamespace",
@@ -157,7 +157,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/activities/cancel": {
+    "/namespaces/{namespace}/activities/cancel": {
       "post": {
         "summary": "RespondActivityTaskFailed is called by workers when processing an activity task fails.",
         "description": "This results in a new `ACTIVITY_TASK_CANCELED` event being written to the workflow history\nand a new workflow task created for the workflow. Fails with `NotFound` if the task token is\nno longer valid due to activity timeout, already being completed, or never having existed.",
@@ -197,7 +197,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/activities/cancel-by-id": {
+    "/namespaces/{namespace}/activities/cancel-by-id": {
       "post": {
         "summary": "See `RecordActivityTaskCanceled`. This version allows clients to record failures by\nnamespace/workflow id/activity id instead of task token.",
         "operationId": "RespondActivityTaskCanceledById",
@@ -237,7 +237,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/activities/complete": {
+    "/namespaces/{namespace}/activities/complete": {
       "post": {
         "summary": "RespondActivityTaskCompleted is called by workers when they successfully complete an activity\ntask.",
         "description": "This results in a new `ACTIVITY_TASK_COMPLETED` event being written to the workflow history\nand a new workflow task created for the workflow. Fails with `NotFound` if the task token is\nno longer valid due to activity timeout, already being completed, or never having existed.",
@@ -277,7 +277,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/activities/complete-by-id": {
+    "/namespaces/{namespace}/activities/complete-by-id": {
       "post": {
         "summary": "See `RecordActivityTaskCompleted`. This version allows clients to record completions by\nnamespace/workflow id/activity id instead of task token.",
         "operationId": "RespondActivityTaskCompletedById",
@@ -317,7 +317,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/activities/fail": {
+    "/namespaces/{namespace}/activities/fail": {
       "post": {
         "summary": "RespondActivityTaskFailed is called by workers when processing an activity task fails.",
         "description": "This results in a new `ACTIVITY_TASK_FAILED` event being written to the workflow history and\na new workflow task created for the workflow. Fails with `NotFound` if the task token is no\nlonger valid due to activity timeout, already being completed, or never having existed.",
@@ -357,7 +357,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/activities/fail-by-id": {
+    "/namespaces/{namespace}/activities/fail-by-id": {
       "post": {
         "summary": "See `RecordActivityTaskFailed`. This version allows clients to record failures by\nnamespace/workflow id/activity id instead of task token.",
         "operationId": "RespondActivityTaskFailedById",
@@ -397,7 +397,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/activities/heartbeat": {
+    "/namespaces/{namespace}/activities/heartbeat": {
       "post": {
         "summary": "RecordActivityTaskHeartbeat is optionally called by workers while they execute activities.",
         "description": "If worker fails to heartbeat within the `heartbeat_timeout` interval for the activity task,\nthen it will be marked as timed out and an `ACTIVITY_TASK_TIMED_OUT` event will be written to\nthe workflow history. Calling `RecordActivityTaskHeartbeat` will fail with `NotFound` in\nsuch situations, in that event, the SDK should request cancellation of the activity.",
@@ -437,7 +437,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/activities/heartbeat-by-id": {
+    "/namespaces/{namespace}/activities/heartbeat-by-id": {
       "post": {
         "summary": "See `RecordActivityTaskHeartbeat`. This version allows clients to record heartbeats by\nnamespace/workflow id/activity id instead of task token.",
         "operationId": "RecordActivityTaskHeartbeatById",
@@ -477,7 +477,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/archived-workflows": {
+    "/namespaces/{namespace}/archived-workflows": {
       "get": {
         "summary": "ListArchivedWorkflowExecutions is a visibility API to list archived workflow executions in a specific namespace.",
         "operationId": "ListArchivedWorkflowExecutions",
@@ -528,7 +528,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/batch-operations": {
+    "/namespaces/{namespace}/batch-operations": {
       "get": {
         "summary": "ListBatchOperations returns a list of batch operations",
         "operationId": "ListBatchOperations",
@@ -576,7 +576,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/batch-operations/{jobId}": {
+    "/namespaces/{namespace}/batch-operations/{jobId}": {
       "get": {
         "summary": "DescribeBatchOperation returns the information about a batch operation",
         "operationId": "DescribeBatchOperation",
@@ -660,7 +660,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/batch-operations/{jobId}/stop": {
+    "/namespaces/{namespace}/batch-operations/{jobId}/stop": {
       "post": {
         "summary": "StopBatchOperation stops a batch operation",
         "operationId": "StopBatchOperation",
@@ -707,7 +707,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/schedules": {
+    "/namespaces/{namespace}/schedules": {
       "get": {
         "summary": "List all schedules in a namespace.",
         "operationId": "ListSchedules",
@@ -762,7 +762,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/schedules/{scheduleId}": {
+    "/namespaces/{namespace}/schedules/{scheduleId}": {
       "get": {
         "summary": "Returns the schedule description and current state of an existing schedule.",
         "operationId": "DescribeSchedule",
@@ -890,7 +890,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/schedules/{scheduleId}/matching-times": {
+    "/namespaces/{namespace}/schedules/{scheduleId}/matching-times": {
       "get": {
         "summary": "Lists matching times within a range.",
         "operationId": "ListScheduleMatchingTimes",
@@ -944,7 +944,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/schedules/{scheduleId}/patch": {
+    "/namespaces/{namespace}/schedules/{scheduleId}/patch": {
       "post": {
         "summary": "Makes a specific change to a schedule or triggers an immediate action.",
         "operationId": "PatchSchedule",
@@ -991,7 +991,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/schedules/{scheduleId}/update": {
+    "/namespaces/{namespace}/schedules/{scheduleId}/update": {
       "post": {
         "summary": "Changes the configuration or state of an existing schedule.",
         "operationId": "UpdateSchedule",
@@ -1038,7 +1038,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/search-attributes": {
+    "/namespaces/{namespace}/search-attributes": {
       "get": {
         "summary": "ListSearchAttributes returns comprehensive information about search attributes.",
         "operationId": "ListSearchAttributes",
@@ -1069,7 +1069,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/task-queues/{taskQueue.name}": {
+    "/namespaces/{namespace}/task-queues/{taskQueue.name}": {
       "get": {
         "summary": "DescribeTaskQueue returns the following information about the target task queue, broken down by Build ID:\n  - List of pollers\n  - Workflow Reachability status\n  - Backlog info for Workflow and/or Activity tasks",
         "operationId": "DescribeTaskQueue",
@@ -1215,7 +1215,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/task-queues/{taskQueue}/worker-build-id-compatibility": {
+    "/namespaces/{namespace}/task-queues/{taskQueue}/worker-build-id-compatibility": {
       "get": {
         "summary": "Deprecated. Use `GetWorkerVersioningRules`.\nFetches the worker build id versioning sets for a task queue.",
         "operationId": "GetWorkerBuildIdCompatibility",
@@ -1261,7 +1261,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/task-queues/{taskQueue}/worker-versioning-rules": {
+    "/namespaces/{namespace}/task-queues/{taskQueue}/worker-versioning-rules": {
       "get": {
         "summary": "Fetches the Build ID assignment and redirect rules for a Task Queue.\nWARNING: Worker Versioning is not yet stable and the API and behavior may change incompatibly.",
         "operationId": "GetWorkerVersioningRules",
@@ -1298,7 +1298,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/update": {
+    "/namespaces/{namespace}/update": {
       "post": {
         "summary": "UpdateNamespace is used to update the information and configuration of a registered\nnamespace.",
         "operationId": "UpdateNamespace",
@@ -1337,7 +1337,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/worker-task-reachability": {
+    "/namespaces/{namespace}/worker-task-reachability": {
       "get": {
         "summary": "Deprecated. Use `DescribeTaskQueue`.",
         "description": "Fetches task reachability to determine whether a worker may be retired.\nThe request may specify task queues to query for or let the server fetch all task queues mapped to the given\nbuild IDs.\n\nWhen requesting a large number of task queues or all task queues associated with the given build ids in a\nnamespace, all task queues will be listed in the response but some of them may not contain reachability\ninformation due to a server enforced limit. When reaching the limit, task queues that reachability information\ncould not be retrieved for will be marked with a single TASK_REACHABILITY_UNSPECIFIED entry. The caller may issue\nanother call to get the reachability for those task queues.\n\nOpen source users can adjust this limit by setting the server's dynamic config value for\n`limit.reachabilityTaskQueueScan` with the caveat that this call can strain the visibility store.",
@@ -1406,7 +1406,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/workflow-count": {
+    "/namespaces/{namespace}/workflow-count": {
       "get": {
         "summary": "CountWorkflowExecutions is a visibility API to count of workflow executions in a specific namespace.",
         "operationId": "CountWorkflowExecutions",
@@ -1443,7 +1443,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/workflows": {
+    "/namespaces/{namespace}/workflows": {
       "get": {
         "summary": "ListWorkflowExecutions is a visibility API to list workflow executions in a specific namespace.",
         "operationId": "ListWorkflowExecutions",
@@ -1494,7 +1494,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/workflows/execute-multi-operation": {
+    "/namespaces/{namespace}/workflows/execute-multi-operation": {
       "post": {
         "summary": "ExecuteMultiOperation executes multiple operations within a single workflow.",
         "description": "Operations are started atomically, meaning if *any* operation fails to be started, none are,\nand the request fails. Upon start, the API returns only when *all* operations have a response.\n\nUpon failure, it returns `MultiOperationExecutionFailure` where the status code\nequals the status code of the *first* operation that failed to be started.\n\nNOTE: Experimental API.",
@@ -1534,7 +1534,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/workflows/{execution.workflowId}": {
+    "/namespaces/{namespace}/workflows/{execution.workflowId}": {
       "get": {
         "summary": "DescribeWorkflowExecution returns information about the specified workflow execution.",
         "operationId": "DescribeWorkflowExecution",
@@ -1577,7 +1577,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/workflows/{execution.workflowId}/history": {
+    "/namespaces/{namespace}/workflows/{execution.workflowId}/history": {
       "get": {
         "summary": "GetWorkflowExecutionHistory returns the history of specified workflow execution. Fails with\n`NotFound` if the specified workflow execution is unknown to the service.",
         "operationId": "GetWorkflowExecutionHistory",
@@ -1661,7 +1661,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/workflows/{execution.workflowId}/history-reverse": {
+    "/namespaces/{namespace}/workflows/{execution.workflowId}/history-reverse": {
       "get": {
         "summary": "GetWorkflowExecutionHistoryReverse returns the history of specified workflow execution in reverse \norder (starting from last event). Fails with`NotFound` if the specified workflow execution is \nunknown to the service.",
         "operationId": "GetWorkflowExecutionHistoryReverse",
@@ -1718,7 +1718,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/workflows/{execution.workflowId}/query/{query.queryType}": {
+    "/namespaces/{namespace}/workflows/{execution.workflowId}/query/{query.queryType}": {
       "post": {
         "summary": "QueryWorkflow requests a query be executed for a specified workflow execution.",
         "operationId": "QueryWorkflow",
@@ -1770,7 +1770,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/workflows/{workflowExecution.workflowId}/cancel": {
+    "/namespaces/{namespace}/workflows/{workflowExecution.workflowId}/cancel": {
       "post": {
         "summary": "RequestCancelWorkflowExecution is called by workers when they want to request cancellation of\na workflow execution.",
         "description": "This results in a new `WORKFLOW_EXECUTION_CANCEL_REQUESTED` event being written to the\nworkflow history and a new workflow task created for the workflow. It returns success if the requested\nworkflow is already closed. It fails with 'NotFound' if the requested workflow doesn't exist.",
@@ -1816,7 +1816,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/workflows/{workflowExecution.workflowId}/reset": {
+    "/namespaces/{namespace}/workflows/{workflowExecution.workflowId}/reset": {
       "post": {
         "summary": "ResetWorkflowExecution will reset an existing workflow execution to a specified\n`WORKFLOW_TASK_COMPLETED` event (exclusive). It will immediately terminate the current\nexecution instance.\nTODO: Does exclusive here mean *just* the completed event, or also WFT started? Otherwise the task is doomed to time out?",
         "operationId": "ResetWorkflowExecution",
@@ -1861,7 +1861,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/workflows/{workflowExecution.workflowId}/signal/{signalName}": {
+    "/namespaces/{namespace}/workflows/{workflowExecution.workflowId}/signal/{signalName}": {
       "post": {
         "summary": "SignalWorkflowExecution is used to send a signal to a running workflow execution.",
         "description": "This results in a `WORKFLOW_EXECUTION_SIGNALED` event recorded in the history and a workflow\ntask being created for the execution.",
@@ -1914,7 +1914,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/workflows/{workflowExecution.workflowId}/terminate": {
+    "/namespaces/{namespace}/workflows/{workflowExecution.workflowId}/terminate": {
       "post": {
         "summary": "TerminateWorkflowExecution terminates an existing workflow execution by recording a\n`WORKFLOW_EXECUTION_TERMINATED` event in the history and immediately terminating the\nexecution instance.",
         "operationId": "TerminateWorkflowExecution",
@@ -1959,7 +1959,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/workflows/{workflowExecution.workflowId}/update/{request.input.name}": {
+    "/namespaces/{namespace}/workflows/{workflowExecution.workflowId}/update/{request.input.name}": {
       "post": {
         "summary": "Invokes the specified update function on user workflow code.",
         "operationId": "UpdateWorkflowExecution",
@@ -2012,7 +2012,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/workflows/{workflowId}": {
+    "/namespaces/{namespace}/workflows/{workflowId}": {
       "post": {
         "summary": "StartWorkflowExecution starts a new workflow execution.",
         "description": "It will create the execution with a `WORKFLOW_EXECUTION_STARTED` event in its history and\nalso schedule the first workflow task. Returns `WorkflowExecutionAlreadyStarted`, if an\ninstance already exists with same workflow id.",
@@ -2058,7 +2058,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/workflows/{workflowId}/signal-with-start/{signalName}": {
+    "/namespaces/{namespace}/workflows/{workflowId}/signal-with-start/{signalName}": {
       "post": {
         "summary": "SignalWithStartWorkflowExecution is used to ensure a signal is sent to a workflow, even if\nit isn't yet started.",
         "description": "If the workflow is running, a `WORKFLOW_EXECUTION_SIGNALED` event is recorded in the history\nand a workflow task is generated.\n\nIf the workflow is not running or not found, then the workflow is created with\n`WORKFLOW_EXECUTION_STARTED` and `WORKFLOW_EXECUTION_SIGNALED` events in its history, and a\nworkflow task is generated.",
@@ -2111,7 +2111,7 @@
         ]
       }
     },
-    "/api/v1/nexus/endpoints": {
+    "/nexus/endpoints": {
       "get": {
         "summary": "List all Nexus endpoints for the cluster, sorted by ID in ascending order. Set page_token in the request to the\nnext_page_token field of the previous response to get the next page of results. An empty next_page_token\nindicates that there are no more results. During pagination, a newly added service with an ID lexicographically\nearlier than the previous page's last endpoint's ID may be missed.",
         "operationId": "ListNexusEndpoints",
@@ -2189,7 +2189,7 @@
         ]
       }
     },
-    "/api/v1/nexus/endpoints/{id}": {
+    "/nexus/endpoints/{id}": {
       "get": {
         "summary": "Get a registered Nexus endpoint by ID. The returned version can be used for optimistic updates.",
         "operationId": "GetNexusEndpoint",
@@ -2259,7 +2259,7 @@
         ]
       }
     },
-    "/api/v1/nexus/endpoints/{id}/update": {
+    "/nexus/endpoints/{id}/update": {
       "post": {
         "summary": "Optimistically update a Nexus endpoint based on provided version as obtained via the `GetNexusEndpoint` or\n`ListNexusEndpointResponse` APIs. This will fail with a status of FAILED_PRECONDITION if the version does not\nmatch.\nReturns the updated endpoint with its updated version. You may use this version for subsequent updates. You don't\nneed to increment the version yourself. The server will increment the version for you after each update.",
         "operationId": "UpdateNexusEndpoint",
@@ -2299,7 +2299,7 @@
         ]
       }
     },
-    "/api/v1/system-info": {
+    "/system-info": {
       "get": {
         "summary": "GetSystemInfo returns information about the system.",
         "operationId": "GetSystemInfo",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -6,7 +6,7 @@ info:
   title: ""
   version: 0.0.1
 paths:
-  /api/v1/cluster-info:
+  /cluster-info:
     get:
       tags:
         - WorkflowService
@@ -25,7 +25,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces:
+  /namespaces:
     get:
       tags:
         - WorkflowService
@@ -93,7 +93,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}:
+  /namespaces/{namespace}:
     get:
       tags:
         - WorkflowService
@@ -122,7 +122,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/activities/cancel:
+  /namespaces/{namespace}/activities/cancel:
     post:
       tags:
         - WorkflowService
@@ -158,7 +158,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/activities/cancel-by-id:
+  /namespaces/{namespace}/activities/cancel-by-id:
     post:
       tags:
         - WorkflowService
@@ -195,7 +195,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/activities/complete:
+  /namespaces/{namespace}/activities/complete:
     post:
       tags:
         - WorkflowService
@@ -232,7 +232,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/activities/complete-by-id:
+  /namespaces/{namespace}/activities/complete-by-id:
     post:
       tags:
         - WorkflowService
@@ -269,7 +269,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/activities/fail:
+  /namespaces/{namespace}/activities/fail:
     post:
       tags:
         - WorkflowService
@@ -305,7 +305,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/activities/fail-by-id:
+  /namespaces/{namespace}/activities/fail-by-id:
     post:
       tags:
         - WorkflowService
@@ -342,7 +342,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/activities/heartbeat:
+  /namespaces/{namespace}/activities/heartbeat:
     post:
       tags:
         - WorkflowService
@@ -379,7 +379,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/activities/heartbeat-by-id:
+  /namespaces/{namespace}/activities/heartbeat-by-id:
     post:
       tags:
         - WorkflowService
@@ -416,7 +416,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/archived-workflows:
+  /namespaces/{namespace}/archived-workflows:
     get:
       tags:
         - WorkflowService
@@ -455,7 +455,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/batch-operations:
+  /namespaces/{namespace}/batch-operations:
     get:
       tags:
         - WorkflowService
@@ -493,7 +493,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/batch-operations/{jobId}:
+  /namespaces/{namespace}/batch-operations/{jobId}:
     get:
       tags:
         - WorkflowService
@@ -562,7 +562,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/batch-operations/{jobId}/stop:
+  /namespaces/{namespace}/batch-operations/{jobId}/stop:
     post:
       tags:
         - WorkflowService
@@ -600,7 +600,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/schedules:
+  /namespaces/{namespace}/schedules:
     get:
       tags:
         - WorkflowService
@@ -643,7 +643,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/schedules/{scheduleId}:
+  /namespaces/{namespace}/schedules/{scheduleId}:
     get:
       tags:
         - WorkflowService
@@ -748,7 +748,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/schedules/{scheduleId}/matching-times:
+  /namespaces/{namespace}/schedules/{scheduleId}/matching-times:
     get:
       tags:
         - WorkflowService
@@ -791,7 +791,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/schedules/{scheduleId}/patch:
+  /namespaces/{namespace}/schedules/{scheduleId}/patch:
     post:
       tags:
         - WorkflowService
@@ -829,7 +829,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/schedules/{scheduleId}/update:
+  /namespaces/{namespace}/schedules/{scheduleId}/update:
     post:
       tags:
         - WorkflowService
@@ -867,7 +867,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/search-attributes:
+  /namespaces/{namespace}/search-attributes:
     get:
       tags:
         - OperatorService
@@ -892,7 +892,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/task-queues/{taskQueue}/worker-build-id-compatibility:
+  /namespaces/{namespace}/task-queues/{taskQueue}/worker-build-id-compatibility:
     get:
       tags:
         - WorkflowService
@@ -933,7 +933,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/task-queues/{taskQueue}/worker-versioning-rules:
+  /namespaces/{namespace}/task-queues/{taskQueue}/worker-versioning-rules:
     get:
       tags:
         - WorkflowService
@@ -965,7 +965,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/task-queues/{task_queue.name}:
+  /namespaces/{namespace}/task-queues/{task_queue.name}:
     get:
       tags:
         - WorkflowService
@@ -1094,7 +1094,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/update:
+  /namespaces/{namespace}/update:
     post:
       tags:
         - WorkflowService
@@ -1127,7 +1127,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/worker-task-reachability:
+  /namespaces/{namespace}/worker-task-reachability:
     get:
       tags:
         - WorkflowService
@@ -1207,7 +1207,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/workflow-count:
+  /namespaces/{namespace}/workflow-count:
     get:
       tags:
         - WorkflowService
@@ -1236,7 +1236,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/workflows:
+  /namespaces/{namespace}/workflows:
     get:
       tags:
         - WorkflowService
@@ -1275,7 +1275,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/workflows/execute-multi-operation:
+  /namespaces/{namespace}/workflows/execute-multi-operation:
     post:
       tags:
         - WorkflowService
@@ -1315,7 +1315,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}:
+  /namespaces/{namespace}/workflows/{execution.workflow_id}:
     get:
       tags:
         - WorkflowService
@@ -1353,7 +1353,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/history:
+  /namespaces/{namespace}/workflows/{execution.workflow_id}/history:
     get:
       tags:
         - WorkflowService
@@ -1429,7 +1429,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/history-reverse:
+  /namespaces/{namespace}/workflows/{execution.workflow_id}/history-reverse:
     get:
       tags:
         - WorkflowService
@@ -1477,7 +1477,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/query/{query.query_type}:
+  /namespaces/{namespace}/workflows/{execution.workflow_id}/query/{query.query_type}:
     post:
       tags:
         - WorkflowService
@@ -1518,7 +1518,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/workflows/{workflowId}:
+  /namespaces/{namespace}/workflows/{workflowId}:
     post:
       tags:
         - WorkflowService
@@ -1559,7 +1559,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/workflows/{workflowId}/signal-with-start/{signalName}:
+  /namespaces/{namespace}/workflows/{workflowId}/signal-with-start/{signalName}:
     post:
       tags:
         - WorkflowService
@@ -1613,7 +1613,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/cancel:
+  /namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/cancel:
     post:
       tags:
         - WorkflowService
@@ -1655,7 +1655,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/reset:
+  /namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/reset:
     post:
       tags:
         - WorkflowService
@@ -1695,7 +1695,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/signal/{signalName}:
+  /namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/signal/{signalName}:
     post:
       tags:
         - WorkflowService
@@ -1741,7 +1741,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/terminate:
+  /namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/terminate:
     post:
       tags:
         - WorkflowService
@@ -1780,7 +1780,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/update/{request.input.name}:
+  /namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/update/{request.input.name}:
     post:
       tags:
         - WorkflowService
@@ -1822,7 +1822,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/nexus/endpoints:
+  /nexus/endpoints:
     get:
       tags:
         - OperatorService
@@ -1895,7 +1895,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/nexus/endpoints/{id}:
+  /nexus/endpoints/{id}:
     get:
       tags:
         - OperatorService
@@ -1951,7 +1951,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/nexus/endpoints/{id}/update:
+  /nexus/endpoints/{id}/update:
     post:
       tags:
         - OperatorService
@@ -1988,7 +1988,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/system-info:
+  /system-info:
     get:
       tags:
         - WorkflowService

--- a/temporal/api/operatorservice/v1/service.proto
+++ b/temporal/api/operatorservice/v1/service.proto
@@ -58,7 +58,7 @@ service OperatorService {
     // ListSearchAttributes returns comprehensive information about search attributes.
     rpc ListSearchAttributes (ListSearchAttributesRequest) returns (ListSearchAttributesResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/search-attributes",
+            get: "/namespaces/{namespace}/search-attributes",
         };
     }
 
@@ -81,7 +81,7 @@ service OperatorService {
     // Get a registered Nexus endpoint by ID. The returned version can be used for optimistic updates.
     rpc GetNexusEndpoint(GetNexusEndpointRequest) returns (GetNexusEndpointResponse) {
         option (google.api.http) = {
-            get: "/api/v1/nexus/endpoints/{id}"
+            get: "/nexus/endpoints/{id}"
         };
     }
 
@@ -90,7 +90,7 @@ service OperatorService {
     // Returns the created endpoint with its initial version. You may use this version for subsequent updates.
     rpc CreateNexusEndpoint(CreateNexusEndpointRequest) returns (CreateNexusEndpointResponse) {
         option (google.api.http) = {
-            post: "/api/v1/nexus/endpoints"
+            post: "/nexus/endpoints"
             body: "*"
         };
     }
@@ -102,7 +102,7 @@ service OperatorService {
     // need to increment the version yourself. The server will increment the version for you after each update.
     rpc UpdateNexusEndpoint(UpdateNexusEndpointRequest) returns (UpdateNexusEndpointResponse) {
         option (google.api.http) = {
-            post: "/api/v1/nexus/endpoints/{id}/update"
+            post: "/nexus/endpoints/{id}/update"
             body: "*"
         };
     }
@@ -110,7 +110,7 @@ service OperatorService {
     // Delete an incoming Nexus service by ID.
     rpc DeleteNexusEndpoint(DeleteNexusEndpointRequest) returns (DeleteNexusEndpointResponse) {
         option (google.api.http) = {
-            delete: "/api/v1/nexus/endpoints/{id}"
+            delete: "/nexus/endpoints/{id}"
         };
     }
 
@@ -120,7 +120,7 @@ service OperatorService {
     // earlier than the previous page's last endpoint's ID may be missed.
     rpc ListNexusEndpoints(ListNexusEndpointsRequest) returns (ListNexusEndpointsResponse) {
         option (google.api.http) = {
-            get: "/api/v1/nexus/endpoints"
+            get: "/nexus/endpoints"
         };
     }
 }

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -56,7 +56,7 @@ service WorkflowService {
     // namespace.
     rpc RegisterNamespace (RegisterNamespaceRequest) returns (RegisterNamespaceResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces"
+            post: "/namespaces"
             body: "*"
         };
     }
@@ -64,14 +64,14 @@ service WorkflowService {
     // DescribeNamespace returns the information and configuration for a registered namespace.
     rpc DescribeNamespace (DescribeNamespaceRequest) returns (DescribeNamespaceResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}"
+            get: "/namespaces/{namespace}"
         };
     }
 
     // ListNamespaces returns the information and configuration for all namespaces.
     rpc ListNamespaces (ListNamespacesRequest) returns (ListNamespacesResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces"
+            get: "/namespaces"
         };
     }
 
@@ -79,7 +79,7 @@ service WorkflowService {
     // namespace.
     rpc UpdateNamespace (UpdateNamespaceRequest) returns (UpdateNamespaceResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/update"
+            post: "/namespaces/{namespace}/update"
             body: "*"
         };
     }
@@ -102,7 +102,7 @@ service WorkflowService {
     // instance already exists with same workflow id.
     rpc StartWorkflowExecution (StartWorkflowExecutionRequest) returns (StartWorkflowExecutionResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_id}"
+            post: "/namespaces/{namespace}/workflows/{workflow_id}"
             body: "*"
         };
     }
@@ -118,7 +118,7 @@ service WorkflowService {
     // NOTE: Experimental API.
     rpc ExecuteMultiOperation (ExecuteMultiOperationRequest) returns (ExecuteMultiOperationResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/workflows/execute-multi-operation"
+            post: "/namespaces/{namespace}/workflows/execute-multi-operation"
             body: "*"
         };
     }
@@ -127,7 +127,7 @@ service WorkflowService {
     // `NotFound` if the specified workflow execution is unknown to the service.
     rpc GetWorkflowExecutionHistory (GetWorkflowExecutionHistoryRequest) returns (GetWorkflowExecutionHistoryResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/history"
+            get: "/namespaces/{namespace}/workflows/{execution.workflow_id}/history"
         };
     }
     
@@ -136,7 +136,7 @@ service WorkflowService {
     // unknown to the service.
     rpc GetWorkflowExecutionHistoryReverse (GetWorkflowExecutionHistoryReverseRequest) returns (GetWorkflowExecutionHistoryReverseResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/history-reverse"
+            get: "/namespaces/{namespace}/workflows/{execution.workflow_id}/history-reverse"
         };
     }
 
@@ -205,7 +205,7 @@ service WorkflowService {
     // such situations, in that event, the SDK should request cancellation of the activity.
     rpc RecordActivityTaskHeartbeat (RecordActivityTaskHeartbeatRequest) returns (RecordActivityTaskHeartbeatResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/activities/heartbeat"
+            post: "/namespaces/{namespace}/activities/heartbeat"
             body: "*"
         };
     }
@@ -217,7 +217,7 @@ service WorkflowService {
     //     aip.dev/not-precedent: "By" is used to indicate request type. --)
     rpc RecordActivityTaskHeartbeatById (RecordActivityTaskHeartbeatByIdRequest) returns (RecordActivityTaskHeartbeatByIdResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/activities/heartbeat-by-id"
+            post: "/namespaces/{namespace}/activities/heartbeat-by-id"
             body: "*"
         };
     }
@@ -230,7 +230,7 @@ service WorkflowService {
     // no longer valid due to activity timeout, already being completed, or never having existed.
     rpc RespondActivityTaskCompleted (RespondActivityTaskCompletedRequest) returns (RespondActivityTaskCompletedResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/activities/complete"
+            post: "/namespaces/{namespace}/activities/complete"
             body: "*"
         };
     }
@@ -242,7 +242,7 @@ service WorkflowService {
     //     aip.dev/not-precedent: "By" is used to indicate request type. --)
     rpc RespondActivityTaskCompletedById (RespondActivityTaskCompletedByIdRequest) returns (RespondActivityTaskCompletedByIdResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/activities/complete-by-id"
+            post: "/namespaces/{namespace}/activities/complete-by-id"
             body: "*"
         };
     }
@@ -254,7 +254,7 @@ service WorkflowService {
     // longer valid due to activity timeout, already being completed, or never having existed.
     rpc RespondActivityTaskFailed (RespondActivityTaskFailedRequest) returns (RespondActivityTaskFailedResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/activities/fail"
+            post: "/namespaces/{namespace}/activities/fail"
             body: "*"
         };
     }
@@ -266,7 +266,7 @@ service WorkflowService {
     //     aip.dev/not-precedent: "By" is used to indicate request type. --)
     rpc RespondActivityTaskFailedById (RespondActivityTaskFailedByIdRequest) returns (RespondActivityTaskFailedByIdResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/activities/fail-by-id"
+            post: "/namespaces/{namespace}/activities/fail-by-id"
             body: "*"
         };
     }
@@ -278,7 +278,7 @@ service WorkflowService {
     // no longer valid due to activity timeout, already being completed, or never having existed.
     rpc RespondActivityTaskCanceled (RespondActivityTaskCanceledRequest) returns (RespondActivityTaskCanceledResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/activities/cancel"
+            post: "/namespaces/{namespace}/activities/cancel"
             body: "*"
         };
     }
@@ -290,7 +290,7 @@ service WorkflowService {
     //     aip.dev/not-precedent: "By" is used to indicate request type. --)
     rpc RespondActivityTaskCanceledById (RespondActivityTaskCanceledByIdRequest) returns (RespondActivityTaskCanceledByIdResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/activities/cancel-by-id"
+            post: "/namespaces/{namespace}/activities/cancel-by-id"
             body: "*"
         };
     }
@@ -303,7 +303,7 @@ service WorkflowService {
     // workflow is already closed. It fails with 'NotFound' if the requested workflow doesn't exist.
     rpc RequestCancelWorkflowExecution (RequestCancelWorkflowExecutionRequest) returns (RequestCancelWorkflowExecutionResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/cancel"
+            post: "/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/cancel"
             body: "*"
         };
     }
@@ -314,7 +314,7 @@ service WorkflowService {
     // task being created for the execution.
     rpc SignalWorkflowExecution (SignalWorkflowExecutionRequest) returns (SignalWorkflowExecutionResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/signal/{signal_name}"
+            post: "/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/signal/{signal_name}"
             body: "*"
         };
     }
@@ -333,7 +333,7 @@ service WorkflowService {
     //     aip.dev/not-precedent: "With" is used to indicate combined operation. --)
     rpc SignalWithStartWorkflowExecution (SignalWithStartWorkflowExecutionRequest) returns (SignalWithStartWorkflowExecutionResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_id}/signal-with-start/{signal_name}"
+            post: "/namespaces/{namespace}/workflows/{workflow_id}/signal-with-start/{signal_name}"
             body: "*"
         };
     }
@@ -344,7 +344,7 @@ service WorkflowService {
     // TODO: Does exclusive here mean *just* the completed event, or also WFT started? Otherwise the task is doomed to time out?
     rpc ResetWorkflowExecution (ResetWorkflowExecutionRequest) returns (ResetWorkflowExecutionResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/reset"
+            post: "/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/reset"
             body: "*"
         };
     }
@@ -354,7 +354,7 @@ service WorkflowService {
     // execution instance.
     rpc TerminateWorkflowExecution (TerminateWorkflowExecutionRequest) returns (TerminateWorkflowExecutionResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/terminate"
+            post: "/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/terminate"
             body: "*"
         };
     }
@@ -383,14 +383,14 @@ service WorkflowService {
     // ListWorkflowExecutions is a visibility API to list workflow executions in a specific namespace.
     rpc ListWorkflowExecutions (ListWorkflowExecutionsRequest) returns (ListWorkflowExecutionsResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/workflows"
+            get: "/namespaces/{namespace}/workflows"
         };
     }
 
     // ListArchivedWorkflowExecutions is a visibility API to list archived workflow executions in a specific namespace.
     rpc ListArchivedWorkflowExecutions (ListArchivedWorkflowExecutionsRequest) returns (ListArchivedWorkflowExecutionsResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/archived-workflows"
+            get: "/namespaces/{namespace}/archived-workflows"
         };
     }
 
@@ -404,7 +404,7 @@ service WorkflowService {
     // CountWorkflowExecutions is a visibility API to count of workflow executions in a specific namespace.
     rpc CountWorkflowExecutions (CountWorkflowExecutionsRequest) returns (CountWorkflowExecutionsResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/workflow-count"
+            get: "/namespaces/{namespace}/workflow-count"
         };
     }
 
@@ -440,7 +440,7 @@ service WorkflowService {
     // QueryWorkflow requests a query be executed for a specified workflow execution.
     rpc QueryWorkflow (QueryWorkflowRequest) returns (QueryWorkflowResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/query/{query.query_type}"
+            post: "/namespaces/{namespace}/workflows/{execution.workflow_id}/query/{query.query_type}"
             body: "*"
         };
     }
@@ -448,7 +448,7 @@ service WorkflowService {
     // DescribeWorkflowExecution returns information about the specified workflow execution.
     rpc DescribeWorkflowExecution (DescribeWorkflowExecutionRequest) returns (DescribeWorkflowExecutionResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}"
+            get: "/namespaces/{namespace}/workflows/{execution.workflow_id}"
         };
     }
 
@@ -458,21 +458,21 @@ service WorkflowService {
     //   - Backlog info for Workflow and/or Activity tasks
     rpc DescribeTaskQueue (DescribeTaskQueueRequest) returns (DescribeTaskQueueResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/task-queues/{task_queue.name}"
+            get: "/namespaces/{namespace}/task-queues/{task_queue.name}"
         };
     }
 
     // GetClusterInfo returns information about temporal cluster
     rpc GetClusterInfo(GetClusterInfoRequest) returns (GetClusterInfoResponse) {
         option (google.api.http) = {
-            get: "/api/v1/cluster-info"
+            get: "/cluster-info"
         };
     }
 
     // GetSystemInfo returns information about the system.
     rpc GetSystemInfo(GetSystemInfoRequest) returns (GetSystemInfoResponse) {
         option (google.api.http) = {
-            get: "/api/v1/system-info"
+            get: "/system-info"
         };
     }
 
@@ -484,7 +484,7 @@ service WorkflowService {
     // Creates a new schedule.
     rpc CreateSchedule (CreateScheduleRequest) returns (CreateScheduleResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/schedules/{schedule_id}"
+            post: "/namespaces/{namespace}/schedules/{schedule_id}"
             body: "*"
         };
     }
@@ -492,14 +492,14 @@ service WorkflowService {
     // Returns the schedule description and current state of an existing schedule.
     rpc DescribeSchedule (DescribeScheduleRequest) returns (DescribeScheduleResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/schedules/{schedule_id}"
+            get: "/namespaces/{namespace}/schedules/{schedule_id}"
         };
     }
 
     // Changes the configuration or state of an existing schedule.
     rpc UpdateSchedule (UpdateScheduleRequest) returns (UpdateScheduleResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/schedules/{schedule_id}/update"
+            post: "/namespaces/{namespace}/schedules/{schedule_id}/update"
             body: "*"
         };
     }
@@ -507,7 +507,7 @@ service WorkflowService {
     // Makes a specific change to a schedule or triggers an immediate action.
     rpc PatchSchedule (PatchScheduleRequest) returns (PatchScheduleResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/schedules/{schedule_id}/patch"
+            post: "/namespaces/{namespace}/schedules/{schedule_id}/patch"
             body: "*"
         };
     }
@@ -515,21 +515,21 @@ service WorkflowService {
     // Lists matching times within a range.
     rpc ListScheduleMatchingTimes (ListScheduleMatchingTimesRequest) returns (ListScheduleMatchingTimesResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/schedules/{schedule_id}/matching-times"
+            get: "/namespaces/{namespace}/schedules/{schedule_id}/matching-times"
         };
     }
 
     // Deletes a schedule, removing it from the system.
     rpc DeleteSchedule (DeleteScheduleRequest) returns (DeleteScheduleResponse) {
         option (google.api.http) = {
-            delete: "/api/v1/namespaces/{namespace}/schedules/{schedule_id}"
+            delete: "/namespaces/{namespace}/schedules/{schedule_id}"
         };
     }
 
     // List all schedules in a namespace.
     rpc ListSchedules (ListSchedulesRequest) returns (ListSchedulesResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/schedules"
+            get: "/namespaces/{namespace}/schedules"
         };
     }
 
@@ -556,7 +556,7 @@ service WorkflowService {
     // Fetches the worker build id versioning sets for a task queue.
     rpc GetWorkerBuildIdCompatibility (GetWorkerBuildIdCompatibilityRequest) returns (GetWorkerBuildIdCompatibilityResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/task-queues/{task_queue}/worker-build-id-compatibility"
+            get: "/namespaces/{namespace}/task-queues/{task_queue}/worker-build-id-compatibility"
         };
     }
 
@@ -589,7 +589,7 @@ service WorkflowService {
     // WARNING: Worker Versioning is not yet stable and the API and behavior may change incompatibly.
     rpc GetWorkerVersioningRules (GetWorkerVersioningRulesRequest) returns (GetWorkerVersioningRulesResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/task-queues/{task_queue}/worker-versioning-rules"
+            get: "/namespaces/{namespace}/task-queues/{task_queue}/worker-versioning-rules"
         };
     }
 
@@ -609,14 +609,14 @@ service WorkflowService {
     // `limit.reachabilityTaskQueueScan` with the caveat that this call can strain the visibility store.
     rpc GetWorkerTaskReachability (GetWorkerTaskReachabilityRequest) returns (GetWorkerTaskReachabilityResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/worker-task-reachability"
+            get: "/namespaces/{namespace}/worker-task-reachability"
         };
     }
 
     // Invokes the specified update function on user workflow code.
     rpc UpdateWorkflowExecution(UpdateWorkflowExecutionRequest) returns (UpdateWorkflowExecutionResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/update/{request.input.name}"
+            post: "/namespaces/{namespace}/workflows/{workflow_execution.workflow_id}/update/{request.input.name}"
             body: "*"
         };
     }
@@ -634,7 +634,7 @@ service WorkflowService {
     // StartBatchOperation starts a new batch operation
     rpc StartBatchOperation(StartBatchOperationRequest) returns (StartBatchOperationResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/batch-operations/{job_id}"
+            post: "/namespaces/{namespace}/batch-operations/{job_id}"
             body: "*"
         };
     }
@@ -642,7 +642,7 @@ service WorkflowService {
     // StopBatchOperation stops a batch operation
     rpc StopBatchOperation(StopBatchOperationRequest) returns (StopBatchOperationResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/batch-operations/{job_id}/stop"
+            post: "/namespaces/{namespace}/batch-operations/{job_id}/stop"
             body: "*"
         };
     }
@@ -650,14 +650,14 @@ service WorkflowService {
     // DescribeBatchOperation returns the information about a batch operation
     rpc DescribeBatchOperation(DescribeBatchOperationRequest) returns (DescribeBatchOperationResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/batch-operations/{job_id}"
+            get: "/namespaces/{namespace}/batch-operations/{job_id}"
         };
     }
 
     // ListBatchOperations returns a list of batch operations
     rpc ListBatchOperations(ListBatchOperationsRequest) returns (ListBatchOperationsResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}/batch-operations"
+            get: "/namespaces/{namespace}/batch-operations"
         };
     }
 


### PR DESCRIPTION
**What changed?**

Remove the `/api/v1` path from HTTP API. This is technically a 💥 breaking change, but the HTTP API has not been publicly/fully released from a Temporal product perspective.