### PR TITLE
Fix RespondWorkflowTask capabilities

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -12,6 +12,8 @@ breaking:
     - WIRE_JSON
   ignore:
     - google
+    # TODO(klassenq): remove me
+    - temporal/api/workflowservice/v1/request_response.proto
 lint:
   use:
     - DEFAULT

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -9772,6 +9772,16 @@
     "v1RespondQueryTaskCompletedResponse": {
       "type": "object"
     },
+    "v1RespondWorkflowTaskCompletedRequestCapabilities": {
+      "type": "object",
+      "properties": {
+        "discardSpeculativeWorkflowTaskWithEvents": {
+          "type": "boolean",
+          "title": "True if the SDK can handle speculative workflow task with command events.\nIf true, the server may chosse, at its discretion, to discard a speculative workflow task\neven if that speculative task included command events the SDK had not previouly processed"
+        }
+      },
+      "description": "SDK capability details."
+    },
     "v1RespondWorkflowTaskCompletedResponse": {
       "type": "object",
       "properties": {
@@ -9791,22 +9801,8 @@
           "type": "string",
           "format": "int64",
           "description": "If non zero, indicates the server has discarded the workflow task that was being responded to.\nWill be the event ID of the last workflow task started event in the history before the new workflow task.\nServer is only expected to discard a workflow task if it could not have modified the workflow state."
-        },
-        "capabilities": {
-          "$ref": "#/definitions/v1RespondWorkflowTaskCompletedResponseCapabilities",
-          "description": "All capabilities the SDK supports."
         }
       }
-    },
-    "v1RespondWorkflowTaskCompletedResponseCapabilities": {
-      "type": "object",
-      "properties": {
-        "discardSpeculativeWorkflowTaskWithEvents": {
-          "type": "boolean",
-          "title": "True if the SDK can handle speculative workflow task with command events.\nIf true, the server may chosse, at its discretion, to discard a speculative workflow task\neven if that speculative task included command events the SDK had not previouly processed"
-        }
-      },
-      "description": "SDK capability details."
     },
     "v1RespondWorkflowTaskFailedResponse": {
       "type": "object"

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -354,6 +354,18 @@ message RespondWorkflowTaskCompletedRequest {
     temporal.api.sdk.v1.WorkflowTaskCompletedMetadata sdk_metadata = 12;
     // Local usage data collected for metering
     temporal.api.common.v1.MeteringMetadata metering_metadata = 13;
+    // All capabilities the SDK supports.
+    Capabilities capabilities = 14;
+    // SDK capability details.
+    message Capabilities {
+        // True if the SDK can handle speculative workflow task with command events.
+        // If true, the server may chosse, at its discretion, to discard a speculative workflow task
+        // even if that speculative task included command events the SDK had not previouly processed
+        //
+        // (-- api-linter: core::0140::prepositions=disabled
+        //     aip.dev/not-precedent: "with" used to describe the workflow task. --)
+        bool discard_speculative_workflow_task_with_events = 1;
+    }
 }
 
 message RespondWorkflowTaskCompletedResponse {
@@ -365,18 +377,6 @@ message RespondWorkflowTaskCompletedResponse {
     // Will be the event ID of the last workflow task started event in the history before the new workflow task.
     // Server is only expected to discard a workflow task if it could not have modified the workflow state.
     int64 reset_history_event_id = 3;
-    // All capabilities the SDK supports.
-    Capabilities capabilities = 4;
-    // SDK capability details.
-    message Capabilities {
-        // True if the SDK can handle speculative workflow task with command events.
-        // If true, the server may chosse, at its discretion, to discard a speculative workflow task
-        // even if that speculative task included command events the SDK had not previouly processed
-        //
-        // (-- api-linter: core::0140::prepositions=disabled
-        //     aip.dev/not-precedent: "with" used to describe the workflow task. --)
-        bool discard_speculative_workflow_task_with_events = 1;
-    }
 }
 
 message RespondWorkflowTaskFailedRequest {


### PR DESCRIPTION
Fix RespondWorkflowTask capabilities, I put it on the `Response` instead of the `Request` because I am dumb.

Note: This is technically a breaking change, but this was not released anywhere
* https://github.com/temporalio/temporal/blob/v1.26.2-122.1/go.mod -> https://github.com/temporalio/api-go/commit/c02089051a35
* https://github.com/temporalio/temporal/blob/v1.26.1/go.mod -> https://github.com/temporalio/api-go/commit/b13574e18f3c
* https://github.com/temporalio/temporal/blob/main/go.mod#L58 -> https://github.com/temporalio/api-go/commit/c02089051a35