### PR TITLE
Add task polling data to task responses

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -8942,9 +8942,9 @@
           "$ref": "#/definitions/v1RetryPolicy",
           "description": "This is the retry policy the service uses which may be different from the one provided\n(or not) during activity scheduling. The service can override the provided one if some\nvalues are not specified or exceed configured system limits."
         },
-        "syncMatchWaitDuration": {
-          "type": "string",
-          "description": "This field is set if the task was delivered as a result of a sync match, and it is set to the\namount of time we waited to make such a match. If the task was delievered from the blacklog,\nthen the field is unset."
+        "taskResponseData": {
+          "$ref": "#/definitions/v1TaskResponsePollingData",
+          "description": "See `TaskResponsePollingData`\nNOTE: Not yet implemented. Update this docstring when released with version."
         }
       }
     },
@@ -8960,9 +8960,9 @@
           "$ref": "#/definitions/apinexusv1Request",
           "description": "Embedded request as translated from the incoming frontend request."
         },
-        "syncMatchWaitDuration": {
-          "type": "string",
-          "description": "This field is set if the task was delivered as a result of a sync match, and it is set to the\namount of time we waited to make such a match. If the task was delievered from the blacklog,\nthen the field is unset."
+        "taskResponseData": {
+          "$ref": "#/definitions/v1TaskResponsePollingData",
+          "description": "See `TaskResponsePollingData`\nNOTE: Not yet implemented. Update this docstring when released with version."
         }
       }
     },
@@ -9059,9 +9059,9 @@
           },
           "title": "Protocol messages piggybacking on a WFT as a transport"
         },
-        "syncMatchWaitDuration": {
-          "type": "string",
-          "description": "This field is set if the task was delivered as a result of a sync match, and it is set to the\namount of time we waited to make such a match. If the task was delievered from the blacklog,\nthen the field is unset."
+        "taskResponseData": {
+          "$ref": "#/definitions/v1TaskResponsePollingData",
+          "description": "See `TaskResponsePollingData`\nNOTE: Not yet implemented. Update this docstring when released with version."
         }
       }
     },
@@ -10907,6 +10907,24 @@
       ],
       "default": "TASK_REACHABILITY_UNSPECIFIED",
       "description": "Specifies which category of tasks may reach a worker on a versioned task queue.\nUsed both in a reachability query and its response.\nDeprecated.\n\n - TASK_REACHABILITY_NEW_WORKFLOWS: There's a possiblity for a worker to receive new workflow tasks. Workers should *not* be retired.\n - TASK_REACHABILITY_EXISTING_WORKFLOWS: There's a possiblity for a worker to receive existing workflow and activity tasks from existing workflows. Workers\nshould *not* be retired.\nThis enum value does not distinguish between open and closed workflows.\n - TASK_REACHABILITY_OPEN_WORKFLOWS: There's a possiblity for a worker to receive existing workflow and activity tasks from open workflows. Workers\nshould *not* be retired.\n - TASK_REACHABILITY_CLOSED_WORKFLOWS: There's a possiblity for a worker to receive existing workflow tasks from closed workflows. Workers may be\nretired dependending on application requirements. For example, if there's no need to query closed workflows."
+    },
+    "v1TaskResponsePollingData": {
+      "type": "object",
+      "properties": {
+        "wasSyncMatch": {
+          "type": "boolean",
+          "description": "Set to true if the returned task was a result of a sync match."
+        },
+        "timePollerWaited": {
+          "type": "string",
+          "description": "Set to the amount of time a poll call waited for a task to be available. This value is allowed to be unset\nif the match was not sync. It is useful to help the SDK understand if it may reduce the number of pollers, since\nany substantial wait time here means the backlog is drained, and poll calls are idling waiting for tasks."
+        },
+        "stats": {
+          "$ref": "#/definitions/v1TaskQueueStats",
+          "description": "See `TaskQueueStats`. This field is only set if the poll hit the root partition, where the data is readily\navailable. SDKs should cache this data, and explicitly refresh it with a call to `DescribeTaskQueue` if some\nTTL has expired."
+        }
+      },
+      "description": "Data attached to successful poll responses (for any task type) which the SDK can use to optimize its polling\nstrategy."
     },
     "v1TerminateWorkflowExecutionResponse": {
       "type": "object"

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -8941,6 +8941,10 @@
         "retryPolicy": {
           "$ref": "#/definitions/v1RetryPolicy",
           "description": "This is the retry policy the service uses which may be different from the one provided\n(or not) during activity scheduling. The service can override the provided one if some\nvalues are not specified or exceed configured system limits."
+        },
+        "syncMatchWaitDuration": {
+          "type": "string",
+          "description": "This field is set if the task was delivered as a result of a sync match, and it is set to the\namount of time we waited to make such a match. If the task was delievered from the blacklog,\nthen the field is unset."
         }
       }
     },
