### PR TITLE
Add `start_time` to `NexusOperationStartedEventAttributes`

### DIFF
--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -842,6 +842,8 @@ message NexusOperationStartedEventAttributes {
 
     // The request ID allocated at schedule time.
     string request_id = 4;
+    // The Nexus handler reported operation start time.
+    google.protobuf.Timestamp start_time = 5;
 }
 
 // Nexus operation completed successfully.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added a new field, `start_time` to `NexusOperationStartedEventAttributes`

<!-- Tell your future self why have you made these changes -->
**Why?**
Used to accurately represent when the operation was started from the handler perspective.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
