### PR TITLE
Add NexusHandlerFailureInfo

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -6212,6 +6212,9 @@
         },
         "nexusOperationExecutionFailureInfo": {
           "$ref": "#/definitions/v1NexusOperationFailureInfo"
+        },
+        "nexusHandlerFailureInfo": {
+          "$ref": "#/definitions/v1NexusHandlerFailureInfo"
         }
       }
     },
@@ -8933,6 +8936,15 @@
         }
       },
       "description": "NewWorkflowExecutionInfo is a shared message that encapsulates all the\nrequired arguments to starting a workflow in different contexts."
+    },
+    "v1NexusHandlerFailureInfo": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The Nexus error type as defined in the spec:\nhttps://github.com/nexus-rpc/api/blob/main/SPEC.md#predefined-handler-errors."
+        }
+      }
     },
     "v1NexusOperationCancelRequestedEventAttributes": {
       "type": "object",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -5740,6 +5740,8 @@ components:
           $ref: '#/components/schemas/ChildWorkflowExecutionFailureInfo'
         nexusOperationExecutionFailureInfo:
           $ref: '#/components/schemas/NexusOperationFailureInfo'
+        nexusHandlerFailureInfo:
+          $ref: '#/components/schemas/NexusHandlerFailureInfo'
     GetClusterInfoResponse:
       type: object
       properties:
@@ -6546,6 +6548,14 @@ components:
       description: |-
         NewWorkflowExecutionInfo is a shared message that encapsulates all the
          required arguments to starting a workflow in different contexts.
+    NexusHandlerFailureInfo:
+      type: object
+      properties:
+        type:
+          type: string
+          description: |-
+            The Nexus error type as defined in the spec:
+             https://github.com/nexus-rpc/api/blob/main/SPEC.md#predefined-handler-errors.
     NexusOperationCancelRequestedEventAttributes:
       type: object
       properties:

--- a/temporal/api/failure/v1/message.proto
+++ b/temporal/api/failure/v1/message.proto
@@ -98,6 +98,12 @@ message NexusOperationFailureInfo {
     string operation_id = 5;
 }
 
+message NexusHandlerFailureInfo {
+    // The Nexus error type as defined in the spec:
+    // https://github.com/nexus-rpc/api/blob/main/SPEC.md#predefined-handler-errors.
+    string type = 1;
+}
+
 message Failure {
     string message = 1;
     // The source this Failure originated in, e.g. TypeScriptSDK / JavaSDK
@@ -131,6 +137,7 @@ message Failure {
         ActivityFailureInfo activity_failure_info = 11;
         ChildWorkflowExecutionFailureInfo child_workflow_execution_failure_info = 12;
         NexusOperationFailureInfo nexus_operation_execution_failure_info = 13;
+        NexusHandlerFailureInfo nexus_handler_failure_info = 14;
     }
 }
 


### PR DESCRIPTION
**Why?**

To better capture when Nexus handlers return `HandlerError`s.