### PR TITLE
Add versioning fields to WorkflowExecutionInfo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ $(PROTO_OUT):
 	mkdir $(PROTO_OUT)
 
 ##### Compile proto files for go #####
-grpc: buf-lint api-linter buf-breaking clean go-grpc fix-path
+grpc: buf-lint api-linter clean go-grpc fix-path
 
 go-grpc: clean $(PROTO_OUT)
 	printf $(COLOR) "Compile for go-gRPC..."

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -6253,14 +6253,14 @@
           "format": "int64",
           "title": "Used by server internally to properly reapply build ID redirects to an execution\nwhen rebuilding it from events.\nDeprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]"
         },
-        "deployment": {
+        "redirectDeployment": {
           "$ref": "#/definitions/v1WorkerDeployment",
-          "description": "The worker deployment to which the task was dispatched. Empty means the task\nwas dispatched to an unversioned worker."
+          "description": "When present, it means this task is dispatched to a new deployment and caused\nthe workflow execution to be redirected to that deployment from this point on."
         },
-        "deploymentChangeCounter": {
+        "deploymentRedirectCounter": {
           "type": "string",
           "format": "int64",
-          "description": "Used by server internally to properly reapply deployment redirects to an\nexecution when rebuilding it from history events."
+          "description": "Used by server internally to properly reapply deployment redirects to an\nexecution when rebuilding it from history events. This is non-zero if and\nonly if `redirect_deployment` is present."
         }
       }
     },
@@ -12410,14 +12410,14 @@
           "format": "int64",
           "title": "Used by server internally to properly reapply build ID redirects to an execution\nwhen rebuilding it from events.\nDeprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]"
         },
-        "deployment": {
+        "redirectDeployment": {
           "$ref": "#/definitions/v1WorkerDeployment",
-          "description": "The worker deployment to which the task was dispatched. Empty means the task\nwas dispatched to an unversioned worker."
+          "description": "When present, it means this task is dispatched to a new deployment and caused\nthe workflow execution to be redirected to that deployment from this point on."
         },
-        "deploymentChangeCounter": {
+        "deploymentRedirectCounter": {
           "type": "string",
           "format": "int64",
-          "description": "Used by server internally to properly reapply deployment redirects to an\nexecution when rebuilding it from history events."
+          "description": "Used by server internally to properly reapply deployment redirects to an\nexecution when rebuilding it from history events. This is non-zero if and\nonly if `redirect_deployment` is present."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -5002,6 +5002,31 @@
         }
       }
     },
+    "WorkflowExecutionInfoVersioningInfo": {
+      "type": "object",
+      "properties": {
+        "versioningBehavior": {
+          "$ref": "#/definitions/v1VersioningBehavior",
+          "description": "Determines how server should treat this execution when workers are upgraded.\nWhen present it means that this workflow is versioned."
+        },
+        "deployment": {
+          "$ref": "#/definitions/v1WorkerDeployment",
+          "description": "The worker deployment to which this workflow is assigned currently.\nMust be present if `versioning_behavior` is set."
+        },
+        "versioningBehaviorOverride": {
+          "$ref": "#/definitions/v1VersioningBehavior",
+          "description": "Manual override for versioning behavior. Takes precedence over\n`versioning_behavior`."
+        },
+        "deploymentOverride": {
+          "$ref": "#/definitions/v1WorkerDeployment",
+          "description": "Manual override for deployment. Takes precedence over `deployment`.\nMust be set when if and only if `versioning_behavior_override` is PINNED."
+        },
+        "redirectingDeployment": {
+          "$ref": "#/definitions/v1WorkerDeployment",
+          "description": "Indicates the workflow is being redirected to a different deployment.\nWorkflow redirect finishes at the next WorkflowTaskCompleted event.\nTasks that start while workflow has an ongoing redirect, will be\ndispatched to `redirecting_deployment`."
+        }
+      }
+    },
     "WorkflowServiceCreateScheduleBody": {
       "type": "object",
       "properties": {
@@ -6221,12 +6246,21 @@
         },
         "workerVersion": {
           "$ref": "#/definitions/v1WorkerVersionStamp",
-          "description": "Version info of the worker to whom this task was dispatched."
+          "title": "Version info of the worker to whom this task was dispatched.\nDeprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]"
         },
         "buildIdRedirectCounter": {
           "type": "string",
           "format": "int64",
-          "description": "Used by server internally to properly reapply build ID redirects to an execution\nwhen rebuilding it from events."
+          "title": "Used by server internally to properly reapply build ID redirects to an execution\nwhen rebuilding it from events.\nDeprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]"
+        },
+        "deployment": {
+          "$ref": "#/definitions/v1WorkerDeployment",
+          "description": "The worker deployment to which the task was dispatched. Empty means the task\nwas dispatched to an unversioned worker."
+        },
+        "deploymentChangeCounter": {
+          "type": "string",
+          "format": "int64",
+          "description": "Used by server internally to properly reapply deployment redirects to an\nexecution when rebuilding it from history events."
         }
       }
     },
