### PR TITLE
Remove skip_generate_workflow_task from signal APIs

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -9,7 +9,8 @@ build:
     - google
 breaking:
   use:
-    - WIRE_JSON
+    # TODO (alex): revert it back to WIRE_JSON in follow up PR.
+    - WIRE
   ignore:
     - google
 lint:

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -12158,6 +12158,10 @@
           "$ref": "#/definitions/v1Header",
           "description": "Headers that were passed by the sender of the signal and copied by temporal \nserver into the workflow task."
         },
+        "skipGenerateWorkflowTask": {
+          "type": "boolean",
+          "description": "This field is deprecated and never respected. It should always be set to false."
+        },
         "externalWorkflowExecution": {
           "$ref": "#/definitions/v1WorkflowExecution",
           "description": "When signal origin is a workflow execution, this field is set."

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -5750,11 +5750,7 @@
         },
         "workflowStartDelay": {
           "type": "string",
-          "description": "Time to wait before dispatching the first workflow task. Cannot be used with `cron_schedule`.\nNote that the signal will be delivered with the first workflow task. If the workflow gets\nanother SignalWithStartWorkflow before the delay and `skip_generate_workflow_task` is false\nor not set, a workflow task will be dispatched immediately and the rest of the delay period\nwill be ignored, even if that request also had a delay. Signal via SignalWorkflowExecution\nwill not unblock the workflow."
-        },
-        "skipGenerateWorkflowTask": {
-          "type": "boolean",
-          "description": "Indicates that a new workflow task should not be generated when this signal is received."
+          "description": "Time to wait before dispatching the first workflow task. Cannot be used with `cron_schedule`.\nNote that the signal will be delivered with the first workflow task. If the workflow gets\nanother SignalWithStartWorkflow before the delay a workflow task will be dispatched immediately\nand the rest of the delay period will be ignored, even if that request also had a delay.\nSignal via SignalWorkflowExecution will not unblock the workflow."
         },
         "userMetadata": {
           "$ref": "#/definitions/v1UserMetadata",
@@ -5801,10 +5797,6 @@
         "header": {
           "$ref": "#/definitions/v1Header",
           "description": "Headers that are passed with the signal to the processing workflow.\nThese can include things like auth or tracing tokens."
-        },
-        "skipGenerateWorkflowTask": {
-          "type": "boolean",
-          "description": "Indicates that a new workflow task should not be generated when this signal is received."
         },
         "links": {
           "type": "array",
@@ -12165,10 +12157,6 @@
         "header": {
           "$ref": "#/definitions/v1Header",
           "description": "Headers that were passed by the sender of the signal and copied by temporal \nserver into the workflow task."
-        },
-        "skipGenerateWorkflowTask": {
-          "type": "boolean",
-          "description": "Indicates the signal did not generate a new workflow task when received."
         },
         "externalWorkflowExecution": {
           "$ref": "#/definitions/v1WorkflowExecution",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -8272,13 +8272,9 @@ components:
           description: |-
             Time to wait before dispatching the first workflow task. Cannot be used with `cron_schedule`.
              Note that the signal will be delivered with the first workflow task. If the workflow gets
-             another SignalWithStartWorkflow before the delay and `skip_generate_workflow_task` is false
-             or not set, a workflow task will be dispatched immediately and the rest of the delay period
-             will be ignored, even if that request also had a delay. Signal via SignalWorkflowExecution
-             will not unblock the workflow.
-        skipGenerateWorkflowTask:
-          type: boolean
-          description: Indicates that a new workflow task should not be generated when this signal is received.
+             another SignalWithStartWorkflow before the delay a workflow task will be dispatched immediately
+             and the rest of the delay period will be ignored, even if that request also had a delay.
+             Signal via SignalWorkflowExecution will not unblock the workflow.
         userMetadata:
           allOf:
             - $ref: '#/components/schemas/UserMetadata'
@@ -8329,9 +8325,6 @@ components:
           description: |-
             Headers that are passed with the signal to the processing workflow.
              These can include things like auth or tracing tokens.
-        skipGenerateWorkflowTask:
-          type: boolean
-          description: Indicates that a new workflow task should not be generated when this signal is received.
         links:
           type: array
           items:
@@ -9689,9 +9682,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/Header'
           description: "Headers that were passed by the sender of the signal and copied by temporal \n server into the workflow task."
-        skipGenerateWorkflowTask:
-          type: boolean
-          description: Indicates the signal did not generate a new workflow task when received.
         externalWorkflowExecution:
           allOf:
             - $ref: '#/components/schemas/WorkflowExecution'

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9682,6 +9682,9 @@ components:
           allOf:
             - $ref: '#/components/schemas/Header'
           description: "Headers that were passed by the sender of the signal and copied by temporal \n server into the workflow task."
+        skipGenerateWorkflowTask:
+          type: boolean
+          description: This field is deprecated and never respected. It should always be set to false.
         externalWorkflowExecution:
           allOf:
             - $ref: '#/components/schemas/WorkflowExecution'

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -472,7 +472,8 @@ message WorkflowExecutionSignaledEventAttributes {
     // Headers that were passed by the sender of the signal and copied by temporal 
     // server into the workflow task.
     temporal.api.common.v1.Header header = 4;
-    reserved 5;
+    // This field is deprecated and never respected. It should always be set to false.
+    bool skip_generate_workflow_task = 5 [deprecated = true];
     // When signal origin is a workflow execution, this field is set.
     temporal.api.common.v1.WorkflowExecution external_workflow_execution = 6;
 }

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -472,8 +472,7 @@ message WorkflowExecutionSignaledEventAttributes {
     // Headers that were passed by the sender of the signal and copied by temporal 
     // server into the workflow task.
     temporal.api.common.v1.Header header = 4;
-    // Indicates the signal did not generate a new workflow task when received.
-    bool skip_generate_workflow_task = 5;
+    reserved 5;
     // When signal origin is a workflow execution, this field is set.
     temporal.api.common.v1.WorkflowExecution external_workflow_execution = 6;
 }

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -654,8 +654,7 @@ message SignalWorkflowExecutionRequest {
     // Headers that are passed with the signal to the processing workflow.
     // These can include things like auth or tracing tokens.
     temporal.api.common.v1.Header header = 8;
-    // Indicates that a new workflow task should not be generated when this signal is received.
-    bool skip_generate_workflow_task = 9;
+    reserved 9;
 
     // Links to be associated with the WorkflowExecutionSignaled event.
     repeated temporal.api.common.v1.Link links = 10;
@@ -708,13 +707,11 @@ message SignalWithStartWorkflowExecutionRequest {
     temporal.api.common.v1.Header header = 19;
     // Time to wait before dispatching the first workflow task. Cannot be used with `cron_schedule`.
     // Note that the signal will be delivered with the first workflow task. If the workflow gets
-    // another SignalWithStartWorkflow before the delay and `skip_generate_workflow_task` is false
-    // or not set, a workflow task will be dispatched immediately and the rest of the delay period
-    // will be ignored, even if that request also had a delay. Signal via SignalWorkflowExecution
-    // will not unblock the workflow.
+    // another SignalWithStartWorkflow before the delay a workflow task will be dispatched immediately
+    // and the rest of the delay period will be ignored, even if that request also had a delay.
+    // Signal via SignalWorkflowExecution will not unblock the workflow.
     google.protobuf.Duration workflow_start_delay = 20;
-    // Indicates that a new workflow task should not be generated when this signal is received.
-    bool skip_generate_workflow_task = 21;
+    reserved 21;
     // Metadata on the workflow if it is started. This is carried over to the WorkflowExecutionInfo
     // for use by user interfaces to display the fixed as-of-start summary and details of the
     // workflow.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove `skip_generate_workflow_task` flag from signal APIs and events.

<!-- Tell your future self why have you made these changes -->
**Why?**
See https://github.com/temporalio/temporal/pull/6810 for details.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
Yes, but shouldn't be used.

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
https://github.com/temporalio/temporal/pull/6810 will be merged before this PR.