### PR TITLE
Added new resource exhausted cause for persistence storage limits.

### DIFF
--- a/temporal/api/enums/v1/failed_cause.proto
+++ b/temporal/api/enums/v1/failed_cause.proto
@@ -137,6 +137,8 @@ enum ResourceExhaustedCause {
     RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW = 5;
     // Caller exceeds action per second limit.
     RESOURCE_EXHAUSTED_CAUSE_APS_LIMIT = 6;
+    // Persistence storage limit exceeded.
+    RESOURCE_EXHAUSTED_CAUSE_PERSISTENCE_STORAGE_LIMIT = 7;
 }
 
 enum ResourceExhaustedScope {


### PR DESCRIPTION
**What changed?**
Added new resource exhausted cause `RESOURCE_EXHAUSTED_CAUSE_PERSISTENCE_STORAGE_LIMIT`.


**Why?**
This cause is used to classify errors errors relating to persistence layer being out of space

**Breaking changes**
No

**Server PR**
TBD