### PR TITLE
Add Request ID to nexus completion events

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -8337,9 +8337,9 @@
           "$ref": "#/definitions/apifailurev1Failure",
           "description": "Cancellation details."
         },
-        "operationInitialVersionedTransition": {
-          "$ref": "#/definitions/v1VersionedTransition",
-          "description": "The execution's versioned transition at the time the operation was scheduled."
+        "requestId": {
+          "type": "string",
+          "description": "The request ID allocated at schedule time."
         }
       },
       "description": "Nexus operation completed as canceled. May or may not have been due to a cancellation request by the workflow."
@@ -8402,9 +8402,9 @@
           "$ref": "#/definitions/v1Payload",
           "description": "Serialized result of the Nexus operation. The response of the Nexus handler.\nDelivered either via a completion callback or as a response to a synchronous operation."
         },
-        "operationInitialVersionedTransition": {
-          "$ref": "#/definitions/v1VersionedTransition",
-          "description": "The execution's versioned transition at the time the operation was scheduled."
+        "requestId": {
+          "type": "string",
+          "description": "The request ID allocated at schedule time."
         }
       },
       "description": "Nexus operation completed successfully."
@@ -8421,9 +8421,9 @@
           "$ref": "#/definitions/apifailurev1Failure",
           "description": "Failure details. A NexusOperationFailureInfo wrapping an ApplicationFailureInfo."
         },
-        "operationInitialVersionedTransition": {
-          "$ref": "#/definitions/v1VersionedTransition",
-          "description": "The execution's versioned transition at the time the operation was scheduled."
+        "requestId": {
+          "type": "string",
+          "description": "The request ID allocated at schedule time."
         }
       },
       "description": "Nexus operation failed."
@@ -8527,9 +8527,9 @@
           "$ref": "#/definitions/apifailurev1Failure",
           "description": "Failure details. A NexusOperationFailureInfo wrapping a CanceledFailureInfo."
         },
-        "operationInitialVersionedTransition": {
-          "$ref": "#/definitions/v1VersionedTransition",
-          "description": "The execution's versioned transition at the time the operation was scheduled."
+        "requestId": {
+          "type": "string",
+          "description": "The request ID allocated at schedule time."
         }
       },
       "description": "Nexus operation timed out."
@@ -11127,22 +11127,6 @@
         }
       },
       "description": "VersionInfo contains details about current and recommended release versions as well as alerts and upgrade instructions."
-    },
-    "v1VersionedTransition": {
-      "type": "object",
-      "properties": {
-        "namespaceFailoverVersion": {
-          "type": "string",
-          "format": "int64",
-          "description": "The namespace failover version at transition time."
-        },
-        "transitionCount": {
-          "type": "string",
-          "format": "int64",
-          "description": "State transition count perceived during the specified namespace_failover_version."
-        }
-      },
-      "description": "VersionedTransition is a unique identifier for a specific mutable state transition.\nThis identifier is used by the server for staleness checks and conflict resolution."
     },
     "v1WaitPolicy": {
       "type": "object",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -8336,6 +8336,10 @@
         "failure": {
           "$ref": "#/definitions/apifailurev1Failure",
           "description": "Cancellation details."
+        },
+        "operationInitialVersionedTransition": {
+          "$ref": "#/definitions/v1VersionedTransition",
+          "description": "The execution's versioned transition at the time the operation was scheduled."
         }
       },
       "description": "Nexus operation completed as canceled. May or may not have been due to a cancellation request by the workflow."
@@ -8397,6 +8401,10 @@
         "result": {
           "$ref": "#/definitions/v1Payload",
           "description": "Serialized result of the Nexus operation. The response of the Nexus handler.\nDelivered either via a completion callback or as a response to a synchronous operation."
+        },
+        "operationInitialVersionedTransition": {
+          "$ref": "#/definitions/v1VersionedTransition",
+          "description": "The execution's versioned transition at the time the operation was scheduled."
         }
       },
       "description": "Nexus operation completed successfully."