@@ -8906,7 +8940,7 @@
         },
         "lastWorkerVersionStamp": {
           "$ref": "#/definitions/v1WorkerVersionStamp",
-          "title": "The version stamp of the worker to whom this activity was most recently dispatched"
+          "title": "The version stamp of the worker to whom this activity was most recently dispatched\nDeprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]"
         },
         "currentRetryInterval": {
           "type": "string",
@@ -8921,6 +8955,10 @@
           "type": "string",
           "format": "date-time",
           "description": "Next time when activity will be scheduled.\nIf activity is currently scheduled or started it will be null."
+        },
+        "lastStartedDeployment": {
+          "$ref": "#/definitions/v1WorkerDeployment",
+          "description": "Present if activity task queue is versioned. The deployment this activity\nwas dispatched to most recently."
         }
       }
     },
@@ -9050,6 +9088,10 @@
         "attempt": {
           "type": "integer",
           "format": "int32"
+        },
+        "lastStartedDeployment": {
+          "$ref": "#/definitions/v1WorkerDeployment",
+          "description": "Present if the workflow is versioned. The deployment this workflow task\nwas dispatched to most recently."
         }
       }
     },
@@ -11469,6 +11511,18 @@
       },
       "description": "Specifies client's intent to wait for Update results."
     },
+    "v1WorkerDeployment": {
+      "type": "object",
+      "properties": {
+        "deploymentName": {
+          "type": "string"
+        },
+        "buildId": {
+          "type": "string"
+        }
+      },
+      "description": "Identifies a versioned worker deployment."
+    },
     "v1WorkerVersionCapabilities": {
       "type": "object",
       "properties": {
@@ -11737,7 +11791,7 @@
         },
         "mostRecentWorkerVersionStamp": {
           "$ref": "#/definitions/v1WorkerVersionStamp",
-          "title": "If set, the most recent worker version stamp that appeared in a workflow task completion"
+          "title": "If set, the most recent worker version stamp that appeared in a workflow task completion\nDeprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]"
         },
         "executionDuration": {
           "type": "string",
@@ -11753,23 +11807,15 @@
         },
         "inheritedBuildId": {
           "type": "string",
-          "description": "Build ID inherited from a previous/parent execution. If present, assigned_build_id will be set to this, instead\nof using the assignment rules."
-        },
-        "buildId": {
-          "type": "string",
-          "title": "Current build ID of this workflow execution that determines the matching queue that new tasks of this execution\nwill be scheduled in. Current build ID is set after completion of the first workflow task, and\nwhen workflow moves to a different build ID either automatically or manually. (versioning-3)"
-        },
-        "deploymentName": {
-          "type": "string",
-          "description": "The deployment name associated with this workflow's task queue + build ID. This is updated when `build_id` is\nupdated. `deployment_name` should be set if `build_id` field is set."
-        },
-        "versioningBehavior": {
-          "$ref": "#/definitions/v1VersioningBehavior",
-          "description": "Determines how server should treat this execution when workers are upgraded. `versioning_behavior` has to be set\nif the `build_id` field is set."
+          "title": "Build ID inherited from a previous/parent execution. If present, assigned_build_id will be set to this, instead\nof using the assignment rules.\nDeprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]"
         },
         "firstRunId": {
           "type": "string",
           "title": "The first run ID in the execution chain.\nExecutions created via the following operations are considered to be in the same chain\n- ContinueAsNew\n- Workflow Retry\n- Workflow Reset\n- Cron Schedule"
+        },
+        "versioningInfo": {
+          "$ref": "#/definitions/WorkflowExecutionInfoVersioningInfo",
+          "description": "Holds all the information about versioning for this particular execution.\nThis info is typically set after the completion of the first workflow\ntask because that is the time that versioning behavior and deployment for\nthe workflow is determined. In some other cases, such as for Child\nWorkflows, or when Starter has forced a particular behavior or deployment,\nthis field will be set before the completion of the first workflow task."
         }
       }
     },
