### PR TITLE
Fix api-go workflow dispatch

### DIFF
--- a/.github/workflows/trigger-api-go-update.yml
+++ b/.github/workflows/trigger-api-go-update.yml
@@ -30,9 +30,9 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: api-go # generate a token with permissions to trigger GHA in api-go repo
 
-      - name: Prepare inputs
-        id: prepare_inputs
+      - name: Dispatch api-go Github Action
         env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
           EVENT_PUSH_BRANCH: ${{ github.event.ref }}
           EVENT_PUSH_COMMIT_AUTHOR: ${{ github.event.head_commit.author.name }}
           EVENT_PUSH_COMMIT_AUTHOR_EMAIL: ${{ github.event.head_commit.author.email }}
@@ -44,7 +44,7 @@ jobs:
               BRANCH="${EVENT_PUSH_BRANCH#refs/heads/}"
               COMMIT_AUTHOR="${EVENT_PUSH_COMMIT_AUTHOR}"
               COMMIT_AUTHOR_EMAIL="${EVENT_PUSH_COMMIT_AUTHOR_EMAIL}"
-              COMMIT_MESSAGE="${EVENT_PUSH_COMMIT_MESSAGE}"
+              COMMIT_MESSAGE="$(head -1 <<<${EVENT_PUSH_COMMIT_MESSAGE})"
               ;;
 
             "workflow_dispatch")
@@ -55,19 +55,6 @@ jobs:
               ;;
           esac
 
-          echo "BRANCH=${BRANCH}" >> $GITHUB_OUTPUT
-          echo "COMMIT_AUTHOR=${COMMIT_AUTHOR}" >> $GITHUB_OUTPUT
-          echo "COMMIT_AUTHOR_EMAIL=${COMMIT_AUTHOR_EMAIL}" >> $GITHUB_OUTPUT
-          echo "COMMIT_MESSAGE=${COMMIT_MESSAGE}" >> $GITHUB_OUTPUT
-
-      - name: Dispatch api-go Github Action
-        env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
-          BRANCH: ${{ steps.prepare_inputs.outputs.BRANCH }}
-          COMMIT_AUTHOR: ${{ steps.prepare_inputs.outputs.COMMIT_AUTHOR }}
-          COMMIT_AUTHOR_EMAIL: ${{ steps.prepare_inputs.outputs.COMMIT_AUTHOR_EMAIL }}
-          COMMIT_MESSAGE: ${{ steps.prepare_inputs.outputs.COMMIT_MESSAGE }}
-        run: |
           gh workflow run update-proto.yml -R https://github.com/temporalio/api-go \
             -r master \
             -f branch="${BRANCH}" \

--- a/.github/workflows/trigger-api-go-update.yml
+++ b/.github/workflows/trigger-api-go-update.yml
@@ -44,7 +44,7 @@ jobs:
               BRANCH="${EVENT_PUSH_BRANCH#refs/heads/}"
               COMMIT_AUTHOR="${EVENT_PUSH_COMMIT_AUTHOR}"
               COMMIT_AUTHOR_EMAIL="${EVENT_PUSH_COMMIT_AUTHOR_EMAIL}"
-              COMMIT_MESSAGE="$(head -1 <<<${EVENT_PUSH_COMMIT_MESSAGE})"
+              COMMIT_MESSAGE="${EVENT_PUSH_COMMIT_MESSAGE}"
               ;;
 
             "workflow_dispatch")


### PR DESCRIPTION
**What changed?**
Collapse two actions into one to avoid problems with multi-line strings and GITHUB_OUTPUT

**Why?**
Fix breakage