@@ -8412,6 +8420,10 @@
         "failure": {
           "$ref": "#/definitions/apifailurev1Failure",
           "description": "Failure details. A NexusOperationFailureInfo wrapping an ApplicationFailureInfo."
+        },
+        "operationInitialVersionedTransition": {
+          "$ref": "#/definitions/v1VersionedTransition",
+          "description": "The execution's versioned transition at the time the operation was scheduled."
         }
       },
       "description": "Nexus operation failed."
@@ -8514,6 +8526,10 @@
         "failure": {
           "$ref": "#/definitions/apifailurev1Failure",
           "description": "Failure details. A NexusOperationFailureInfo wrapping a CanceledFailureInfo."
+        },
+        "operationInitialVersionedTransition": {
+          "$ref": "#/definitions/v1VersionedTransition",
+          "description": "The execution's versioned transition at the time the operation was scheduled."
         }
       },
       "description": "Nexus operation timed out."
@@ -11111,6 +11127,22 @@
         }
       },
       "description": "VersionInfo contains details about current and recommended release versions as well as alerts and upgrade instructions."
+    },
+    "v1VersionedTransition": {
+      "type": "object",
+      "properties": {
+        "namespaceFailoverVersion": {
+          "type": "string",
+          "format": "int64",
+          "description": "The namespace failover version at transition time."
+        },
+        "transitionCount": {
+          "type": "string",
+          "format": "int64",
+          "description": "State transition count perceived during the specified namespace_failover_version."
+        }
+      },
+      "description": "VersionedTransition is a unique identifier for a specific mutable state transition.\nThis identifier is used by the server for staleness checks and conflict resolution."
     },
     "v1WaitPolicy": {
       "type": "object",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -6121,6 +6121,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/Failure'
           description: Cancellation details.
+        operationInitialVersionedTransition:
+          allOf:
+            - $ref: '#/components/schemas/VersionedTransition'
+          description: The execution's versioned transition at the time the operation was scheduled.
       description: Nexus operation completed as canceled. May or may not have been due to a cancellation request by the workflow.
     NexusOperationCancellationInfo:
       type: object
@@ -6170,6 +6174,10 @@ components:
           description: |-
             Serialized result of the Nexus operation. The response of the Nexus handler.
              Delivered either via a completion callback or as a response to a synchronous operation.
+        operationInitialVersionedTransition:
+          allOf:
+            - $ref: '#/components/schemas/VersionedTransition'
+          description: The execution's versioned transition at the time the operation was scheduled.
       description: Nexus operation completed successfully.
     NexusOperationFailedEventAttributes:
       type: object
@@ -6181,6 +6189,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/Failure'
           description: Failure details. A NexusOperationFailureInfo wrapping an ApplicationFailureInfo.
+        operationInitialVersionedTransition:
+          allOf:
+            - $ref: '#/components/schemas/VersionedTransition'
+          description: The execution's versioned transition at the time the operation was scheduled.
       description: Nexus operation failed.
     NexusOperationFailureInfo:
       type: object
@@ -6277,6 +6289,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/Failure'
           description: Failure details. A NexusOperationFailureInfo wrapping a CanceledFailureInfo.
+        operationInitialVersionedTransition:
+          allOf:
+            - $ref: '#/components/schemas/VersionedTransition'
+          description: The execution's versioned transition at the time the operation was scheduled.
       description: Nexus operation timed out.
     Outcome:
       type: object
@@ -8584,6 +8600,18 @@ components:
           type: string
           format: date-time
       description: VersionInfo contains details about current and recommended release versions as well as alerts and upgrade instructions.
+    VersionedTransition:
+      type: object
+      properties:
+        namespaceFailoverVersion:
+          type: string
+          description: The namespace failover version at transition time.
+        transitionCount:
+          type: string
+          description: State transition count perceived during the specified namespace_failover_version.
+      description: |-
+        VersionedTransition is a unique identifier for a specific mutable state transition.
+         This identifier is used by the server for staleness checks and conflict resolution.
     WaitPolicy:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -6121,10 +6121,9 @@ components:
           allOf:
             - $ref: '#/components/schemas/Failure'
           description: Cancellation details.
-        operationInitialVersionedTransition:
-          allOf:
-            - $ref: '#/components/schemas/VersionedTransition'
-          description: The execution's versioned transition at the time the operation was scheduled.
+        requestId:
+          type: string
+          description: The request ID allocated at schedule time.
       description: Nexus operation completed as canceled. May or may not have been due to a cancellation request by the workflow.
     NexusOperationCancellationInfo:
       type: object
@@ -6174,10 +6173,9 @@ components:
           description: |-
             Serialized result of the Nexus operation. The response of the Nexus handler.
              Delivered either via a completion callback or as a response to a synchronous operation.
-        operationInitialVersionedTransition:
-          allOf:
-            - $ref: '#/components/schemas/VersionedTransition'
-          description: The execution's versioned transition at the time the operation was scheduled.
+        requestId:
+          type: string
+          description: The request ID allocated at schedule time.
       description: Nexus operation completed successfully.
     NexusOperationFailedEventAttributes:
       type: object
@@ -6189,10 +6187,9 @@ components:
           allOf:
             - $ref: '#/components/schemas/Failure'
           description: Failure details. A NexusOperationFailureInfo wrapping an ApplicationFailureInfo.
-        operationInitialVersionedTransition:
-          allOf:
-            - $ref: '#/components/schemas/VersionedTransition'
-          description: The execution's versioned transition at the time the operation was scheduled.
+        requestId:
+          type: string
+          description: The request ID allocated at schedule time.
       description: Nexus operation failed.
     NexusOperationFailureInfo:
       type: object
@@ -6289,10 +6286,9 @@ components:
           allOf:
             - $ref: '#/components/schemas/Failure'
           description: Failure details. A NexusOperationFailureInfo wrapping a CanceledFailureInfo.
-        operationInitialVersionedTransition:
-          allOf:
-            - $ref: '#/components/schemas/VersionedTransition'
-          description: The execution's versioned transition at the time the operation was scheduled.
+        requestId:
+          type: string
+          description: The request ID allocated at schedule time.
       description: Nexus operation timed out.
     Outcome:
       type: object
@@ -8600,18 +8596,6 @@ components:
           type: string
           format: date-time
       description: VersionInfo contains details about current and recommended release versions as well as alerts and upgrade instructions.
-    VersionedTransition:
-      type: object
-      properties:
-        namespaceFailoverVersion:
-          type: string
-          description: The namespace failover version at transition time.
-        transitionCount:
-          type: string
-          description: State transition count perceived during the specified namespace_failover_version.
-      description: |-
-        VersionedTransition is a unique identifier for a specific mutable state transition.
-         This identifier is used by the server for staleness checks and conflict resolution.
     WaitPolicy:
       type: object
       properties:

--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -196,3 +196,12 @@ message Callback {
         Nexus nexus = 2;
     }
 }
