### PR TITLE
Improve active task queue definition

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -1173,7 +1173,7 @@
           },
           {
             "name": "versions.allActive",
-            "description": "Include all active versions. A version is considered active if it has had new\ntasks or polls recently.",
+            "description": "Include all active versions. A version is considered active if, in the last few minutes,\nit has had new tasks or polls, or it has been the subject of certain task queue API calls.",
             "in": "query",
             "required": false,
             "type": "boolean"
@@ -3710,7 +3710,7 @@
           },
           {
             "name": "versions.allActive",
-            "description": "Include all active versions. A version is considered active if it has had new\ntasks or polls recently.",
+            "description": "Include all active versions. A version is considered active if, in the last few minutes,\nit has had new tasks or polls, or it has been the subject of certain task queue API calls.",
             "in": "query",
             "required": false,
             "type": "boolean"
@@ -10882,7 +10882,7 @@
         },
         "allActive": {
           "type": "boolean",
-          "description": "Include all active versions. A version is considered active if it has had new\ntasks or polls recently."
+          "description": "Include all active versions. A version is considered active if, in the last few minutes,\nit has had new tasks or polls, or it has been the subject of certain task queue API calls."
         }
       },
       "description": "Used for specifying versions the caller is interested in."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -1049,8 +1049,8 @@ paths:
         - name: versions.allActive
           in: query
           description: |-
-            Include all active versions. A version is considered active if it has had new
-             tasks or polls recently.
+            Include all active versions. A version is considered active if, in the last few minutes,
+             it has had new tasks or polls, or it has been the subject of certain task queue API calls.
           schema:
             type: boolean
         - name: taskQueueTypes
@@ -3251,8 +3251,8 @@ paths:
         - name: versions.allActive
           in: query
           description: |-
-            Include all active versions. A version is considered active if it has had new
-             tasks or polls recently.
+            Include all active versions. A version is considered active if, in the last few minutes,
+             it has had new tasks or polls, or it has been the subject of certain task queue API calls.
           schema:
             type: boolean
         - name: taskQueueTypes

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -60,8 +60,8 @@ message TaskQueueVersionSelection {
     repeated string build_ids = 1;
     // Include the unversioned queue.
     bool unversioned = 2;
-    // Include all active versions. A version is considered active if it has had new
-    // tasks or polls recently.
+    // Include all active versions. A version is considered active if, in the last few minutes,
+    // it has had new tasks or polls, or it has been the subject of certain task queue API calls.
     bool all_active = 3;
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Refining the definition of `all_active` flag to align it to what server actually returns.

<!-- Tell your future self why have you made these changes -->
**Why?**
The `all_active` options essentially returns all build IDs that are loaded in the server. Besides receiving recent tasks and polls, a build ID would be loaded/active if it was the subject of server APIs such as DescribeTaskQueue.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
