### PR TITLE
Add request ID to NexusOperationStarted event

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -8511,6 +8511,10 @@
         "operationId": {
           "type": "string",
           "description": "The operation ID returned by the Nexus handler in the response to the StartOperation request.\nThis ID is used when canceling the operation."
+        },
+        "requestId": {
+          "type": "string",
+          "description": "The request ID allocated at schedule time."
         }
       },
       "description": "Event marking an asynchronous operation was started by the responding Nexus handler.\nIf the operation completes synchronously, this event is not generated.\nIn rare situations, such as request timeouts, the service may fail to record the actual start time and will fabricate\nthis event upon receiving the operation completion via callback."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -6271,6 +6271,9 @@ components:
           description: |-
             The operation ID returned by the Nexus handler in the response to the StartOperation request.
              This ID is used when canceling the operation.
+        requestId:
+          type: string
+          description: The request ID allocated at schedule time.
       description: |-
         Event marking an asynchronous operation was started by the responding Nexus handler.
          If the operation completes synchronously, this event is not generated.

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -839,6 +839,9 @@ message NexusOperationStartedEventAttributes {
     // The operation ID returned by the Nexus handler in the response to the StartOperation request.
     // This ID is used when canceling the operation.
     string operation_id = 3;
+
+    // The request ID allocated at schedule time.
+    string request_id = 4;
 }
 
 // Nexus operation completed successfully.


### PR DESCRIPTION
Continuing the work from #432...

Realized we need the request ID also on the started event since it can also be reapplied.
See conversations on that other PR for the rationale.