+
+// VersionedTransition is a unique identifier for a specific mutable state transition.
+// This identifier is used by the server for staleness checks and conflict resolution.
+message VersionedTransition {
+    // The namespace failover version at transition time.
+    int64 namespace_failover_version = 1;
+    // State transition count perceived during the specified namespace_failover_version.
+    int64 transition_count = 2;
+}

--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -196,12 +196,3 @@ message Callback {
         Nexus nexus = 2;
     }
 }
-
-// VersionedTransition is a unique identifier for a specific mutable state transition.
-// This identifier is used by the server for staleness checks and conflict resolution.
-message VersionedTransition {
-    // The namespace failover version at transition time.
-    int64 namespace_failover_version = 1;
-    // State transition count perceived during the specified namespace_failover_version.
-    int64 transition_count = 2;
-}

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -849,8 +849,8 @@ message NexusOperationCompletedEventAttributes {
     // Delivered either via a completion callback or as a response to a synchronous operation.
     temporal.api.common.v1.Payload result = 2;
 
-    // The execution's versioned transition at the time the operation was scheduled.
-    temporal.api.common.v1.VersionedTransition operation_initial_versioned_transition = 3;
+    // The request ID allocated at schedule time.
+    string request_id = 3;
 }
 
 // Nexus operation failed.