@@ -8955,6 +8959,10 @@
         "request": {
           "$ref": "#/definitions/apinexusv1Request",
           "description": "Embedded request as translated from the incoming frontend request."
+        },
+        "syncMatchWaitDuration": {
+          "type": "string",
+          "description": "This field is set if the task was delivered as a result of a sync match, and it is set to the\namount of time we waited to make such a match. If the task was delievered from the blacklog,\nthen the field is unset."
         }
       }
     },
@@ -9050,6 +9058,10 @@
             "$ref": "#/definitions/v1Message"
           },
           "title": "Protocol messages piggybacking on a WFT as a transport"
+        },
+        "syncMatchWaitDuration": {
+          "type": "string",
+          "description": "This field is set if the task was delivered as a result of a sync match, and it is set to the\namount of time we waited to make such a match. If the task was delievered from the blacklog,\nthen the field is unset."
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -6617,13 +6617,12 @@ components:
           items:
             $ref: '#/components/schemas/Message'
           description: Protocol messages piggybacking on a WFT as a transport
-        syncMatchWaitDuration:
-          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
-          type: string
+        taskResponseData:
+          allOf:
+            - $ref: '#/components/schemas/TaskResponsePollingData'
           description: |-
-            This field is set if the task was delivered as a result of a sync match, and it is set to the
-             amount of time we waited to make such a match. If the task was delievered from the blacklog,
-             then the field is unset.
+            See `TaskResponsePollingData`
+             NOTE: Not yet implemented. Update this docstring when released with version.
     PollerInfo:
       type: object
       properties:
@@ -8311,6 +8310,29 @@ components:
              who inherit the parent/previous workflow's Build ID but not its Task Queue. In those cases, make
              sure to query reachability for the parent/previous workflow's Task Queue as well.
           format: enum
+    TaskResponsePollingData:
+      type: object
+      properties:
+        wasSyncMatch:
+          type: boolean
+          description: Set to true if the returned task was a result of a sync match.
+        timePollerWaited:
+          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+          type: string
+          description: |-
+            Set to the amount of time a poll call waited for a task to be available. This value is allowed to be unset
+             if the match was not sync. It is useful to help the SDK understand if it may reduce the number of pollers, since
+             any substantial wait time here means the backlog is drained, and poll calls are idling waiting for tasks.
+        stats:
+          allOf:
+            - $ref: '#/components/schemas/TaskQueueStats'
+          description: |-
+            See `TaskQueueStats`. This field is only set if the poll hit the root partition, where the data is readily
+             available. SDKs should cache this data, and explicitly refresh it with a call to `DescribeTaskQueue` if some
+             TTL has expired.
+      description: |-
+        Data attached to successful poll responses (for any task type) which the SDK can use to optimize its polling
+         strategy.
     TerminateWorkflowExecutionRequest:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -6617,6 +6617,13 @@ components:
           items:
             $ref: '#/components/schemas/Message'
           description: Protocol messages piggybacking on a WFT as a transport
+        syncMatchWaitDuration:
+          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+          type: string
+          description: |-
+            This field is set if the task was delivered as a result of a sync match, and it is set to the
+             amount of time we waited to make such a match. If the task was delievered from the blacklog,
+             then the field is unset.
     PollerInfo:
       type: object
       properties:

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -258,3 +258,18 @@ message TimestampedCompatibleBuildIdRedirectRule {
     CompatibleBuildIdRedirectRule rule = 1;
     google.protobuf.Timestamp create_time = 2;
 }
+
+// Data attached to successful poll responses (for any task type) which the SDK can use to optimize its polling
+// strategy.
+message TaskResponsePollingData {
+    // Set to true if the returned task was a result of a sync match.
+    bool was_sync_match = 1;
+    // Set to the amount of time a poll call waited for a task to be available. This value is allowed to be unset
+    // if the match was not sync. It is useful to help the SDK understand if it may reduce the number of pollers, since
+    // any substantial wait time here means the backlog is drained, and poll calls are idling waiting for tasks.
+    google.protobuf.Duration time_poller_waited = 2;
+    // See `TaskQueueStats`. This field is only set if the poll hit the root partition, where the data is readily
+    // available. SDKs should cache this data, and explicitly refresh it with a call to `DescribeTaskQueue` if some
+    // TTL has expired.
+    TaskQueueStats stats = 3;
+}

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -315,6 +315,10 @@ message PollWorkflowTaskQueueResponse {
     map<string, temporal.api.query.v1.WorkflowQuery> queries = 14;
     // Protocol messages piggybacking on a WFT as a transport
     repeated temporal.api.protocol.v1.Message messages = 15;
+    // This field is set if the task was delivered as a result of a sync match, and it is set to the
+    // amount of time we waited to make such a match. If the task was delievered from the blacklog,
+    // then the field is unset.
+    google.protobuf.Duration sync_match_wait_duration = 16;
 }
 
 message RespondWorkflowTaskCompletedRequest {
@@ -447,6 +451,10 @@ message PollActivityTaskQueueResponse {
     // (or not) during activity scheduling. The service can override the provided one if some
     // values are not specified or exceed configured system limits.
     temporal.api.common.v1.RetryPolicy retry_policy = 17;
+    // This field is set if the task was delivered as a result of a sync match, and it is set to the
+    // amount of time we waited to make such a match. If the task was delievered from the blacklog,
+    // then the field is unset.
+    google.protobuf.Duration sync_match_wait_duration = 18;
 }
 
 message RecordActivityTaskHeartbeatRequest {
@@ -1588,6 +1596,10 @@ message PollNexusTaskQueueResponse {
     bytes task_token = 1;
     // Embedded request as translated from the incoming frontend request.
     temporal.api.nexus.v1.Request request = 2;
+    // This field is set if the task was delivered as a result of a sync match, and it is set to the
+    // amount of time we waited to make such a match. If the task was delievered from the blacklog,
+    // then the field is unset.
+    google.protobuf.Duration sync_match_wait_duration = 3;
 }
 
 message RespondNexusTaskCompletedRequest {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -315,10 +315,9 @@ message PollWorkflowTaskQueueResponse {
     map<string, temporal.api.query.v1.WorkflowQuery> queries = 14;
     // Protocol messages piggybacking on a WFT as a transport
     repeated temporal.api.protocol.v1.Message messages = 15;
-    // This field is set if the task was delivered as a result of a sync match, and it is set to the
-    // amount of time we waited to make such a match. If the task was delievered from the blacklog,
-    // then the field is unset.
-    google.protobuf.Duration sync_match_wait_duration = 16;
+    // See `TaskResponsePollingData`
+    // NOTE: Not yet implemented. Update this docstring when released with version.
+    temporal.api.taskqueue.v1.TaskResponsePollingData task_response_data = 16;
 }
 
 message RespondWorkflowTaskCompletedRequest {
@@ -451,10 +450,9 @@ message PollActivityTaskQueueResponse {
     // (or not) during activity scheduling. The service can override the provided one if some
     // values are not specified or exceed configured system limits.
     temporal.api.common.v1.RetryPolicy retry_policy = 17;
-    // This field is set if the task was delivered as a result of a sync match, and it is set to the
-    // amount of time we waited to make such a match. If the task was delievered from the blacklog,
-    // then the field is unset.
-    google.protobuf.Duration sync_match_wait_duration = 18;
+    // See `TaskResponsePollingData`
+    // NOTE: Not yet implemented. Update this docstring when released with version.
+    temporal.api.taskqueue.v1.TaskResponsePollingData task_response_data = 18;
 }
 
 message RecordActivityTaskHeartbeatRequest {
@@ -1596,10 +1594,9 @@ message PollNexusTaskQueueResponse {
     bytes task_token = 1;
     // Embedded request as translated from the incoming frontend request.
     temporal.api.nexus.v1.Request request = 2;
-    // This field is set if the task was delivered as a result of a sync match, and it is set to the
-    // amount of time we waited to make such a match. If the task was delievered from the blacklog,
-    // then the field is unset.
-    google.protobuf.Duration sync_match_wait_duration = 3;
+    // See `TaskResponsePollingData`
+    // NOTE: Not yet implemented. Update this docstring when released with version.
+    temporal.api.taskqueue.v1.TaskResponsePollingData task_response_data = 3;
 }
 
 message RespondNexusTaskCompletedRequest {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add some additional information to polling responses about the task queue 

## Outcome of discussion w/ @ShahabT and @dnr 
Initially I would've liked `TaskQueueStats` to be returned on every poll response. This appears to be too much from both a performance and complexity perspective initially because regularly updating and distributing aggregated data across partitions would require more frequent internal RPCs, and would require them to go in a direction they don't currently (from sub-partition -> root rather than just the other way around).

The alternative is to have SDK acquire that data via `DescribeTaskQueue`. Calling that very frequently would also be problematic, since there is an RPS limit per-namespace.

The landed on middle ground, which is low complexity but ought to be reasonably efficient, is to include `TaskQueueStats` in the response whenever a poll hits the root partition, where it is readily available. If the SDK has not seen such a response in some reasonable TTL (~seconds), then it will call `DescribeTaskQueue` in order to have an updated view. In practice, it should be fairly unlikely for a worker with a reasonable number of pollers to somehow miss root, and low-traffic queues are also more likely to forward to the root to see if there is a task. Since the desired outcome SDK side is to only have a low number of pollers when there's low traffic, that should work out.

<!-- Tell your future self why have you made these changes -->
**Why?**
This will allow poller auto-tuning to have an idea of if it should be increasing the number of pollers because most matches are not sync (possibly in conjunction w/ a backlog hint)

If we are making sync matches, then we can reduce the number of pollers once the wait duration starts to exceed some threshold.

It can also inform the SDK what the minimum latency is when polling, since if we didn't make a sync match, then we were pulling something out of the backlog and delivered a task roughly as quickly as is possible.

The task queue stats info is useful to help to decide how quickly pollers should be ramped up, if at all.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
nope

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
Will make one assuming we're OK with this add.
