### PR TITLE
GHA to create release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -111,11 +111,6 @@ jobs:
           ref: ${{ needs.prepare-inputs.outputs.api_commit_sha }}
           token: ${{ steps.generate_token.outputs.token }}
 
-      - name: Set up Github credentials
-        run: |
-          git config --local user.name 'Temporal Data'
-          git config --local user.email 'commander-data@temporal.io'
-
       - name: Create release
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,4 +1,4 @@
-name: "Create a tag"
+name: "Create release"
 
 on:
   workflow_dispatch:
@@ -10,10 +10,6 @@ on:
       tag:
         description: "Tag for new version (v1.23.4)"
         required: true
-      create_release:
-        description: "Create release and set as latest"
-        type: boolean
-        default: true
       base_tag:
         description: "Base tag to generate commit list for release notes"
         required: false
@@ -26,55 +22,61 @@ jobs:
     name: "Prepare inputs"
     runs-on: ubuntu-latest
     outputs:
-      tag: ${{ steps.new_version.output.tag }}
-      api_commit_sha: ${{ steps.new_version.output.commit_sha }}
-      api_go_commit_sha: ${{ steps.pin_api_go.output.api_go_commit_sha }}
+      api_commit_sha: ${{ steps.pin_commits.outputs.api_commit_sha }}
+      api_go_commit_sha: ${{ steps.pin_commits.outputs.api_go_commit_sha }}
     steps:
-      - name: Checkout
+      - name: Checkout api
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch }}
           fetch-depth: 0
           fetch-tags: true
+          path: api
 
-      - name: Prepare new version string
-        id: new_version
-        env:
-          TAG: ${{ github.event.inputs.tag }}
-        run: |
-          if [[ "${TAG}" =~ ^v.* ]]; then
-              echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          else
-              echo "tag=v${TAG}" >> "$GITHUB_OUTPUT"
-          fi
-          echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Checkout api-go
+        uses: actions/checkout@v4
+        with:
+          repository: temporalio/api-go
+          ref: ${{ github.event.inputs.branch }}
+          submodules: true
+          path: api-go
 
       - name: Validate inputs
         env:
           BRANCH: ${{ github.event.inputs.branch }}
-          TAG: ${{ steps.new_version.outputs.tag }}
-          CREATE_RELEASE: ${{ github.event.inputs.create_release }}
+          TAG: ${{ github.event.inputs.tag }}
           BASE_TAG: ${{ github.event.inputs.base_tag }}
+        working-directory: ./api
         run: |
-          if [[ -n "$(git tag -l "$TAG")" && "$(git rev-parse "$TAG")" != "$(git rev-parse HEAD)" ]]; then
-            echo "::error::Tag already exists and it doesn't reference current HEAD of branch $BRANCH"
+          if ! [[ "${TAG}" =~ ^v.* ]]; then
+            echo "::error::Tag is not prefixed with 'v'"
             exit 1
           fi
 
-          if [[ "$CREATE_RELEASE" == "true" ]]; then
-            if [[ -z "$BASE_TAG" || -z "$(git tag -l "$BASE_TAG")" ]]; then
-              echo "::error::Base tag not specified or does not exist"
-              exit 1
-            fi
+          if [[ -n "$(git tag -l "$TAG")" ]]; then
+            echo "::error::Tag already exists"
+            exit 1
           fi
 
-      - name: Pin api-go commit sha
-        id: pin_api_go
+          if [[ -z "$BASE_TAG" || -z "$(git tag -l "$BASE_TAG")" ]]; then
+            echo "::error::Base tag not specified or does not exist"
+            exit 1
+          fi
+
+      - name: Pin commits sha
+        id: pin_commits
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: ${{ github.event.inputs.branch }}
         run: |
