### PR TITLE
Add /cluster prefixes to nexus and namespace CRUD APIs

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -42,7 +42,7 @@
         ]
       }
     },
-    "/namespaces": {
+    "/cluster/namespaces": {
       "get": {
         "summary": "ListNamespaces returns the information and configuration for all namespaces.",
         "operationId": "ListNamespaces",
@@ -120,7 +120,7 @@
         ]
       }
     },
-    "/namespaces/{namespace}": {
+    "/cluster/namespaces/{namespace}": {
       "get": {
         "summary": "DescribeNamespace returns the information and configuration for a registered namespace.",
         "operationId": "DescribeNamespace",
@@ -154,6 +154,264 @@
         ],
         "tags": [
           "WorkflowService"
+        ]
+      }
+    },
+    "/cluster/namespaces/{namespace}/search-attributes": {
+      "get": {
+        "summary": "ListSearchAttributes returns comprehensive information about search attributes.",
+        "operationId": "ListSearchAttributes",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListSearchAttributesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "OperatorService"
+        ]
+      }
+    },
+    "/cluster/namespaces/{namespace}/update": {
+      "post": {
+        "summary": "UpdateNamespace is used to update the information and configuration of a registered\nnamespace.",
+        "operationId": "UpdateNamespace",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1UpdateNamespaceResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceUpdateNamespaceBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/cluster/nexus/endpoints": {
+      "get": {
+        "summary": "List all Nexus endpoints for the cluster, sorted by ID in ascending order. Set page_token in the request to the\nnext_page_token field of the previous response to get the next page of results. An empty next_page_token\nindicates that there are no more results. During pagination, a newly added service with an ID lexicographically\nearlier than the previous page's last endpoint's ID may be missed.",
+        "operationId": "ListNexusEndpoints",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListNexusEndpointsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "nextPageToken",
+            "description": "To get the next page, pass in `ListNexusEndpointsResponse.next_page_token` from the previous page's\nresponse, the token will be empty if there's no other page.\nNote: the last page may be empty if the total number of endpoints registered is a multiple of the page size.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "format": "byte"
+          },
+          {
+            "name": "name",
+            "description": "Name of the incoming endpoint to filter on - optional. Specifying this will result in zero or one results.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "OperatorService"
+        ]
+      },
+      "post": {
+        "summary": "Create a Nexus endpoint. This will fail if an endpoint with the same name is already registered with a status of\nALREADY_EXISTS.\nReturns the created endpoint with its initial version. You may use this version for subsequent updates.",
+        "operationId": "CreateNexusEndpoint",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1CreateNexusEndpointResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateNexusEndpointRequest"
+            }
+          }
+        ],
+        "tags": [
+          "OperatorService"
+        ]
+      }
+    },
+    "/cluster/nexus/endpoints/{id}": {
+      "get": {
+        "summary": "Get a registered Nexus endpoint by ID. The returned version can be used for optimistic updates.",
+        "operationId": "GetNexusEndpoint",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetNexusEndpointResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "description": "Server-generated unique endpoint ID.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "OperatorService"
+        ]
+      },
+      "delete": {
+        "summary": "Delete an incoming Nexus service by ID.",
+        "operationId": "DeleteNexusEndpoint",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1DeleteNexusEndpointResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "description": "Server-generated unique endpoint ID.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "version",
+            "description": "Data version for this endpoint. Must match current version.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "format": "int64"
+          }
+        ],
+        "tags": [
+          "OperatorService"
+        ]
+      }
+    },
+    "/cluster/nexus/endpoints/{id}/update": {
+      "post": {
+        "summary": "Optimistically update a Nexus endpoint based on provided version as obtained via the `GetNexusEndpoint` or\n`ListNexusEndpointResponse` APIs. This will fail with a status of FAILED_PRECONDITION if the version does not\nmatch.\nReturns the updated endpoint with its updated version. You may use this version for subsequent updates. You don't\nneed to increment the version yourself. The server will increment the version for you after each update.",
+        "operationId": "UpdateNexusEndpoint",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1UpdateNexusEndpointResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "description": "Server-generated unique endpoint ID.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OperatorServiceUpdateNexusEndpointBody"
+            }
+          }
+        ],
+        "tags": [
+          "OperatorService"
         ]
       }
     },
