### PR TITLE
Provide option to exclude all events from being reapplied beyond reset point

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -9622,10 +9622,10 @@
         "RESET_REAPPLY_EXCLUDE_TYPE_UNSPECIFIED",
         "RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL",
         "RESET_REAPPLY_EXCLUDE_TYPE_UPDATE",
-        "RESET_REAPPLY_EXCLUDE_TYPE_ALL"
+        "RESET_REAPPLY_EXCLUDE_TYPE_NEXUS"
       ],
       "default": "RESET_REAPPLY_EXCLUDE_TYPE_UNSPECIFIED",
-      "description": "Event types to exclude when reapplying events beyond the reset point.\n\n - RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: Exclude signals when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: Exclude updates when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_ALL: Exclude all events to prevent reapplying events beyond the reset point."
+      "description": "Event types to exclude when reapplying events beyond the reset point.\n\n - RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: Exclude signals when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: Exclude updates when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_NEXUS: Exclude nexus events when reapplying events beyond the reset point."
     },
     "v1ResetReapplyType": {
       "type": "string",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -9625,7 +9625,7 @@
         "RESET_REAPPLY_EXCLUDE_TYPE_ALL"
       ],
       "default": "RESET_REAPPLY_EXCLUDE_TYPE_UNSPECIFIED",
-      "description": "Event types to exclude when reapplying events.\n\n - RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: Exclude signals when reapplying events.\n - RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: Exclude updates when reapplying events.\n - RESET_REAPPLY_EXCLUDE_TYPE_ALL: Exclude all events to prevent reapplying events past the reset point."
+      "description": "Event types to exclude when reapplying events beyond the reset point.\n\n - RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: Exclude signals when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: Exclude updates when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_ALL: Exclude all events to prevent reapplying events beyond the reset point."
     },
     "v1ResetReapplyType": {
       "type": "string",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -9621,10 +9621,11 @@
       "enum": [
         "RESET_REAPPLY_EXCLUDE_TYPE_UNSPECIFIED",
         "RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL",
-        "RESET_REAPPLY_EXCLUDE_TYPE_UPDATE"
+        "RESET_REAPPLY_EXCLUDE_TYPE_UPDATE",
+        "RESET_REAPPLY_EXCLUDE_TYPE_ALL"
       ],
       "default": "RESET_REAPPLY_EXCLUDE_TYPE_UNSPECIFIED",
-      "description": "Event types to exclude when reapplying events.\n\n - RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: Exclude signals when reapplying events.\n - RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: Exclude updates when reapplying events."
+      "description": "Event types to exclude when reapplying events.\n\n - RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: Exclude signals when reapplying events.\n - RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: Exclude updates when reapplying events.\n - RESET_REAPPLY_EXCLUDE_TYPE_ALL: Exclude all events to prevent reapplying events past the reset point."
     },
     "v1ResetReapplyType": {
       "type": "string",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -7058,6 +7058,7 @@ components:
               - RESET_REAPPLY_EXCLUDE_TYPE_UNSPECIFIED
               - RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL
               - RESET_REAPPLY_EXCLUDE_TYPE_UPDATE
+              - RESET_REAPPLY_EXCLUDE_TYPE_ALL
             type: string
             format: enum
           description: Event types not to be reapplied
@@ -7138,6 +7139,7 @@ components:
               - RESET_REAPPLY_EXCLUDE_TYPE_UNSPECIFIED
               - RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL
               - RESET_REAPPLY_EXCLUDE_TYPE_UPDATE
+              - RESET_REAPPLY_EXCLUDE_TYPE_ALL
             type: string
             format: enum
           description: Event types not to be reapplied

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -7058,7 +7058,7 @@ components:
               - RESET_REAPPLY_EXCLUDE_TYPE_UNSPECIFIED
               - RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL
               - RESET_REAPPLY_EXCLUDE_TYPE_UPDATE
-              - RESET_REAPPLY_EXCLUDE_TYPE_ALL
+              - RESET_REAPPLY_EXCLUDE_TYPE_NEXUS
             type: string
             format: enum
           description: Event types not to be reapplied
@@ -7139,7 +7139,7 @@ components:
               - RESET_REAPPLY_EXCLUDE_TYPE_UNSPECIFIED
               - RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL
               - RESET_REAPPLY_EXCLUDE_TYPE_UPDATE
-              - RESET_REAPPLY_EXCLUDE_TYPE_ALL
+              - RESET_REAPPLY_EXCLUDE_TYPE_NEXUS
             type: string
             format: enum
           description: Event types not to be reapplied

--- a/temporal/api/enums/v1/reset.proto
+++ b/temporal/api/enums/v1/reset.proto
@@ -38,8 +38,8 @@ enum ResetReapplyExcludeType {
     RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL = 1;
     // Exclude updates when reapplying events beyond the reset point.
     RESET_REAPPLY_EXCLUDE_TYPE_UPDATE = 2;
-    // Exclude all events to prevent reapplying events beyond the reset point.
-    RESET_REAPPLY_EXCLUDE_TYPE_ALL = 3;
+    // Exclude nexus events when reapplying events beyond the reset point.
+    RESET_REAPPLY_EXCLUDE_TYPE_NEXUS = 3;
 }
 
 // Event types to include when reapplying events. Deprecated: applications

--- a/temporal/api/enums/v1/reset.proto
+++ b/temporal/api/enums/v1/reset.proto
@@ -38,6 +38,8 @@ enum ResetReapplyExcludeType {
     RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL = 1;
     // Exclude updates when reapplying events.
     RESET_REAPPLY_EXCLUDE_TYPE_UPDATE = 2;
+    // Exclude all events to prevent reapplying events past the reset point.
+    RESET_REAPPLY_EXCLUDE_TYPE_ALL = 3;
 }
 
 // Event types to include when reapplying events. Deprecated: applications

--- a/temporal/api/enums/v1/reset.proto
+++ b/temporal/api/enums/v1/reset.proto
@@ -31,14 +31,14 @@ option java_outer_classname = "ResetProto";
 option ruby_package = "Temporalio::Api::Enums::V1";
 option csharp_namespace = "Temporalio.Api.Enums.V1";
 
-// Event types to exclude when reapplying events.
+// Event types to exclude when reapplying events beyond the reset point.
 enum ResetReapplyExcludeType {
     RESET_REAPPLY_EXCLUDE_TYPE_UNSPECIFIED = 0;
-    // Exclude signals when reapplying events.
+    // Exclude signals when reapplying events beyond the reset point.
     RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL = 1;
-    // Exclude updates when reapplying events.
+    // Exclude updates when reapplying events beyond the reset point.
     RESET_REAPPLY_EXCLUDE_TYPE_UPDATE = 2;
-    // Exclude all events to prevent reapplying events past the reset point.
+    // Exclude all events to prevent reapplying events beyond the reset point.
     RESET_REAPPLY_EXCLUDE_TYPE_ALL = 3;
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Added a new option `RESET_REAPPLY_EXCLUDE_TYPE_ALL` that the operator could choose to completely disable reapplying of all events beyond the reset point.

<!-- Tell your future self why have you made these changes -->
Some events are re-applied (ex: Nexus events) without having an option to opt-out. So we are providing an option to completely exclude all events. 