-          API_GO_COMMIT_SHA=$(gh api /repos/temporalio/api-go/branches/$BRANCH --jq '.commit.sha')
+          API_COMMIT_SHA=$(git -C ./api rev-parse HEAD)
+          API_GO_COMMIT_SHA=$(git -C ./api-go rev-parse HEAD)
+          API_GO_API_COMMIT_SHA=$(git -C ./api-go rev-parse HEAD:proto/api)
+          if [[ "${API_GO_API_COMMIT_SHA}" != "${API_COMMIT_SHA}" ]]; then
+            echo "::error::api-go ref ${API_GO_COMMIT_SHA} does not reference api ref ${API_COMMIT_SHA}, api-go repo might not be up-to-date."
+            exit 1
+          fi
+          echo "api_commit_sha=$API_COMMIT_SHA" >> "$GITHUB_OUTPUT"
           echo "api_go_commit_sha=$API_GO_COMMIT_SHA" >> "$GITHUB_OUTPUT"
 
   check-compatibility-sdk-go:
@@ -82,11 +84,11 @@ jobs:
     if: ${{ github.event.inputs.skip_sdk_check == false || github.event.inputs.skip_sdk_check == 'false' }}
     uses: temporalio/api-go/.github/workflows/check-sdk-compat.yml@master
     with:
-      sdk_commit: latest
-      api_commit: ${{ needs.prepare-inputs.outputs.api_go_commit_sha }}
+      sdk_ref: latest
+      api_ref: ${{ needs.prepare-inputs.outputs.api_go_commit_sha }}
 
-  create-tag:
-    name: "Create a tag"
+  create-release:
+    name: "Create release"
     needs: [prepare-inputs, check-compatibility-sdk-go]
     if: |
       !cancelled() &&
@@ -106,47 +108,33 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare-inputs.outputs.commit_sha }}
+          ref: ${{ needs.prepare-inputs.outputs.api_commit_sha }}
           token: ${{ steps.generate_token.outputs.token }}
-          persist-credentials: true
-          fetch-depth: 0
-          fetch-tags: true
 
       - name: Set up Github credentials
         run: |
           git config --local user.name 'Temporal Data'
           git config --local user.email 'commander-data@temporal.io'
 
-      - name: Create and push tag
-        env:
-          TAG: ${{ needs.prepare-inputs.outputs.tag }}
-        run: |
-          if [[ -z "$(git tag -l "$TAG")" ]]; then
-            git tag "$TAG"
-            git push origin "$TAG"
-          fi
-
       - name: Create release
-        if: ${{ github.event.inputs.create_release == true || github.event.inputs.create_release == 'true' }}
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
-          TAG: ${{ needs.prepare-inputs.outputs.tag }}
+          REF: ${{ needs.prepare-inputs.outputs.api_commit_sha }}
+          TAG: ${{ github.event.inputs.tag }}
           BASE_TAG: ${{ github.event.inputs.base_tag }}
         run: |
           gh repo set-default ${{ github.repository }}
-          gh release create "$TAG" --verify-tag --latest --generate-notes --notes-start-tag "$BASE_TAG"
+          gh release create "$TAG" --target "$REF" --latest --generate-notes --notes-start-tag "$BASE_TAG" --draft
 
   release-api-go:
-    needs: create-tag
+    needs: [prepare-inputs, create-release]
     if: |
       !cancelled() &&
-      (needs.create-tag.result == 'success') &&
-      (github.event.inputs.create_release == true || github.event.inputs.create_release == 'true')
-    uses: temporalio/api-go/.github/workflows/create-tag.yml@master
+      needs.create-release.result == 'success'
+    uses: temporalio/api-go/.github/workflows/create-release.yml@master
     with:
       ref: ${{ needs.prepare-inputs.outputs.api_go_commit_sha }}
-      tag: ${{ needs.prepare-inputs.outputs.tag }}
-      create_release: true
+      tag: ${{ github.event.inputs.tag }}
+      api_commit_sha: ${{ needs.prepare-inputs.outputs.api_commit_sha }}
       base_tag: ${{ github.event.inputs.base_tag }}