@@ -11912,7 +11958,7 @@
         },
         "sourceVersionStamp": {
           "$ref": "#/definitions/v1WorkerVersionStamp",
-          "title": "If this workflow intends to use anything other than the current overall default version for\nthe queue, then we include it here.\nDeprecated. use `inherited_build_id` instead"
+          "title": "If this workflow intends to use anything other than the current overall default version for\nthe queue, then we include it here.\nDeprecated. [cleanup-experimental-wv]"
         },
         "completionCallbacks": {
           "type": "array",
@@ -11928,7 +11974,7 @@
         },
         "inheritedBuildId": {
           "type": "string",
-          "description": "When present, this execution is assigned to the build ID of its parent or previous execution."
+          "title": "When present, this execution is assigned to the build ID of its parent or previous execution.\nDeprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]"
         }
       },
       "title": "Always the first event in workflow history"
@@ -12357,12 +12403,21 @@
         },
         "workerVersion": {
           "$ref": "#/definitions/v1WorkerVersionStamp",
-          "description": "Version info of the worker to whom this task was dispatched."
+          "title": "Version info of the worker to whom this task was dispatched.\nDeprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]"
         },
         "buildIdRedirectCounter": {
           "type": "string",
           "format": "int64",
-          "description": "Used by server internally to properly reapply build ID redirects to an execution\nwhen rebuilding it from events."
+          "title": "Used by server internally to properly reapply build ID redirects to an execution\nwhen rebuilding it from events.\nDeprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]"
+        },
+        "deployment": {
+          "$ref": "#/definitions/v1WorkerDeployment",
+          "description": "The worker deployment to which the task was dispatched. Empty means the task\nwas dispatched to an unversioned worker."
+        },
+        "deploymentChangeCounter": {
+          "type": "string",
+          "format": "int64",
+          "description": "Used by server internally to properly reapply deployment redirects to an\nexecution when rebuilding it from history events."
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -4351,17 +4351,18 @@ components:
             Used by server internally to properly reapply build ID redirects to an execution
              when rebuilding it from events.
              Deprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]
-        deployment:
+        redirectDeployment:
           allOf:
             - $ref: '#/components/schemas/WorkerDeployment'
           description: |-
-            The worker deployment to which the task was dispatched. Empty means the task
-             was dispatched to an unversioned worker.
-        deploymentChangeCounter:
+            When present, it means this task is dispatched to a new deployment and caused
+             the workflow execution to be redirected to that deployment from this point on.
+        deploymentRedirectCounter:
           type: string
           description: |-
             Used by server internally to properly reapply deployment redirects to an
-             execution when rebuilding it from history events.
+             execution when rebuilding it from history events. This is non-zero if and
+             only if `redirect_deployment` is present.
     ActivityTaskTimedOutEventAttributes:
       type: object
       properties:
@@ -9905,17 +9906,18 @@ components:
             Used by server internally to properly reapply build ID redirects to an execution
              when rebuilding it from events.
              Deprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]
-        deployment:
+        redirectDeployment:
           allOf:
             - $ref: '#/components/schemas/WorkerDeployment'
           description: |-
-            The worker deployment to which the task was dispatched. Empty means the task
-             was dispatched to an unversioned worker.
-        deploymentChangeCounter:
+            When present, it means this task is dispatched to a new deployment and caused
+             the workflow execution to be redirected to that deployment from this point on.
+        deploymentRedirectCounter:
           type: string
           description: |-
             Used by server internally to properly reapply deployment redirects to an
-             execution when rebuilding it from history events.
+             execution when rebuilding it from history events. This is non-zero if and
+             only if `redirect_deployment` is present.
     WorkflowTaskTimedOutEventAttributes:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -4342,12 +4342,26 @@ components:
         workerVersion:
           allOf:
             - $ref: '#/components/schemas/WorkerVersionStamp'
-          description: Version info of the worker to whom this task was dispatched.
+          description: |-
+            Version info of the worker to whom this task was dispatched.
+             Deprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]
         buildIdRedirectCounter:
           type: string
           description: |-
             Used by server internally to properly reapply build ID redirects to an execution
              when rebuilding it from events.
+             Deprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]
+        deployment:
+          allOf:
+            - $ref: '#/components/schemas/WorkerDeployment'
+          description: |-
+            The worker deployment to which the task was dispatched. Empty means the task
+             was dispatched to an unversioned worker.
+        deploymentChangeCounter:
+          type: string
+          description: |-
+            Used by server internally to properly reapply deployment redirects to an
+             execution when rebuilding it from history events.
     ActivityTaskTimedOutEventAttributes:
       type: object
       properties:
@@ -6551,7 +6565,9 @@ components:
         lastWorkerVersionStamp:
           allOf:
             - $ref: '#/components/schemas/WorkerVersionStamp'
-          description: The version stamp of the worker to whom this activity was most recently dispatched
+          description: |-
+            The version stamp of the worker to whom this activity was most recently dispatched
+             Deprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]
         currentRetryInterval:
           pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
           type: string
@@ -6570,6 +6586,12 @@ components:
             Next time when activity will be scheduled.
              If activity is currently scheduled or started it will be null.
           format: date-time
+        lastStartedDeployment:
+          allOf:
+            - $ref: '#/components/schemas/WorkerDeployment'
+          description: |-
+            Present if activity task queue is versioned. The deployment this activity
+             was dispatched to most recently.
     PendingChildExecutionInfo:
       type: object
       properties:
@@ -6680,6 +6702,12 @@ components:
         attempt:
           type: integer
           format: int32
+        lastStartedDeployment:
+          allOf:
+            - $ref: '#/components/schemas/WorkerDeployment'
+          description: |-
+            Present if the workflow is versioned. The deployment this workflow task
+             was dispatched to most recently.
     PollWorkflowTaskQueueResponse:
       type: object
       properties:
@@ -8906,6 +8934,14 @@ components:
              user specified timeout, API call returns even if specified stage is not reached.
           format: enum
       description: Specifies client's intent to wait for Update results.
+    WorkerDeployment:
+      type: object
+      properties:
+        deploymentName:
+          type: string
+        buildId:
+          type: string
+      description: Identifies a versioned worker deployment.
     WorkerVersionCapabilities:
       type: object
       properties:
@@ -9203,7 +9239,9 @@ components:
         mostRecentWorkerVersionStamp:
           allOf:
             - $ref: '#/components/schemas/WorkerVersionStamp'
-          description: If set, the most recent worker version stamp that appeared in a workflow task completion
+          description: |-
+            If set, the most recent worker version stamp that appeared in a workflow task completion
+             Deprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]
         executionDuration:
           pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
           type: string
@@ -9246,27 +9284,7 @@ components:
           description: |-
             Build ID inherited from a previous/parent execution. If present, assigned_build_id will be set to this, instead
              of using the assignment rules.
