### PR TITLE
Provide option to exclude cancel request events from being reapplied beyond reset point

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -10071,10 +10071,11 @@
         "RESET_REAPPLY_EXCLUDE_TYPE_UNSPECIFIED",
         "RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL",
         "RESET_REAPPLY_EXCLUDE_TYPE_UPDATE",
-        "RESET_REAPPLY_EXCLUDE_TYPE_NEXUS"
+        "RESET_REAPPLY_EXCLUDE_TYPE_NEXUS",
+        "RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST"
       ],
       "default": "RESET_REAPPLY_EXCLUDE_TYPE_UNSPECIFIED",
-      "description": "Event types to exclude when reapplying events beyond the reset point.\n\n - RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: Exclude signals when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: Exclude updates when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_NEXUS: Exclude nexus events when reapplying events beyond the reset point."
+      "description": "Event types to exclude when reapplying events beyond the reset point.\n\n - RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: Exclude signals when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: Exclude updates when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_NEXUS: Exclude nexus events when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST: Exclude cancel request events when reapplying events beyond the reset point."
     },
     "v1ResetReapplyType": {
       "type": "string",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -7457,6 +7457,7 @@ components:
               - RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL
               - RESET_REAPPLY_EXCLUDE_TYPE_UPDATE
               - RESET_REAPPLY_EXCLUDE_TYPE_NEXUS
+              - RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST
             type: string
             format: enum
           description: Event types not to be reapplied
@@ -7543,6 +7544,7 @@ components:
               - RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL
               - RESET_REAPPLY_EXCLUDE_TYPE_UPDATE
               - RESET_REAPPLY_EXCLUDE_TYPE_NEXUS
+              - RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST
             type: string
             format: enum
           description: Event types not to be reapplied

--- a/temporal/api/enums/v1/reset.proto
+++ b/temporal/api/enums/v1/reset.proto
@@ -41,7 +41,7 @@ enum ResetReapplyExcludeType {
     // Exclude nexus events when reapplying events beyond the reset point.
     RESET_REAPPLY_EXCLUDE_TYPE_NEXUS = 3;
     // Exclude cancel request events when reapplying events beyond the reset point.
-	RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST = 4;
+    RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST = 4;
 }
 
 // Event types to include when reapplying events. Deprecated: applications

--- a/temporal/api/enums/v1/reset.proto
+++ b/temporal/api/enums/v1/reset.proto
@@ -40,6 +40,8 @@ enum ResetReapplyExcludeType {
     RESET_REAPPLY_EXCLUDE_TYPE_UPDATE = 2;
     // Exclude nexus events when reapplying events beyond the reset point.
     RESET_REAPPLY_EXCLUDE_TYPE_NEXUS = 3;
+    // Exclude cancel request events when reapplying events beyond the reset point.
+	RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST = 4;
 }
 
 // Event types to include when reapplying events. Deprecated: applications


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Added a new option RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST that the operator could choose to disable reapplying of cancel request events beyond the reset point.

<!-- Tell your future self why have you made these changes -->
**Why?**
We are adding cancellation reapply to conflict resolution and workflow reset.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
