### PR TITLE
Fix trigger-api-go-update GHA to escape backticks in commit message

### DIFF
--- a/.github/workflows/trigger-api-go-update.yml
+++ b/.github/workflows/trigger-api-go-update.yml
@@ -37,6 +37,7 @@ jobs:
           EVENT_PUSH_COMMIT_AUTHOR: ${{ github.event.head_commit.author.name }}
           EVENT_PUSH_COMMIT_AUTHOR_EMAIL: ${{ github.event.head_commit.author.email }}
           EVENT_PUSH_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          EVENT_WF_DISPATCH_BRANCH: ${{ github.event.inputs.branch }}
         run: |
           case "${{ github.event_name }}" in
             "push")
@@ -47,7 +48,7 @@ jobs:
               ;;
 
             "workflow_dispatch")
-              BRANCH="${{ github.event.inputs.branch }}"
+              BRANCH="${EVENT_WF_DISPATCH_BRANCH}"
               COMMIT_AUTHOR="Temporal Data"
               COMMIT_AUTHOR_EMAIL="commander-data@temporal.io"
               COMMIT_MESSAGE="Update proto"

--- a/.github/workflows/trigger-api-go-update.yml
+++ b/.github/workflows/trigger-api-go-update.yml
@@ -39,7 +39,10 @@ jobs:
               BRANCH=${BRANCH#refs/heads/}
               COMMIT_AUTHOR=${{ toJSON(github.event.head_commit.author.name) }}
               COMMIT_AUTHOR_EMAIL=${{ toJSON(github.event.head_commit.author.email) }}
-              COMMIT_MESSAGE=${{ toJSON(github.event.head_commit.message) }}
+              COMMIT_MESSAGE=$(cat << 'EOF' | xargs
+                ${{ toJSON(github.event.head_commit.message) }}
+              EOF
+              )
               ;;
 
             "workflow_dispatch")

--- a/.github/workflows/trigger-api-go-update.yml
+++ b/.github/workflows/trigger-api-go-update.yml
@@ -32,17 +32,18 @@ jobs:
 
       - name: Prepare inputs
         id: prepare_inputs
+        env:
+          EVENT_PUSH_BRANCH: ${{ github.event.ref }}
+          EVENT_PUSH_COMMIT_AUTHOR: ${{ github.event.head_commit.author.name }}
+          EVENT_PUSH_COMMIT_AUTHOR_EMAIL: ${{ github.event.head_commit.author.email }}
+          EVENT_PUSH_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           case "${{ github.event_name }}" in
             "push")
-              BRANCH=${{ github.event.ref }}
-              BRANCH=${BRANCH#refs/heads/}
-              COMMIT_AUTHOR=${{ toJSON(github.event.head_commit.author.name) }}
-              COMMIT_AUTHOR_EMAIL=${{ toJSON(github.event.head_commit.author.email) }}
-              COMMIT_MESSAGE=$(cat << 'EOF' | xargs
-                ${{ toJSON(github.event.head_commit.message) }}
-              EOF
-              )
+              BRANCH="${EVENT_PUSH_BRANCH#refs/heads/}"
+              COMMIT_AUTHOR="${EVENT_PUSH_COMMIT_AUTHOR}"
+              COMMIT_AUTHOR_EMAIL="${EVENT_PUSH_COMMIT_AUTHOR_EMAIL}"
+              COMMIT_MESSAGE="${EVENT_PUSH_COMMIT_MESSAGE}"
               ;;
 
             "workflow_dispatch")


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix trigger-api-go-update GHA to escape backticks in commit message

<!-- Tell your future self why have you made these changes -->
**Why?**
Backticks in commit message are being executed as bash commands.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
