### PR TITLE
Add ShutdownStickyTaskQueue internal API

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -10018,6 +10018,9 @@
       ],
       "default": "SEVERITY_UNSPECIFIED"
     },
+    "v1ShutdownStickyTaskQueueResponse": {
+      "type": "object"
+    },
     "v1SignalExternalWorkflowExecutionCommandAttributes": {
       "type": "object",
       "properties": {

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -10018,7 +10018,7 @@
       ],
       "default": "SEVERITY_UNSPECIFIED"
     },
-    "v1ShutdownStickyTaskQueueResponse": {
+    "v1ShutdownWorkerResponse": {
       "type": "object"
     },
     "v1SignalExternalWorkflowExecutionCommandAttributes": {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -869,12 +869,12 @@ message ResetStickyTaskQueueRequest {
 message ResetStickyTaskQueueResponse {
 }
 
-message ShutdownStickyTaskQueueRequest {
+message ShutdownWorkerRequest {
     string namespace = 1;
-    temporal.api.taskqueue.v1.TaskQueue task_queue = 2;
+    string sticky_task_queue = 2;
 }
 
-message ShutdownStickyTaskQueueResponse {
+message ShutdownWorkerResponse {
 }
 
 message QueryWorkflowRequest {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -869,6 +869,14 @@ message ResetStickyTaskQueueRequest {
 message ResetStickyTaskQueueResponse {
 }
 
+message ShutdownStickyTaskQueueRequest {
+    string namespace = 1;
+    temporal.api.taskqueue.v1.TaskQueue task_queue = 2;
+}
+
+message ShutdownStickyTaskQueueResponse {
+}
+
 message QueryWorkflowRequest {
     string namespace = 1;
     temporal.api.common.v1.WorkflowExecution execution = 2;

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -872,6 +872,8 @@ message ResetStickyTaskQueueResponse {
 message ShutdownWorkerRequest {
     string namespace = 1;
     string sticky_task_queue = 2;
+    string identity = 3;
+    string reason = 4;
 }
 
 message ShutdownWorkerResponse {

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -536,7 +536,10 @@ service WorkflowService {
     // in the normal task queue, eligible for any worker to pick up.
     //
     // ShutdownWorker should be called by workers while shutting down,
-    // after they've shut down their pollers.
+    // after they've shut down their pollers. If another sticky poll
+    // request is issued, the sticky task queue will be revived.
+    //
+    // As of Temporal Server v1.25.0, ShutdownWorker hasn't yet been implemented.
     //
     // (-- api-linter: core::0127::http-annotation=disabled
     //     aip.dev/not-precedent: We do not expose worker API to HTTP. --)

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -521,9 +521,26 @@ service WorkflowService {
     // 1. StickyTaskQueue
     // 2. StickyScheduleToStartTimeout
     //
+    // When possible, ShutdownStickyTaskQueue should be preferred over
+    // ResetStickyTaskQueue (particularly when a worker is shutting down or
+    // cycling).
+    //
     // (-- api-linter: core::0127::http-annotation=disabled
     //     aip.dev/not-precedent: We do not expose worker API to HTTP. --)
     rpc ResetStickyTaskQueue (ResetStickyTaskQueueRequest) returns (ResetStickyTaskQueueResponse) {
+    }
+
+    // ShutdownStickyTaskQueue is used to indicate that the given sticky task
+    // queue is no longer being polled by its worker. Following the completion of
+    // ShutdownStickyTaskQueue, newly-added workflow tasks will instead be placed
+    // in the normal task queue, eligible for any worker to pick up.
+    //
+    // ShutdownStickyTaskQueue should be called by workers while shutting down,
+    // after they've shut down their pollers.
+    //
+    // (-- api-linter: core::0127::http-annotation=disabled
+    //     aip.dev/not-precedent: We do not expose worker API to HTTP. --)
+    rpc ShutdownStickyTaskQueue (ShutdownStickyTaskQueueRequest) returns (ShutdownStickyTaskQueueResponse) {
     }
 
     // QueryWorkflow requests a query be executed for a specified workflow execution.

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -521,7 +521,7 @@ service WorkflowService {
     // 1. StickyTaskQueue
     // 2. StickyScheduleToStartTimeout
     //
-    // When possible, ShutdownStickyTaskQueue should be preferred over
+    // When possible, ShutdownWorker should be preferred over
     // ResetStickyTaskQueue (particularly when a worker is shutting down or
     // cycling).
     //
@@ -530,17 +530,17 @@ service WorkflowService {
     rpc ResetStickyTaskQueue (ResetStickyTaskQueueRequest) returns (ResetStickyTaskQueueResponse) {
     }
 
-    // ShutdownStickyTaskQueue is used to indicate that the given sticky task
+    // ShutdownWorker is used to indicate that the given sticky task
     // queue is no longer being polled by its worker. Following the completion of
-    // ShutdownStickyTaskQueue, newly-added workflow tasks will instead be placed
+    // ShutdownWorker, newly-added workflow tasks will instead be placed
     // in the normal task queue, eligible for any worker to pick up.
     //
-    // ShutdownStickyTaskQueue should be called by workers while shutting down,
+    // ShutdownWorker should be called by workers while shutting down,
     // after they've shut down their pollers.
     //
     // (-- api-linter: core::0127::http-annotation=disabled
     //     aip.dev/not-precedent: We do not expose worker API to HTTP. --)
-    rpc ShutdownStickyTaskQueue (ShutdownStickyTaskQueueRequest) returns (ShutdownStickyTaskQueueResponse) {
+    rpc ShutdownWorker (ShutdownWorkerRequest) returns (ShutdownWorkerResponse) {
     }
 
     // QueryWorkflow requests a query be executed for a specified workflow execution.


### PR DESCRIPTION
**What changed?**
- Adds the ShutdownStickyTaskQueue API. 

**Why?**
This API will allow workers to signal shutdown/restart, which Matching can use to unload the shutdown worker's sticky task queue. This will effectively remove the latency incurred from tasks being pushed to a sticky worker after that worker has already been shutdown. 

**Breaking changes**
- None. We aren't changing the existing `ResetStickyTaskQueue` API. This is a fully new API that will hit Matching, instead of History.

**Server PR**
- [Stub PR](https://github.com/temporalio/temporal/pull/6443) 