@@ -860,8 +860,8 @@ message NexusOperationFailedEventAttributes {
     // Failure details. A NexusOperationFailureInfo wrapping an ApplicationFailureInfo.
     temporal.api.failure.v1.Failure failure = 2;
 
-    // The execution's versioned transition at the time the operation was scheduled.
-    temporal.api.common.v1.VersionedTransition operation_initial_versioned_transition = 3;
+    // The request ID allocated at schedule time.
+    string request_id = 3;
 }
 
 // Nexus operation timed out.
@@ -871,8 +871,8 @@ message NexusOperationTimedOutEventAttributes {
     // Failure details. A NexusOperationFailureInfo wrapping a CanceledFailureInfo.
     temporal.api.failure.v1.Failure failure = 2;
 
-    // The execution's versioned transition at the time the operation was scheduled.
-    temporal.api.common.v1.VersionedTransition operation_initial_versioned_transition = 3;
+    // The request ID allocated at schedule time.
+    string request_id = 3;
 }
 
 // Nexus operation completed as canceled. May or may not have been due to a cancellation request by the workflow.
@@ -882,8 +882,8 @@ message NexusOperationCanceledEventAttributes {
     // Cancellation details.
     temporal.api.failure.v1.Failure failure = 2;
 
-    // The execution's versioned transition at the time the operation was scheduled.
-    temporal.api.common.v1.VersionedTransition operation_initial_versioned_transition = 3;
+    // The request ID allocated at schedule time.
+    string request_id = 3;
 }
 
 message NexusOperationCancelRequestedEventAttributes {

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -848,6 +848,9 @@ message NexusOperationCompletedEventAttributes {
     // Serialized result of the Nexus operation. The response of the Nexus handler.
     // Delivered either via a completion callback or as a response to a synchronous operation.
     temporal.api.common.v1.Payload result = 2;
+
+    // The execution's versioned transition at the time the operation was scheduled.
+    temporal.api.common.v1.VersionedTransition operation_initial_versioned_transition = 3;
 }
 
 // Nexus operation failed.
@@ -856,6 +859,9 @@ message NexusOperationFailedEventAttributes {
     int64 scheduled_event_id = 1;
     // Failure details. A NexusOperationFailureInfo wrapping an ApplicationFailureInfo.
     temporal.api.failure.v1.Failure failure = 2;
+
+    // The execution's versioned transition at the time the operation was scheduled.
+    temporal.api.common.v1.VersionedTransition operation_initial_versioned_transition = 3;
 }
 
 // Nexus operation timed out.
@@ -864,6 +870,9 @@ message NexusOperationTimedOutEventAttributes {
     int64 scheduled_event_id = 1;
     // Failure details. A NexusOperationFailureInfo wrapping a CanceledFailureInfo.
     temporal.api.failure.v1.Failure failure = 2;
+
+    // The execution's versioned transition at the time the operation was scheduled.
+    temporal.api.common.v1.VersionedTransition operation_initial_versioned_transition = 3;
 }
 
 // Nexus operation completed as canceled. May or may not have been due to a cancellation request by the workflow.
@@ -872,6 +881,9 @@ message NexusOperationCanceledEventAttributes {
     int64 scheduled_event_id = 1;
     // Cancellation details.
     temporal.api.failure.v1.Failure failure = 2;
+
+    // The execution's versioned transition at the time the operation was scheduled.
+    temporal.api.common.v1.VersionedTransition operation_initial_versioned_transition = 3;
 }
 
 message NexusOperationCancelRequestedEventAttributes {


### PR DESCRIPTION
**Why?**

We need this information to safely reapply completion events during namespace failover.
Without this information, we could potentially apply a completion for the wrong operation.