@@ -1038,37 +1296,6 @@
         ]
       }
     },
-    "/namespaces/{namespace}/search-attributes": {
-      "get": {
-        "summary": "ListSearchAttributes returns comprehensive information about search attributes.",
-        "operationId": "ListSearchAttributes",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1ListSearchAttributesResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "tags": [
-          "OperatorService"
-        ]
-      }
-    },
     "/namespaces/{namespace}/task-queues/{taskQueue.name}": {
       "get": {
         "summary": "DescribeTaskQueue returns the following information about the target task queue, broken down by Build ID:\n  - List of pollers\n  - Workflow Reachability status\n  - Backlog info for Workflow and/or Activity tasks",
@@ -1298,45 +1525,6 @@
             "in": "path",
             "required": true,
             "type": "string"
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
-    "/namespaces/{namespace}/update": {
-      "post": {
-        "summary": "UpdateNamespace is used to update the information and configuration of a registered\nnamespace.",
-        "operationId": "UpdateNamespace",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1UpdateNamespaceResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceUpdateNamespaceBody"
-            }
           }
         ],
         "tags": [
@@ -2115,194 +2303,6 @@
         ],
         "tags": [
           "WorkflowService"
-        ]
-      }
-    },
-    "/nexus/endpoints": {
-      "get": {
-        "summary": "List all Nexus endpoints for the cluster, sorted by ID in ascending order. Set page_token in the request to the\nnext_page_token field of the previous response to get the next page of results. An empty next_page_token\nindicates that there are no more results. During pagination, a newly added service with an ID lexicographically\nearlier than the previous page's last endpoint's ID may be missed.",
-        "operationId": "ListNexusEndpoints",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1ListNexusEndpointsResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "pageSize",
-            "in": "query",
-            "required": false,
-            "type": "integer",
-            "format": "int32"
-          },
-          {
-            "name": "nextPageToken",
-            "description": "To get the next page, pass in `ListNexusEndpointsResponse.next_page_token` from the previous page's\nresponse, the token will be empty if there's no other page.\nNote: the last page may be empty if the total number of endpoints registered is a multiple of the page size.",
-            "in": "query",
-            "required": false,
-            "type": "string",
-            "format": "byte"
-          },
-          {
-            "name": "name",
-            "description": "Name of the incoming endpoint to filter on - optional. Specifying this will result in zero or one results.",
-            "in": "query",
-            "required": false,
-            "type": "string"
-          }
-        ],
-        "tags": [
-          "OperatorService"
-        ]
-      },
-      "post": {
-        "summary": "Create a Nexus endpoint. This will fail if an endpoint with the same name is already registered with a status of\nALREADY_EXISTS.\nReturns the created endpoint with its initial version. You may use this version for subsequent updates.",
-        "operationId": "CreateNexusEndpoint",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1CreateNexusEndpointResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/v1CreateNexusEndpointRequest"
-            }
-          }
-        ],
-        "tags": [
-          "OperatorService"
-        ]
-      }
-    },
-    "/nexus/endpoints/{id}": {
-      "get": {
-        "summary": "Get a registered Nexus endpoint by ID. The returned version can be used for optimistic updates.",
-        "operationId": "GetNexusEndpoint",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1GetNexusEndpointResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "id",
-            "description": "Server-generated unique endpoint ID.",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "tags": [
-          "OperatorService"
-        ]
-      },
-      "delete": {
-        "summary": "Delete an incoming Nexus service by ID.",
-        "operationId": "DeleteNexusEndpoint",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1DeleteNexusEndpointResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "id",
-            "description": "Server-generated unique endpoint ID.",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "version",
-            "description": "Data version for this endpoint. Must match current version.",
-            "in": "query",
-            "required": false,
-            "type": "string",
-            "format": "int64"
-          }
-        ],
-        "tags": [
-          "OperatorService"
-        ]
-      }
-    },
-    "/nexus/endpoints/{id}/update": {
-      "post": {
-        "summary": "Optimistically update a Nexus endpoint based on provided version as obtained via the `GetNexusEndpoint` or\n`ListNexusEndpointResponse` APIs. This will fail with a status of FAILED_PRECONDITION if the version does not\nmatch.\nReturns the updated endpoint with its updated version. You may use this version for subsequent updates. You don't\nneed to increment the version yourself. The server will increment the version for you after each update.",
-        "operationId": "UpdateNexusEndpoint",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1UpdateNexusEndpointResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "id",
-            "description": "Server-generated unique endpoint ID.",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/OperatorServiceUpdateNexusEndpointBody"
-            }
-          }
-        ],
-        "tags": [
-          "OperatorService"
         ]
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -25,7 +25,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /namespaces:
+  /cluster/namespaces:
     get:
       tags:
         - WorkflowService
