### PR TITLE
Use UserMetadata in Nexus EndpointSpec

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -13,6 +13,8 @@ breaking:
     - google
     # Remove this after user metadata is merged
     - temporal/api/sdk/v1/workflow_metadata.proto
+    # Remove after applying nexus spec metadata change
+    - temporal/api/nexus/v1/message.proto
 lint:
   use:
     - DEFAULT

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -4845,9 +4845,8 @@
           "type": "string",
           "description": "Endpoint name, unique for this cluster. Must match `[a-zA-Z_][a-zA-Z0-9_]*`.\nRenaming an endpoint breaks all workflow callers that reference this endpoint, causing operations to fail."
         },
-        "description": {
-          "$ref": "#/definitions/v1Payload",
-          "description": "Markdown description serialized as a single JSON string.\nIf the Payload is encrypted, the UI and CLI may decrypt with the configured codec server endpoint."
+        "metadata": {
+          "$ref": "#/definitions/v1UserMetadata"
         },
         "target": {
           "$ref": "#/definitions/v1EndpointTarget",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -3149,12 +3149,8 @@ components:
           description: |-
             Endpoint name, unique for this cluster. Must match `[a-zA-Z_][a-zA-Z0-9_]*`.
              Renaming an endpoint breaks all workflow callers that reference this endpoint, causing operations to fail.
-        description:
-          allOf:
-            - $ref: '#/components/schemas/Payload'
-          description: |-
-            Markdown description serialized as a single JSON string.
-             If the Payload is encrypted, the UI and CLI may decrypt with the configured codec server endpoint.
+        metadata:
+          $ref: '#/components/schemas/UserMetadata'
         target:
           allOf:
             - $ref: '#/components/schemas/EndpointTarget'

--- a/temporal/api/nexus/v1/message.proto
+++ b/temporal/api/nexus/v1/message.proto
@@ -31,6 +31,7 @@ option csharp_namespace = "Temporalio.Api.Nexus.V1";
 
 import "google/protobuf/timestamp.proto";
 import "temporal/api/common/v1/message.proto";
+import "temporal/api/sdk/v1/user_metadata.proto";
 
 // A general purpose failure message.
 // See: https://github.com/nexus-rpc/api/blob/main/SPEC.md#failure
@@ -160,9 +161,8 @@ message EndpointSpec {
     // Endpoint name, unique for this cluster. Must match `[a-zA-Z_][a-zA-Z0-9_]*`.
     // Renaming an endpoint breaks all workflow callers that reference this endpoint, causing operations to fail.
     string name = 1;
-    // Markdown description serialized as a single JSON string.
-    // If the Payload is encrypted, the UI and CLI may decrypt with the configured codec server endpoint.
-    temporal.api.common.v1.Payload description = 2;
+
+    temporal.api.sdk.v1.UserMetadata metadata = 2;
 
     // Target to route requests to.
     EndpointTarget target = 3;


### PR DESCRIPTION
**Why?**

For consistency with other forms of metadata in the API.

**Breaking changes**

Yes, but functionality is not yet released.

**Server PR**

TBD