### PR TITLE
Remove request_id from UpdateWorkflowExecutionOptions because it is idempotent

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -6421,10 +6421,6 @@
           "description": "The target Workflow Id and (optionally) a specific Run Id thereof.",
           "title": "The target Workflow Id and (optionally) a specific Run Id thereof."
         },
-        "requestId": {
-          "type": "string",
-          "title": "Used to de-dupe update-options requests"
-        },
         "workflowExecutionOptions": {
           "$ref": "#/definitions/v1WorkflowExecutionOptions",
           "description": "Workflow Execution options. Partial updates are accepted and controlled by update_mask."
@@ -7110,10 +7106,6 @@
         "identity": {
           "type": "string",
           "description": "The identity of the worker/client."
-        },
-        "requestId": {
-          "type": "string",
-          "title": "Used to de-dupe update-options requests"
         },
         "workflowExecutionOptions": {
           "$ref": "#/definitions/v1WorkflowExecutionOptions",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -5104,9 +5104,6 @@ components:
         identity:
           type: string
           description: The identity of the worker/client.
-        requestId:
-          type: string
-          description: Used to de-dupe update-options requests
         workflowExecutionOptions:
           allOf:
             - $ref: '#/components/schemas/WorkflowExecutionOptions'
@@ -9559,9 +9556,6 @@ components:
             The target Workflow Id and (optionally) a specific Run Id thereof.
              (-- api-linter: core::0203::optional=disabled
                  aip.dev/not-precedent: false positive triggered by the word "optional" --)
-        requestId:
-          type: string
-          description: Used to de-dupe update-options requests
         workflowExecutionOptions:
           allOf:
             - $ref: '#/components/schemas/WorkflowExecutionOptions'

--- a/temporal/api/batch/v1/message.proto
+++ b/temporal/api/batch/v1/message.proto
@@ -111,13 +111,10 @@ message BatchOperationUpdateWorkflowExecutionOptions {
   // The identity of the worker/client.
   string identity = 1;
 
-  // Used to de-dupe update-options requests
-  string request_id = 2;
-
   // Workflow Execution options. Partial updates are accepted and controlled by update_mask.
-  temporal.api.workflow.v1.WorkflowExecutionOptions workflow_execution_options = 3;
+  temporal.api.workflow.v1.WorkflowExecutionOptions workflow_execution_options = 2;
 
   // Controls which fields from `workflow_execution_options` will be applied.
   // To unset a field, set it to null and use the update mask to indicate that it should be mutated.
-  google.protobuf.FieldMask update_mask = 4;
+  google.protobuf.FieldMask update_mask = 3;
 }

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1749,15 +1749,12 @@ message UpdateWorkflowExecutionOptionsRequest {
     //     aip.dev/not-precedent: false positive triggered by the word "optional" --)
     temporal.api.common.v1.WorkflowExecution workflow_execution = 2;
 
-    // Used to de-dupe update-options requests
-    string request_id = 3;
-
     // Workflow Execution options. Partial updates are accepted and controlled by update_mask.
-    temporal.api.workflow.v1.WorkflowExecutionOptions workflow_execution_options = 4;
+    temporal.api.workflow.v1.WorkflowExecutionOptions workflow_execution_options = 3;
 
     // Controls which fields from `workflow_execution_options` will be applied.
     // To unset a field, set it to null and use the update mask to indicate that it should be mutated.
-    google.protobuf.FieldMask update_mask = 5;
+    google.protobuf.FieldMask update_mask = 4;
 }
 
 message UpdateWorkflowExecutionOptionsResponse {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Remove request_id from UpdateWorkflowExecutionOptions because it is idempotent


<!-- Tell your future self why have you made these changes -->
No need to de-dupe an idempotent request


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
