### PR TITLE
Add running_workflows to ScheduleListInfo, for ListSchedules

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -10081,6 +10081,14 @@
             "type": "string",
             "format": "date-time"
           }
+        },
+        "runningWorkflows": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1WorkflowExecution"
+          },
+          "description": "From state:\nRunning workflows returned here are eventually consistent, and their\nstatus may be out-of-date. For a strongly consistent view of a schedule's\nrunning workflows, use the `DescribeSchedule` API."
         }
       },
       "description": "ScheduleListInfo is an abbreviated set of values from Schedule and ScheduleInfo\nthat's returned in ListSchedules."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -7528,6 +7528,15 @@ components:
           items:
             type: string
             format: date-time
+        runningWorkflows:
+          type: array
+          items:
+            $ref: '#/components/schemas/WorkflowExecution'
+          description: |-
+            From state:
+             Running workflows returned here are eventually consistent, and their
+             status may be out-of-date. For a strongly consistent view of a schedule's
+             running workflows, use the `DescribeSchedule` API.
       description: |-
         ScheduleListInfo is an abbreviated set of values from Schedule and ScheduleInfo
          that's returned in ListSchedules.

--- a/temporal/api/schedule/v1/message.proto
+++ b/temporal/api/schedule/v1/message.proto
@@ -388,6 +388,12 @@ message ScheduleListInfo {
     // From info (maybe fewer entries):
     repeated ScheduleActionResult recent_actions = 5;
     repeated google.protobuf.Timestamp future_action_times = 6;
+
+    // From state:
+    // Running workflows returned here are eventually consistent, and their
+    // status may be out-of-date. For a strongly consistent view of a schedule's
+    // running workflows, use the `DescribeSchedule` API.
+    repeated temporal.api.common.v1.WorkflowExecution running_workflows = 7;
 }
 
 // ScheduleListEntry is returned by ListSchedules.


### PR DESCRIPTION
**What changed?**
- A new field `RunningWorkflows` was added to `ScheduleListInfo`, matching the field in `ScheduleInfo`.

**Why?**
- Customers would like to be able to drill down into running workflow executions without having to follow a `ListSchedule` call with fan-outs to `DescribeSchedule`).

**Breaking changes**
- None here

**Server PR**
- Pending

