### PR TITLE
Add NamespaceUnavailableFailure

### DIFF
--- a/temporal/api/errordetails/v1/message.proto
+++ b/temporal/api/errordetails/v1/message.proto
@@ -56,6 +56,12 @@ message NamespaceNotActiveFailure {
     string active_cluster = 3;
 }
 
+// NamespaceUnavailableFailure is returned by the service when a request addresses a namespace that is unavailable. For
+// example, when a namespace is in the process of failing over between clusters.
+message NamespaceUnavailableFailure {
+    string namespace = 1;
+}
+
 message NamespaceInvalidStateFailure {
     string namespace = 1;
     // Current state of the requested namespace.

--- a/temporal/api/errordetails/v1/message.proto
+++ b/temporal/api/errordetails/v1/message.proto
@@ -58,6 +58,7 @@ message NamespaceNotActiveFailure {
 
 // NamespaceUnavailableFailure is returned by the service when a request addresses a namespace that is unavailable. For
 // example, when a namespace is in the process of failing over between clusters.
+// This is a transient error that should be automatically retried by clients.
 message NamespaceUnavailableFailure {
     string namespace = 1;
 }


### PR DESCRIPTION
**Why?**

To differentiate between a namespace that's temporary unavailable and not active.
This new failure will be returned with a gRPC unavailable error and should be retried by clients automatically.
