### PR TITLE
Replace GHA token in workflow to trigger api-go update

### DIFF
--- a/.github/workflows/trigger-api-go-update.yml
+++ b/.github/workflows/trigger-api-go-update.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - master
   workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch in api-go repo to trigger update protos (default: master)"
+        required: true
+        default: master
 
 jobs:
   notify:
@@ -16,14 +21,51 @@ jobs:
         shell: bash
 
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
+          private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: api-go # generate a token with permissions to trigger GHA in api-go repo
+
+      - name: Prepare inputs
+        id: prepare_inputs
+        run: |
+          case "${{ github.event_name }}" in
+            "push")
+              BRANCH=${{ github.event.ref }}
+              BRANCH=${BRANCH#refs/heads/}
+              COMMIT_AUTHOR=${{ toJSON(github.event.head_commit.author.name) }}
+              COMMIT_AUTHOR_EMAIL=${{ toJSON(github.event.head_commit.author.email) }}
+              COMMIT_MESSAGE=${{ toJSON(github.event.head_commit.message) }}
+              ;;
+
+            "workflow_dispatch")
+              BRANCH="${{ github.event.inputs.branch }}"
+              COMMIT_AUTHOR="Temporal Data"
+              COMMIT_AUTHOR_EMAIL="commander-data@temporal.io"
+              COMMIT_MESSAGE="Update proto"
+              ;;
+          esac
+
+          echo "BRANCH=${BRANCH}" >> $GITHUB_OUTPUT
+          echo "COMMIT_AUTHOR=${COMMIT_AUTHOR}" >> $GITHUB_OUTPUT
+          echo "COMMIT_AUTHOR_EMAIL=${COMMIT_AUTHOR_EMAIL}" >> $GITHUB_OUTPUT
+          echo "COMMIT_MESSAGE=${COMMIT_MESSAGE}" >> $GITHUB_OUTPUT
+
       - name: Dispatch api-go Github Action
         env:
-          PAT: ${{ secrets.COMMANDER_DATA_TOKEN }}
-          PARENT_REPO: temporalio/api-go
-          PARENT_BRANCH: ${{ toJSON('master') }}
-          WORKFLOW_ID: update-proto.yml
-          COMMIT_AUTHOR: ${{ toJSON(github.event.head_commit.author.name) }}
-          COMMIT_AUTHOR_EMAIL: ${{ toJSON(github.event.head_commit.author.email) }}
-          COMMIT_MESSAGE: ${{ toJSON(github.event.head_commit.message) }}
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+          BRANCH: ${{ steps.prepare_inputs.outputs.BRANCH }}
+          COMMIT_AUTHOR: ${{ steps.prepare_inputs.outputs.COMMIT_AUTHOR }}
+          COMMIT_AUTHOR_EMAIL: ${{ steps.prepare_inputs.outputs.COMMIT_AUTHOR_EMAIL }}
+          COMMIT_MESSAGE: ${{ steps.prepare_inputs.outputs.COMMIT_MESSAGE }}
         run: |
-          curl -fL -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${{ env.PAT }}" https://api.github.com/repos/${{ env.PARENT_REPO }}/actions/workflows/${{ env.WORKFLOW_ID }}/dispatches -d '{"ref":'"$PARENT_BRANCH"', "inputs":{"commit_author":'"$COMMIT_AUTHOR"', "commit_author_email":'"$COMMIT_AUTHOR_EMAIL"', "commit_message":'"$COMMIT_MESSAGE"'}}'
+          gh workflow run update-proto.yml -R https://github.com/temporalio/api-go \
+            -r master \
+            -f branch="${BRANCH}" \
+            -f commit_author="${COMMIT_AUTHOR}" \
+            -f commit_author_email="${COMMIT_AUTHOR_EMAIL}" \
+            -f commit_message="${COMMIT_MESSAGE}"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Replace GHA token in workflow to trigger api-go update (redo https://github.com/temporalio/api/pull/407 which was reverted in https://github.com/temporalio/api/pull/408).

Also added an input for `workflow_dispatch` event so we can actually manually trigger it.


<!-- Tell your future self why have you made these changes -->
**Why?**
Replace the token so it won't use my PAT.
Fix `workflow_dispatch` event since there are required fields in `update-proto.yml`.


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
