### PR TITLE
Add capabilities field to RespondWorkflowTaskCompletedResponse

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -9801,7 +9801,7 @@
     "v1RespondWorkflowTaskCompletedResponseCapabilities": {
       "type": "object",
       "properties": {
-        "discardSpeculativeWorkflowTaskWithCommandEvents": {
+        "discardSpeculativeWorkflowTaskWithEvents": {
           "type": "boolean",
           "title": "True if the SDK can handle speculative workflow task with command events.\nIf true, the server may chosse, at its discretion, to discard a speculative workflow task\neven if that speculative task included command events the SDK had not previouly processed"
         }

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -9791,8 +9791,22 @@
           "type": "string",
           "format": "int64",
           "description": "If non zero, indicates the server has discarded the workflow task that was being responded to.\nWill be the event ID of the last workflow task started event in the history before the new workflow task.\nServer is only expected to discard a workflow task if it could not have modified the workflow state."
+        },
+        "capabilities": {
+          "$ref": "#/definitions/v1RespondWorkflowTaskCompletedResponseCapabilities",
+          "description": "All capabilities the SDK supports."
         }
       }
+    },
+    "v1RespondWorkflowTaskCompletedResponseCapabilities": {
+      "type": "object",
+      "properties": {
+        "discardSpeculativeWorkflowTaskWithCommandEvents": {
+          "type": "boolean",
+          "title": "True if the SDK can handle speculative workflow task with command events.\nIf true, the server may chosse, at its discretion, to discard a speculative workflow task\neven if that speculative task included command events the SDK had not previouly processed"
+        }
+      },
+      "description": "SDK capability details."
     },
     "v1RespondWorkflowTaskFailedResponse": {
       "type": "object"

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -372,7 +372,7 @@ message RespondWorkflowTaskCompletedResponse {
         // True if the SDK can handle speculative workflow task with command events.
         // If true, the server may chosse, at its discretion, to discard a speculative workflow task
         // even if that speculative task included command events the SDK had not previouly processed.
-        bool may_discard_speculative_workflowtask_with_command_events = 1;
+        bool may_discard_speculative_workflow_task_with_command_events = 1;
     }
 }
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -371,7 +371,10 @@ message RespondWorkflowTaskCompletedResponse {
     message Capabilities {
         // True if the SDK can handle speculative workflow task with command events.
         // If true, the server may chosse, at its discretion, to discard a speculative workflow task
-        // even if that speculative task included command events the SDK had not previouly processed.
+        // even if that speculative task included command events the SDK had not previouly processed
+        //
+        // (-- api-linter: core::0140::prepositions=disabled
+        //     aip.dev/not-precedent: "with" used to describe the workflow task. --)
         bool discard_speculative_workflow_task_with_command_events = 1;
     }
 }

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -365,6 +365,15 @@ message RespondWorkflowTaskCompletedResponse {
     // Will be the event ID of the last workflow task started event in the history before the new workflow task.
     // Server is only expected to discard a workflow task if it could not have modified the workflow state.
     int64 reset_history_event_id = 3;
+    // All capabilities the SDK supports.
+    Capabilities capabilities = 4;
+    // SDK capability details.
+    message Capabilities {
+        // True if the SDK can handle speculative workflow task with command events.
+        // If true, the server may chosse, at its discretion, to discard a speculative workflow task
+        // even if that speculative task included command events the SDK had not previouly processed.
+        bool may_discard_speculative_workflowtask_with_command_events = 1;
+    }
 }
 
 message RespondWorkflowTaskFailedRequest {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -372,7 +372,7 @@ message RespondWorkflowTaskCompletedResponse {
         // True if the SDK can handle speculative workflow task with command events.
         // If true, the server may chosse, at its discretion, to discard a speculative workflow task
         // even if that speculative task included command events the SDK had not previouly processed.
-        bool may_discard_speculative_workflow_task_with_command_events = 1;
+        bool discard_speculative_workflow_task_with_command_events = 1;
     }
 }
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -375,7 +375,7 @@ message RespondWorkflowTaskCompletedResponse {
         //
         // (-- api-linter: core::0140::prepositions=disabled
         //     aip.dev/not-precedent: "with" used to describe the workflow task. --)
-        bool discard_speculative_workflow_task_with_command_events = 1;
+        bool discard_speculative_workflow_task_with_events = 1;
     }
 }
 


### PR DESCRIPTION
Add capabilities field to RespondWorkflowTaskCompletedResponse. Add `may_discard_speculative_workflowtask_with_command_events` that will allow the SDK to signal to the Server that it supports discarding speculative workflow tasks with command events. When this is set to true it will allow the server to discard a lot more speculative workflow tasks then it can today.