-      skip_sdk_check: true
     secrets: inherit

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -12,7 +12,7 @@ on:
         required: true
       base_tag:
         description: "Base tag to generate commit list for release notes"
-        required: false
+        required: true
       skip_sdk_check:
         description: "Skip sdk-go compatibility check"
         type: boolean

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,0 +1,127 @@
+name: "Create a tag"
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to be tagged"
+        required: true
+        default: master
+      tag:
+        description: "Tag for new version (v1.23.4)"
+        required: true
+      create_release:
+        description: "Create release and set as latest"
+        type: boolean
+        default: true
+      base_tag:
+        description: "Base tag to generate commit list for release notes"
+        required: false
+      skip_sdk_check:
+        description: "Skip sdk-go compatibility check"
+        type: boolean
+        default: false
+
+jobs:
+  create-tag:
+    name: "Create a tag"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
+          private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+          token: ${{ steps.generate_token.outputs.token }}
+          persist-credentials: true
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Github credentials
+        run: |
+          git config --local user.name 'Temporal Data'
+          git config --local user.email 'commander-data@temporal.io'
+
+      - name: Prepare new version string
+        id: new_version
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          if [[ "${TAG}" =~ ^v.* ]]; then
+              echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          else
+              echo "tag=v${TAG}" >> "$GITHUB_OUTPUT"
+          fi
+          echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Validate input
+        env:
+          BRANCH: ${{ inputs.branch }}
+          TAG: ${{ steps.new_version.outputs.tag }}
+          CREATE_RELEASE: ${{ inputs.create_release }}
+          BASE_TAG: ${{ inputs.base_tag }}
+        run: |
+          if [[ -n "$(git tag -l "$TAG")" && "$(git rev-parse "$TAG")" != "$(git rev-parse HEAD)" ]]; then
+            echo "::error::Tag already exists and it doesn't reference current HEAD of branch $BRANCH"
+            exit 1
+          fi
+
+          if [[ "$CREATE_RELEASE" == "true" ]]; then
+            if [[ -z "$BASE_TAG" || -z "$(git tag -l "$BASE_TAG")" ]]; then
+              echo "::error::Base tag not specified or does not exist"
+              exit 1
+            fi
+          fi
+
+      - name: Pin api-go commit sha
+        id: pin-api-go
+        env:
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          API_GO_COMMIT_SHA=$(gh api /repos/temporalio/api-go/branches/$BRANCH --jq '.commit.sha')
+          echo "API_GO_COMMIT_SHA=$API_GO_COMMIT_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Check compatibility with sdk-go
+        if: ${{ inputs.skip_sdk_check == 'false'  }}
+        uses: temporalio/sdk-go/.github/workflows/check-api-go.yml@master
+        with:
+          sdk_commit: latest
+          api_commit: ${{ steps.pin-api-go.outputs.API_GO_COMMIT_SHA }}
+
+      - name: Create and push tag
+        env:
+          BRANCH: ${{ inputs.branch }}
+          TAG: ${{ steps.new_version.outputs.tag }}
+        run: |
+          if [[ -z "$(git tag -l "$TAG")" ]]; then
+            git tag "$TAG"
+            git push origin "$TAG"
+          fi
+
+      - name: Create release
+        if: ${{ inputs.create_release == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+          TAG: ${{ steps.new_version.outputs.tag }}
+          BASE_TAG: ${{ inputs.base_tag }}
+        run: |
+          gh repo set-default ${{ github.repository }}
+          gh release create "$TAG" --verify-tag --latest --generate-notes --notes-start-tag "$BASE_TAG"
+
+      - name: Release api-go
+        if: ${{ inputs.create_release == 'true' }}
+        uses: temporalio/api-go/.workflows/create-tag.yml@master
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+          ref: ${{ steps.pin-api-go.outputs.API_GO_COMMIT_SHA }}
+          tag: ${{ steps.new_version.outputs.tag }}
+          create_release: true
+          base_tag: ${{ inputs.base_tag }}

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -20,40 +20,27 @@ on:
       skip_sdk_check:
         description: "Skip sdk-go compatibility check"
         type: boolean
-        default: false
 
 jobs:
-  create-tag:
-    name: "Create a tag"
+  prepare-inputs:
+    name: "Prepare inputs"
     runs-on: ubuntu-latest
-
+    outputs:
+      tag: ${{ steps.new_version.output.tag }}
+      api_commit_sha: ${{ steps.new_version.output.commit_sha }}
+      api_go_commit_sha: ${{ steps.pin_api_go.output.api_go_commit_sha }}
     steps:
-      - name: Generate token
-        id: generate_token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
-          private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
-          token: ${{ steps.generate_token.outputs.token }}
-          persist-credentials: true
+          ref: ${{ github.event.inputs.branch }}
           fetch-depth: 0
           fetch-tags: true
-
-      - name: Set up Github credentials
-        run: |
-          git config --local user.name 'Temporal Data'
-          git config --local user.email 'commander-data@temporal.io'
 
       - name: Prepare new version string
         id: new_version
         env:
-          TAG: ${{ inputs.tag }}
+          TAG: ${{ github.event.inputs.tag }}
         run: |
           if [[ "${TAG}" =~ ^v.* ]]; then
               echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
@@ -62,12 +49,12 @@ jobs:
           fi
           echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Validate input
+      - name: Validate inputs
         env:
-          BRANCH: ${{ inputs.branch }}
+          BRANCH: ${{ github.event.inputs.branch }}
           TAG: ${{ steps.new_version.outputs.tag }}
-          CREATE_RELEASE: ${{ inputs.create_release }}
-          BASE_TAG: ${{ inputs.base_tag }}
+          CREATE_RELEASE: ${{ github.event.inputs.create_release }}
+          BASE_TAG: ${{ github.event.inputs.base_tag }}
         run: |
           if [[ -n "$(git tag -l "$TAG")" && "$(git rev-parse "$TAG")" != "$(git rev-parse HEAD)" ]]; then
             echo "::error::Tag already exists and it doesn't reference current HEAD of branch $BRANCH"
@@ -82,24 +69,57 @@ jobs:
           fi
 
       - name: Pin api-go commit sha
-        id: pin-api-go
+        id: pin_api_go
         env:
-          BRANCH: ${{ inputs.branch }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.event.inputs.branch }}
         run: |
           API_GO_COMMIT_SHA=$(gh api /repos/temporalio/api-go/branches/$BRANCH --jq '.commit.sha')
-          echo "API_GO_COMMIT_SHA=$API_GO_COMMIT_SHA" >> "$GITHUB_OUTPUT"
+          echo "api_go_commit_sha=$API_GO_COMMIT_SHA" >> "$GITHUB_OUTPUT"
 
-      - name: Check compatibility with sdk-go
-        if: ${{ inputs.skip_sdk_check == 'false'  }}
-        uses: temporalio/sdk-go/.github/workflows/check-api-go.yml@master
+  check-compatibility-sdk-go:
+    needs: prepare-inputs
+    if: ${{ github.event.inputs.skip_sdk_check == false || github.event.inputs.skip_sdk_check == 'false' }}
+    uses: temporalio/api-go/.github/workflows/check-sdk-compat.yml@master
+    with:
+      sdk_commit: latest
+      api_commit: ${{ needs.prepare-inputs.outputs.api_go_commit_sha }}
+
+  create-tag:
+    name: "Create a tag"
+    needs: [prepare-inputs, check-compatibility-sdk-go]
+    if: |
+      !cancelled() &&
+      needs.prepare-inputs.result == 'success' &&
+      contains(fromJSON('["success", "skipped"]'), needs.check-compatibility-sdk-go.result)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
         with:
-          sdk_commit: latest
-          api_commit: ${{ steps.pin-api-go.outputs.API_GO_COMMIT_SHA }}
+          app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
+          private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-inputs.outputs.commit_sha }}
+          token: ${{ steps.generate_token.outputs.token }}
+          persist-credentials: true
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Github credentials
+        run: |
+          git config --local user.name 'Temporal Data'
+          git config --local user.email 'commander-data@temporal.io'
 
       - name: Create and push tag
         env:
-          BRANCH: ${{ inputs.branch }}
-          TAG: ${{ steps.new_version.outputs.tag }}
+          TAG: ${{ needs.prepare-inputs.outputs.tag }}
         run: |
           if [[ -z "$(git tag -l "$TAG")" ]]; then
             git tag "$TAG"
@@ -107,21 +127,26 @@ jobs:
           fi
 
       - name: Create release
-        if: ${{ inputs.create_release == 'true' }}
+        if: ${{ github.event.inputs.create_release == true || github.event.inputs.create_release == 'true' }}
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
-          TAG: ${{ steps.new_version.outputs.tag }}
-          BASE_TAG: ${{ inputs.base_tag }}
+          TAG: ${{ needs.prepare-inputs.outputs.tag }}
+          BASE_TAG: ${{ github.event.inputs.base_tag }}
         run: |
           gh repo set-default ${{ github.repository }}
           gh release create "$TAG" --verify-tag --latest --generate-notes --notes-start-tag "$BASE_TAG"
 
-      - name: Release api-go
-        if: ${{ inputs.create_release == 'true' }}
-        uses: temporalio/api-go/.workflows/create-tag.yml@master
-        with:
-          token: ${{ steps.generate_token.outputs.token }}
-          ref: ${{ steps.pin-api-go.outputs.API_GO_COMMIT_SHA }}
-          tag: ${{ steps.new_version.outputs.tag }}
-          create_release: true
-          base_tag: ${{ inputs.base_tag }}
+  release-api-go:
+    needs: create-tag
+    if: |
+      !cancelled() &&
+      (needs.create-tag.result == 'success') &&
+      (github.event.inputs.create_release == true || github.event.inputs.create_release == 'true')
+    uses: temporalio/api-go/.github/workflows/create-tag.yml@master
+    with:
+      ref: ${{ needs.prepare-inputs.outputs.api_go_commit_sha }}
+      tag: ${{ needs.prepare-inputs.outputs.tag }}
+      create_release: true
+      base_tag: ${{ github.event.inputs.base_tag }}
+      skip_sdk_check: true
+    secrets: inherit

