### PR TITLE
Add internal callback variant

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -4653,6 +4653,17 @@
       "type": "object",
       "description": "Trigger for when the workflow is closed."
     },
+    "CallbackInternal": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string",
+          "format": "byte",
+          "description": "Opaque internal data."
+        }
+      },
+      "description": "Callbacks to be delivered internally within the system.\nThis variant is not settable in the API and will be rejected by the service with an INVALID_ARGUMENT error.\nThe only reason that this is exposed is because callbacks are replicated across clusters via the\nWorkflowExecutionStarted event, which is defined in the public API."
+    },
     "CallbackNexus": {
       "type": "object",
       "properties": {
@@ -6300,6 +6311,9 @@
       "properties": {
         "nexus": {
           "$ref": "#/definitions/CallbackNexus"
+        },
+        "internal": {
+          "$ref": "#/definitions/CallbackInternal"
         }
       },
       "description": "Callback to attach to various events in the system, e.g. workflow run completion."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -4572,6 +4572,8 @@ components:
       properties:
         nexus:
           $ref: '#/components/schemas/Callback_Nexus'
+        internal:
+          $ref: '#/components/schemas/Callback_Internal'
       description: Callback to attach to various events in the system, e.g. workflow run completion.
     CallbackInfo:
       type: object
@@ -4626,6 +4628,18 @@ components:
       type: object
       properties: {}
       description: Trigger for when the workflow is closed.
+    Callback_Internal:
+      type: object
+      properties:
+        data:
+          type: string
+          description: Opaque internal data.
+          format: bytes
+      description: |-
+        Callbacks to be delivered internally within the system.
+         This variant is not settable in the API and will be rejected by the service with an INVALID_ARGUMENT error.
+         The only reason that this is exposed is because callbacks are replicated across clusters via the
+         WorkflowExecutionStarted event, which is defined in the public API.
     Callback_Nexus:
       type: object
       properties:

--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -191,8 +191,18 @@ message Callback {
         map<string, string> header = 2;
     }
 
+    // Callbacks to be delivered internally within the system.
+    // This variant is not settable in the API and will be rejected by the service with an INVALID_ARGUMENT error.
+    // The only reason that this is exposed is because callbacks are replicated across clusters via the
+    // WorkflowExecutionStarted event, which is defined in the public API.
+    message Internal {
+        // Opaque internal data.
+        bytes data = 1;
+    }
+
     reserved 1; // For a generic callback mechanism to be added later.
     oneof variant {
         Nexus nexus = 2;
+        Internal internal = 3;
     }
 }


### PR DESCRIPTION
**What changed?**


Added an internal callback variant for callbacks that are delivered internally within the system.
This variant is not settable in the API and will be rejected by the service with an INVALID_ARGUMENT error.
The only reason that this is exposed is because callbacks are replicated across clusters via the
WorkflowExecutionStarted event, which is defined in the public API.

**Why?**

The first use case for this will be for the scheduler as a state machine rewrite. Later on we'll use this to allow arbitrary workflow to listen for "external" workflow completions.