@@ -93,7 +93,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}:
+  /cluster/namespaces/{namespace}:
     get:
       tags:
         - WorkflowService
@@ -116,6 +116,230 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DescribeNamespaceResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /cluster/namespaces/{namespace}/search-attributes:
+    get:
+      tags:
+        - OperatorService
+      description: ListSearchAttributes returns comprehensive information about search attributes.
+      operationId: ListSearchAttributes
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListSearchAttributesResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /cluster/namespaces/{namespace}/update:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        UpdateNamespace is used to update the information and configuration of a registered
+         namespace.
+      operationId: UpdateNamespace
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateNamespaceRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateNamespaceResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /cluster/nexus/endpoints:
+    get:
+      tags:
+        - OperatorService
+      description: |-
+        List all Nexus endpoints for the cluster, sorted by ID in ascending order. Set page_token in the request to the
+         next_page_token field of the previous response to get the next page of results. An empty next_page_token
+         indicates that there are no more results. During pagination, a newly added service with an ID lexicographically
+         earlier than the previous page's last endpoint's ID may be missed.
+      operationId: ListNexusEndpoints
+      parameters:
+        - name: pageSize
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: nextPageToken
+          in: query
+          description: |-
+            To get the next page, pass in `ListNexusEndpointsResponse.next_page_token` from the previous page's
+             response, the token will be empty if there's no other page.
+             Note: the last page may be empty if the total number of endpoints registered is a multiple of the page size.
+          schema:
+            type: string
+            format: bytes
+        - name: name
+          in: query
+          description: |-
+            Name of the incoming endpoint to filter on - optional. Specifying this will result in zero or one results.
+             (-- api-linter: core::203::field-behavior-required=disabled
+                 aip.dev/not-precedent: Not following linter rules. --)
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListNexusEndpointsResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+    post:
+      tags:
+        - OperatorService
+      description: |-
+        Create a Nexus endpoint. This will fail if an endpoint with the same name is already registered with a status of
+         ALREADY_EXISTS.
+         Returns the created endpoint with its initial version. You may use this version for subsequent updates.
+      operationId: CreateNexusEndpoint
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateNexusEndpointRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateNexusEndpointResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /cluster/nexus/endpoints/{id}:
+    get:
+      tags:
+        - OperatorService
+      description: Get a registered Nexus endpoint by ID. The returned version can be used for optimistic updates.
+      operationId: GetNexusEndpoint
+      parameters:
+        - name: id
+          in: path
+          description: Server-generated unique endpoint ID.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetNexusEndpointResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+    delete:
+      tags:
+        - OperatorService
+      description: Delete an incoming Nexus service by ID.
+      operationId: DeleteNexusEndpoint
+      parameters:
+        - name: id
+          in: path
+          description: Server-generated unique endpoint ID.
+          required: true
+          schema:
+            type: string
+        - name: version
+          in: query
+          description: Data version for this endpoint. Must match current version.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteNexusEndpointResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /cluster/nexus/endpoints/{id}/update:
+    post:
+      tags:
+        - OperatorService
+      description: |-
+        Optimistically update a Nexus endpoint based on provided version as obtained via the `GetNexusEndpoint` or
+         `ListNexusEndpointResponse` APIs. This will fail with a status of FAILED_PRECONDITION if the version does not
+         match.
+         Returns the updated endpoint with its updated version. You may use this version for subsequent updates. You don't
+         need to increment the version yourself. The server will increment the version for you after each update.
+      operationId: UpdateNexusEndpoint
+      parameters:
+        - name: id
+          in: path
+          description: Server-generated unique endpoint ID.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateNexusEndpointRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateNexusEndpointResponse'
         default:
           description: Default error response
           content:
@@ -867,31 +1091,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/search-attributes:
-    get:
-      tags:
-        - OperatorService
-      description: ListSearchAttributes returns comprehensive information about search attributes.
-      operationId: ListSearchAttributes
-      parameters:
-        - name: namespace
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListSearchAttributesResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
   /namespaces/{namespace}/task-queues/{taskQueue}/worker-build-id-compatibility:
     get:
       tags:
@@ -1090,39 +1289,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DescribeTaskQueueResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/update:
-    post:
-      tags:
-        - WorkflowService
-      description: |-
-        UpdateNamespace is used to update the information and configuration of a registered
-         namespace.
-      operationId: UpdateNamespace
-      parameters:
-        - name: namespace
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UpdateNamespaceRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UpdateNamespaceResponse'
         default:
           description: Default error response
           content:
@@ -1818,172 +1984,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/UpdateWorkflowExecutionResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-  /nexus/endpoints:
-    get:
-      tags:
-        - OperatorService
-      description: |-
-        List all Nexus endpoints for the cluster, sorted by ID in ascending order. Set page_token in the request to the
-         next_page_token field of the previous response to get the next page of results. An empty next_page_token
-         indicates that there are no more results. During pagination, a newly added service with an ID lexicographically
-         earlier than the previous page's last endpoint's ID may be missed.
-      operationId: ListNexusEndpoints
-      parameters:
-        - name: pageSize
-          in: query
-          schema:
-            type: integer
-            format: int32
-        - name: nextPageToken
-          in: query
-          description: |-
-            To get the next page, pass in `ListNexusEndpointsResponse.next_page_token` from the previous page's
-             response, the token will be empty if there's no other page.
-             Note: the last page may be empty if the total number of endpoints registered is a multiple of the page size.
-          schema:
-            type: string
-            format: bytes
-        - name: name
-          in: query
-          description: |-
-            Name of the incoming endpoint to filter on - optional. Specifying this will result in zero or one results.
-             (-- api-linter: core::203::field-behavior-required=disabled
-                 aip.dev/not-precedent: Not following linter rules. --)
-          schema:
-            type: string
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListNexusEndpointsResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-    post:
-      tags:
-        - OperatorService
-      description: |-
-        Create a Nexus endpoint. This will fail if an endpoint with the same name is already registered with a status of
-         ALREADY_EXISTS.
-         Returns the created endpoint with its initial version. You may use this version for subsequent updates.
-      operationId: CreateNexusEndpoint
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateNexusEndpointRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CreateNexusEndpointResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-  /nexus/endpoints/{id}:
-    get:
-      tags:
-        - OperatorService
-      description: Get a registered Nexus endpoint by ID. The returned version can be used for optimistic updates.
-      operationId: GetNexusEndpoint
-      parameters:
-        - name: id
-          in: path
-          description: Server-generated unique endpoint ID.
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetNexusEndpointResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-    delete:
-      tags:
-        - OperatorService
-      description: Delete an incoming Nexus service by ID.
-      operationId: DeleteNexusEndpoint
-      parameters:
-        - name: id
-          in: path
-          description: Server-generated unique endpoint ID.
-          required: true
-          schema:
-            type: string
-        - name: version
-          in: query
-          description: Data version for this endpoint. Must match current version.
-          schema:
-            type: string
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DeleteNexusEndpointResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-  /nexus/endpoints/{id}/update:
-    post:
-      tags:
-        - OperatorService
-      description: |-
-        Optimistically update a Nexus endpoint based on provided version as obtained via the `GetNexusEndpoint` or
-         `ListNexusEndpointResponse` APIs. This will fail with a status of FAILED_PRECONDITION if the version does not
-         match.
-         Returns the updated endpoint with its updated version. You may use this version for subsequent updates. You don't
-         need to increment the version yourself. The server will increment the version for you after each update.
-      operationId: UpdateNexusEndpoint
-      parameters:
-        - name: id
-          in: path
-          description: Server-generated unique endpoint ID.
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UpdateNexusEndpointRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UpdateNexusEndpointResponse'
         default:
           description: Default error response
           content:

--- a/temporal/api/operatorservice/v1/service.proto
+++ b/temporal/api/operatorservice/v1/service.proto
@@ -58,7 +58,7 @@ service OperatorService {
     // ListSearchAttributes returns comprehensive information about search attributes.
     rpc ListSearchAttributes (ListSearchAttributesRequest) returns (ListSearchAttributesResponse) {
         option (google.api.http) = {
-            get: "/namespaces/{namespace}/search-attributes",
+            get: "/cluster/namespaces/{namespace}/search-attributes",
         };
     }
 
@@ -81,7 +81,7 @@ service OperatorService {
     // Get a registered Nexus endpoint by ID. The returned version can be used for optimistic updates.
     rpc GetNexusEndpoint(GetNexusEndpointRequest) returns (GetNexusEndpointResponse) {
         option (google.api.http) = {
-            get: "/nexus/endpoints/{id}"
+            get: "/cluster/nexus/endpoints/{id}"
         };
     }
 
@@ -90,7 +90,7 @@ service OperatorService {
     // Returns the created endpoint with its initial version. You may use this version for subsequent updates.
     rpc CreateNexusEndpoint(CreateNexusEndpointRequest) returns (CreateNexusEndpointResponse) {
         option (google.api.http) = {
-            post: "/nexus/endpoints"
+            post: "/cluster/nexus/endpoints"
             body: "*"
         };
     }
@@ -102,7 +102,7 @@ service OperatorService {
     // need to increment the version yourself. The server will increment the version for you after each update.
     rpc UpdateNexusEndpoint(UpdateNexusEndpointRequest) returns (UpdateNexusEndpointResponse) {
         option (google.api.http) = {
-            post: "/nexus/endpoints/{id}/update"
+            post: "/cluster/nexus/endpoints/{id}/update"
             body: "*"
         };
     }
@@ -110,7 +110,7 @@ service OperatorService {
     // Delete an incoming Nexus service by ID.
     rpc DeleteNexusEndpoint(DeleteNexusEndpointRequest) returns (DeleteNexusEndpointResponse) {
         option (google.api.http) = {
-            delete: "/nexus/endpoints/{id}"
+            delete: "/cluster/nexus/endpoints/{id}"
         };
     }
 
@@ -120,7 +120,7 @@ service OperatorService {
     // earlier than the previous page's last endpoint's ID may be missed.
     rpc ListNexusEndpoints(ListNexusEndpointsRequest) returns (ListNexusEndpointsResponse) {
         option (google.api.http) = {
-            get: "/nexus/endpoints"
+            get: "/cluster/nexus/endpoints"
         };
     }
 }

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -56,7 +56,7 @@ service WorkflowService {
     // namespace.
     rpc RegisterNamespace (RegisterNamespaceRequest) returns (RegisterNamespaceResponse) {
         option (google.api.http) = {
-            post: "/namespaces"
+            post: "/cluster/namespaces"
             body: "*"
         };
     }
@@ -64,14 +64,14 @@ service WorkflowService {
     // DescribeNamespace returns the information and configuration for a registered namespace.
     rpc DescribeNamespace (DescribeNamespaceRequest) returns (DescribeNamespaceResponse) {
         option (google.api.http) = {
-            get: "/namespaces/{namespace}"
+            get: "/cluster/namespaces/{namespace}"
         };
     }
 
     // ListNamespaces returns the information and configuration for all namespaces.
     rpc ListNamespaces (ListNamespacesRequest) returns (ListNamespacesResponse) {
         option (google.api.http) = {
-            get: "/namespaces"
+            get: "/cluster/namespaces"
         };
     }
 
@@ -79,7 +79,7 @@ service WorkflowService {
     // namespace.
     rpc UpdateNamespace (UpdateNamespaceRequest) returns (UpdateNamespaceResponse) {
         option (google.api.http) = {
-            post: "/namespaces/{namespace}/update"
+            post: "/cluster/namespaces/{namespace}/update"
             body: "*"
         };
     }


### PR DESCRIPTION
**Why?**

To annotate that these APIs are for self hosted clusters only.

**Breaking changes**

Yes, but the HTTP API is still not officially released.