-        buildId:
-          type: string
-          description: |-
-            Current build ID of this workflow execution that determines the matching queue that new tasks of this execution
-             will be scheduled in. Current build ID is set after completion of the first workflow task, and
-             when workflow moves to a different build ID either automatically or manually. (versioning-3)
-        deploymentName:
-          type: string
-          description: |-
-            The deployment name associated with this workflow's task queue + build ID. This is updated when `build_id` is
-             updated. `deployment_name` should be set if `build_id` field is set.
-        versioningBehavior:
-          enum:
-            - VERSIONING_BEHAVIOR_UNSPECIFIED
-            - VERSIONING_BEHAVIOR_PINNED
-            - VERSIONING_BEHAVIOR_AUTO_UPGRADE
-          type: string
-          description: |-
-            Determines how server should treat this execution when workers are upgraded. `versioning_behavior` has to be set
-             if the `build_id` field is set.
-          format: enum
+             Deprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]
         firstRunId:
           type: string
           description: |-
@@ -9276,6 +9294,59 @@ components:
              - Workflow Retry
              - Workflow Reset
              - Cron Schedule
+        versioningInfo:
+          allOf:
+            - $ref: '#/components/schemas/WorkflowExecutionInfo_VersioningInfo'
+          description: |-
+            Holds all the information about versioning for this particular execution.
+             This info is typically set after the completion of the first workflow
+             task because that is the time that versioning behavior and deployment for
+             the workflow is determined. In some other cases, such as for Child
+             Workflows, or when Starter has forced a particular behavior or deployment,
+             this field will be set before the completion of the first workflow task.
+    WorkflowExecutionInfo_VersioningInfo:
+      type: object
+      properties:
+        versioningBehavior:
+          enum:
+            - VERSIONING_BEHAVIOR_UNSPECIFIED
+            - VERSIONING_BEHAVIOR_PINNED
+            - VERSIONING_BEHAVIOR_AUTO_UPGRADE
+          type: string
+          description: |-
+            Determines how server should treat this execution when workers are upgraded.
+             When present it means that this workflow is versioned.
+          format: enum
+        deployment:
+          allOf:
+            - $ref: '#/components/schemas/WorkerDeployment'
+          description: |-
+            The worker deployment to which this workflow is assigned currently.
+             Must be present if `versioning_behavior` is set.
+        versioningBehaviorOverride:
+          enum:
+            - VERSIONING_BEHAVIOR_UNSPECIFIED
+            - VERSIONING_BEHAVIOR_PINNED
+            - VERSIONING_BEHAVIOR_AUTO_UPGRADE
+          type: string
+          description: |-
+            Manual override for versioning behavior. Takes precedence over
+             `versioning_behavior`.
+          format: enum
+        deploymentOverride:
+          allOf:
+            - $ref: '#/components/schemas/WorkerDeployment'
+          description: |-
+            Manual override for deployment. Takes precedence over `deployment`.
+             Must be set when if and only if `versioning_behavior_override` is PINNED.
+        redirectingDeployment:
+          allOf:
+            - $ref: '#/components/schemas/WorkerDeployment'
+          description: |-
+            Indicates the workflow is being redirected to a different deployment.
+             Workflow redirect finishes at the next WorkflowTaskCompleted event.
+             Tasks that start while workflow has an ongoing redirect, will be
+             dispatched to `redirecting_deployment`.
     WorkflowExecutionSignaledEventAttributes:
       type: object
       properties:
@@ -9413,7 +9484,7 @@ components:
           description: |-
             If this workflow intends to use anything other than the current overall default version for
              the queue, then we include it here.
-             Deprecated. use `inherited_build_id` instead
+             Deprecated. [cleanup-experimental-wv]
         completionCallbacks:
           type: array
           items:
@@ -9442,7 +9513,9 @@ components:
                  - The root workflow of W1 is W1 and the root workflow of W2 is W2.
         inheritedBuildId:
           type: string
