### PR TITLE
Expose scheduled event ID on PendingNexusOperationInfo

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -8725,6 +8725,11 @@
         },
         "cancellationInfo": {
           "$ref": "#/definitions/v1NexusOperationCancellationInfo"
+        },
+        "scheduledEventId": {
+          "type": "string",
+          "format": "int64",
+          "description": "The event ID of the NexusOperationScheduled event. Can be used to correlate an operation in the\nDescribeWorkflowExecution response with workflow history."
         }
       },
       "description": "PendingNexusOperationInfo contains the state of a pending Nexus operation."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -6461,6 +6461,11 @@ components:
           format: date-time
         cancellationInfo:
           $ref: '#/components/schemas/NexusOperationCancellationInfo'
+        scheduledEventId:
+          type: string
+          description: |-
+            The event ID of the NexusOperationScheduled event. Can be used to correlate an operation in the
+             DescribeWorkflowExecution response with workflow history.
       description: PendingNexusOperationInfo contains the state of a pending Nexus operation.
     PendingWorkflowTaskInfo:
       type: object

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -273,6 +273,10 @@ message PendingNexusOperationInfo {
     google.protobuf.Timestamp next_attempt_schedule_time = 11;
 
     NexusOperationCancellationInfo cancellation_info = 12;
+
+    // The event ID of the NexusOperationScheduled event. Can be used to correlate an operation in the
+    // DescribeWorkflowExecution response with workflow history.
+    int64 scheduled_event_id = 13;
 }
 
 // NexusOperationCancellationInfo contains the state of a nexus operation cancellation.


### PR DESCRIPTION
**Why?**

So the UI can correlate the info from describe with the history event.