--- a/.github/workflows/trigger-api-go-delete-release.yml
+++ b/.github/workflows/trigger-api-go-delete-release.yml
@@ -1,0 +1,13 @@
+name: "Trigger api-go delete release"
+
+on:
+  release:
+    types: [deleted]
+
+jobs:
+  trigger-api-go-delete-release:
+    uses: temporalio/api-go/.github/workflows/delete-release.yml@master
+    with:
+      tag: ${{ github.event.release.tag_name }}
+      api_commit_sha: ${{ github.event.release.target_commitish }}
+    secrets: inherit

--- a/.github/workflows/trigger-api-go-publish-release.yml
+++ b/.github/workflows/trigger-api-go-publish-release.yml
@@ -1,0 +1,13 @@
+name: "Trigger api-go publish release"
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  trigger-api-go-publish-release:
+    uses: temporalio/api-go/.github/workflows/publish-release.yml@master
+    with:
+      tag: ${{ github.event.release.tag_name }}
+      api_commit_sha: ${{ github.event.release.target_commitish }}
+    secrets: inherit


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
GHA to create, publish and delete releases.
- `create-release`: manually triggered, it validates the input, checks compatibility with sdk-go, and creates draft releases in `api` and `api-go`.
- `publish-release`: triggered when a release is published, it publishes the corresponding `api-go` release.
- `delete-release`: triggered when a release is deleted, it deletes the corresponding `api-go` release (only works for deleting draft releases).

<!-- Tell your future self why have you made these changes -->
**Why?**
Automation.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