-          description: When present, this execution is assigned to the build ID of its parent or previous execution.
+          description: |-
+            When present, this execution is assigned to the build ID of its parent or previous execution.
+             Deprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]
       description: Always the first event in workflow history
     WorkflowExecutionTerminatedEventAttributes:
       type: object
@@ -9823,12 +9896,26 @@ components:
         workerVersion:
           allOf:
             - $ref: '#/components/schemas/WorkerVersionStamp'
-          description: Version info of the worker to whom this task was dispatched.
+          description: |-
+            Version info of the worker to whom this task was dispatched.
+             Deprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]
         buildIdRedirectCounter:
           type: string
           description: |-
             Used by server internally to properly reapply build ID redirects to an execution
              when rebuilding it from events.
+             Deprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]
+        deployment:
+          allOf:
+            - $ref: '#/components/schemas/WorkerDeployment'
+          description: |-
+            The worker deployment to which the task was dispatched. Empty means the task
+             was dispatched to an unversioned worker.
+        deploymentChangeCounter:
+          type: string
+          description: |-
+            Used by server internally to properly reapply deployment redirects to an
+             execution when rebuilding it from history events.
     WorkflowTaskTimedOutEventAttributes:
       type: object
       properties:

--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -156,6 +156,12 @@ message WorkerVersionCapabilities {
     // Later, may include info like "I can process WASM and/or JS bundles"
 }
 
