### PR TITLE
Fix outdated request_eager_execution attr name for Activity

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -9492,7 +9492,7 @@
             "type": "object",
             "$ref": "#/definitions/v1PollActivityTaskQueueResponse"
           },
-          "title": "See `ScheduleActivityTaskCommandAttributes::request_start`"
+          "title": "See `ScheduleActivityTaskCommandAttributes::request_eager_execution`"
         },
         "resetHistoryEventId": {
           "type": "string",

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -355,7 +355,7 @@ message RespondWorkflowTaskCompletedRequest {
 message RespondWorkflowTaskCompletedResponse {
     // See `RespondWorkflowTaskCompletedResponse::return_new_workflow_task`
     PollWorkflowTaskQueueResponse workflow_task = 1;
-    // See `ScheduleActivityTaskCommandAttributes::request_start`
+    // See `ScheduleActivityTaskCommandAttributes::request_eager_execution`
     repeated PollActivityTaskQueueResponse activity_tasks = 2;
     // If non zero, indicates the server has discarded the workflow task that was being responded to.
     // Will be the event ID of the last workflow task started event in the history before the new workflow task.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Rectify the attr name which was changed in the spec a while back at:
https://github.com/temporalio/api/commit/bc22e6ac3a0b0df0ed25e06c344f4921bcf1530d
