### PR TITLE
Change ShutdownWorker task queue type

### DIFF
--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -875,9 +875,13 @@ message ResetStickyTaskQueueResponse {
 
 message ShutdownWorkerRequest {
     string namespace = 1;
-    string sticky_task_queue = 2;
+    reserved 2;
+    reserved "sticky_task_queue";
     string identity = 3;
     string reason = 4;
+
+    // Must always be the worker's sticky task queue.
+    temporal.api.taskqueue.v1.TaskQueue worker_task_queue = 5;
 }
 
 message ShutdownWorkerResponse {


### PR DESCRIPTION
**What changed?**
- Changed the unreleased `ShutdownWorker` task queue type to the unified task queue structure.

**Why?**
- To route to the correct matching node, we need the full `TaskQueue` structure ([ref](https://github.com/temporalio/temporal/blob/main/common/tqid/task_queue_id.go#L180-L181)). 

**Breaking changes**
- No, `buf-breaking` passes, and `api-go` builds. No consumers use this API yet.