+// Identifies a versioned worker deployment.
+message WorkerDeployment {
+    string deployment_name = 1;
+    string build_id = 2;
+}
+
 // Describes where and how to reset a workflow, used for batch reset currently
 // and may be used for single-workflow reset later.
 message ResetOptions {

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -222,12 +222,13 @@ message WorkflowTaskStartedEventAttributes {
     // when rebuilding it from events.
     // Deprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]
     int64 build_id_redirect_counter = 7;
-    // The worker deployment to which the task was dispatched. Empty means the task
-    // was dispatched to an unversioned worker.
-    temporal.api.common.v1.WorkerDeployment deployment = 8;
+    // When present, it means this task is dispatched to a new deployment and caused
+    // the workflow execution to be redirected to that deployment from this point on.
+    temporal.api.common.v1.WorkerDeployment redirect_deployment = 8;
     // Used by server internally to properly reapply deployment redirects to an
-    // execution when rebuilding it from history events.
-    int64 deployment_change_counter = 9;
+    // execution when rebuilding it from history events. This is non-zero if and
+    // only if `redirect_deployment` is present.
+    int64 deployment_redirect_counter = 9;
 }
 
 message WorkflowTaskCompletedEventAttributes {
@@ -352,12 +353,13 @@ message ActivityTaskStartedEventAttributes {
     // when rebuilding it from events.
     // Deprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]
     int64 build_id_redirect_counter = 7;
-    // The worker deployment to which the task was dispatched. Empty means the task
-    // was dispatched to an unversioned worker.
-    temporal.api.common.v1.WorkerDeployment deployment = 8;
+    // When present, it means this task is dispatched to a new deployment and caused
+    // the workflow execution to be redirected to that deployment from this point on.
+    temporal.api.common.v1.WorkerDeployment redirect_deployment = 8;
     // Used by server internally to properly reapply deployment redirects to an
-    // execution when rebuilding it from history events.
-    int64 deployment_change_counter = 9;
+    // execution when rebuilding it from history events. This is non-zero if and
+    // only if `redirect_deployment` is present.
+    int64 deployment_redirect_counter = 9;
 }
 
 message ActivityTaskCompletedEventAttributes {

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -104,7 +104,7 @@ message WorkflowExecutionStartedEventAttributes {
     string workflow_id = 28;
     // If this workflow intends to use anything other than the current overall default version for
     // the queue, then we include it here.
-    // Deprecated. use `inherited_build_id` instead
+    // Deprecated. [cleanup-experimental-wv]
     temporal.api.common.v1.WorkerVersionStamp source_version_stamp = 29;
     // Completion callbacks attached when this workflow was started.
     repeated temporal.api.common.v1.Callback completion_callbacks = 30;
@@ -128,6 +128,7 @@ message WorkflowExecutionStartedEventAttributes {
     //     - The root workflow of W1 is W1 and the root workflow of W2 is W2.
     temporal.api.common.v1.WorkflowExecution root_workflow_execution = 31;
     // When present, this execution is assigned to the build ID of its parent or previous execution.
+    // Deprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]
     string inherited_build_id = 32;
 }
 
@@ -215,10 +216,18 @@ message WorkflowTaskStartedEventAttributes {
     // just the event id of this event, so we don't include it explicitly here.
     int64 history_size_bytes = 5;
     // Version info of the worker to whom this task was dispatched.
+    // Deprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]
     temporal.api.common.v1.WorkerVersionStamp worker_version = 6;
     // Used by server internally to properly reapply build ID redirects to an execution
     // when rebuilding it from events.
+    // Deprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]
     int64 build_id_redirect_counter = 7;
+    // The worker deployment to which the task was dispatched. Empty means the task
+    // was dispatched to an unversioned worker.
+    temporal.api.common.v1.WorkerDeployment deployment = 8;
+    // Used by server internally to properly reapply deployment redirects to an
+    // execution when rebuilding it from history events.
+    int64 deployment_change_counter = 9;
 }
 
 message WorkflowTaskCompletedEventAttributes {
@@ -337,10 +346,18 @@ message ActivityTaskStartedEventAttributes {
     // been retried.
     temporal.api.failure.v1.Failure last_failure = 5;
     // Version info of the worker to whom this task was dispatched.
+    // Deprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]
     temporal.api.common.v1.WorkerVersionStamp worker_version = 6;
     // Used by server internally to properly reapply build ID redirects to an execution
     // when rebuilding it from events.
+    // Deprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]
     int64 build_id_redirect_counter = 7;
+    // The worker deployment to which the task was dispatched. Empty means the task
+    // was dispatched to an unversioned worker.
+    temporal.api.common.v1.WorkerDeployment deployment = 8;
+    // Used by server internally to properly reapply deployment redirects to an
+    // execution when rebuilding it from history events.
+    int64 deployment_change_counter = 9;
 }
 
 message ActivityTaskCompletedEventAttributes {

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -59,6 +59,7 @@ message WorkflowExecutionInfo {
     int64 state_transition_count = 14;
     int64 history_size_bytes = 15;
     // If set, the most recent worker version stamp that appeared in a workflow task completion
+    // Deprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]
     temporal.api.common.v1.WorkerVersionStamp most_recent_worker_version_stamp = 16;
     // Workflow execution duration is defined as difference between close time and execution time.
     // This field is only populated if the workflow is closed.
@@ -91,18 +92,8 @@ message WorkflowExecutionInfo {
     string assigned_build_id = 19;
     // Build ID inherited from a previous/parent execution. If present, assigned_build_id will be set to this, instead
     // of using the assignment rules.
+    // Deprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]
     string inherited_build_id = 20;
-    // Current build ID of this workflow execution that determines the matching queue that new tasks of this execution
-    // will be scheduled in. Current build ID is set after completion of the first workflow task, and
-    // when workflow moves to a different build ID either automatically or manually. (versioning-3)
-    string build_id = 22;
-    // The deployment name associated with this workflow's task queue + build ID. This is updated when `build_id` is
-    // updated. `deployment_name` should be set if `build_id` field is set.
-    string deployment_name = 23;
-    // Determines how server should treat this execution when workers are upgraded. `versioning_behavior` has to be set
-    // if the `build_id` field is set.
-    temporal.api.enums.v1.VersioningBehavior versioning_behavior = 24;
-
     // The first run ID in the execution chain.
     // Executions created via the following operations are considered to be in the same chain
     // - ContinueAsNew
@@ -110,6 +101,34 @@ message WorkflowExecutionInfo {
     // - Workflow Reset
     // - Cron Schedule
     string first_run_id = 21;
+
+    // Holds all the information about versioning for this particular execution.
+    // This info is typically set after the completion of the first workflow
+    // task because that is the time that versioning behavior and deployment for
+    // the workflow is determined. In some other cases, such as for Child
+    // Workflows, or when Starter has forced a particular behavior or deployment,
+    // this field will be set before the completion of the first workflow task.
+    VersioningInfo versioning_info = 22;
+
+    message VersioningInfo {
+        // Determines how server should treat this execution when workers are upgraded.
+        // When present it means that this workflow is versioned.
+        temporal.api.enums.v1.VersioningBehavior versioning_behavior = 1;
+        // The worker deployment to which this workflow is assigned currently.
+        // Must be present if `versioning_behavior` is set.
+        temporal.api.common.v1.WorkerDeployment deployment = 2;
+        // Manual override for versioning behavior. Takes precedence over
+        // `versioning_behavior`.
+        temporal.api.enums.v1.VersioningBehavior versioning_behavior_override = 3;
+        // Manual override for deployment. Takes precedence over `deployment`.
+        // Must be set when if and only if `versioning_behavior_override` is PINNED.
+        temporal.api.common.v1.WorkerDeployment deployment_override = 4;
+        // Indicates the workflow is being redirected to a different deployment.
+        // Workflow redirect finishes at the next WorkflowTaskCompleted event.
+        // Tasks that start while workflow has an ongoing redirect, will be
+        // dispatched to `redirecting_deployment`.
+        temporal.api.common.v1.WorkerDeployment redirecting_deployment = 5;
+    }
 }
 
 message WorkflowExecutionConfig {
@@ -137,6 +156,7 @@ message PendingActivityInfo {
     // Absence of `assigned_build_id` generally means this task is on an "unversioned" task queue.
     // In rare cases, it can also mean that the task queue is versioned but we failed to write activity's
     // independently-assigned build ID to the database. This case heals automatically once the task is dispatched.
+    // Deprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]
     oneof assigned_build_id {
         // When present, it means this activity is assigned to the build ID of its workflow.
         google.protobuf.Empty use_workflow_build_id = 13;
@@ -147,6 +167,7 @@ message PendingActivityInfo {
         string last_independently_assigned_build_id = 14;
     }
     // The version stamp of the worker to whom this activity was most recently dispatched
+    // Deprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]
     temporal.api.common.v1.WorkerVersionStamp last_worker_version_stamp = 15;
 
     // The time activity will wait until the next retry.
@@ -161,6 +182,10 @@ message PendingActivityInfo {
     // Next time when activity will be scheduled.
     // If activity is currently scheduled or started it will be null.
     google.protobuf.Timestamp next_attempt_schedule_time = 18;
+
+    // Present if activity task queue is versioned. The deployment this activity
+    // was dispatched to most recently.
+    temporal.api.common.v1.WorkerDeployment last_started_deployment = 19;
 }
 
 message PendingChildExecutionInfo {
@@ -182,6 +207,9 @@ message PendingWorkflowTaskInfo {
     google.protobuf.Timestamp original_scheduled_time = 3;
     google.protobuf.Timestamp started_time = 4;
     int32 attempt = 5;
+    // Present if the workflow is versioned. The deployment this workflow task
+    // was dispatched to most recently.
+    temporal.api.common.v1.WorkerDeployment last_started_deployment = 6;
 }
 
 message ResetPoints {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add `versioning_info` to `WorkflowExecutionInfo`. For now `versioning_info` includes:
- `versioning_behavior`
- `deployment`
- `versioning_behavior_override`
- `deployment_override`
- `redirecting_deployment`

<!-- Tell your future self why have you made these changes -->
**Why?**
This info is important to users dealing with versioned workflows.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
Deprecated V2 fields.

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
