### PR TITLE
Document invalid workflow_start_delay option

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -4725,7 +4725,7 @@
       "properties": {
         "startWorkflow": {
           "$ref": "#/definitions/v1StartWorkflowExecutionRequest",
-          "title": "Additional restrictions:\n- setting `cron_schedule` is invalid\n- setting `request_eager_execution` is invalid"
+          "title": "Additional restrictions:\n- setting `cron_schedule` is invalid\n- setting `request_eager_execution` is invalid\n- setting `workflow_start_delay` is invalid"
         },
         "updateWorkflow": {
           "$ref": "#/definitions/v1UpdateWorkflowExecutionRequest",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -5234,6 +5234,7 @@ components:
             Additional restrictions:
              - setting `cron_schedule` is invalid
              - setting `request_eager_execution` is invalid
+             - setting `workflow_start_delay` is invalid
         updateWorkflow:
           allOf:
             - $ref: '#/components/schemas/UpdateWorkflowExecutionRequest'

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1632,6 +1632,7 @@ message ExecuteMultiOperationRequest {
             // Additional restrictions:
             // - setting `cron_schedule` is invalid
             // - setting `request_eager_execution` is invalid
+            // - setting `workflow_start_delay` is invalid
             StartWorkflowExecutionRequest start_workflow = 1;
 
             // Additional restrictions:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Documented invalid option for StartWorkflow inside a MultiOperation.

<!-- Tell your future self why have you made these changes -->
**Why?**

Changed in https://github.com/temporalio/temporal/pull/6414.

Note that this restriction might be lifted eventually, right now we can't support it.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
