### PR TITLE
Warn PR authors about the merge policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._
+
 <!-- Describe what has changed in this PR -->
 **What changed?**
 


### PR DESCRIPTION
**What changed?**

Add a warning to the GitHub PR template reminding everyone that both Server AND SDK teams must sign off on a PR before it's merged.

**Why?**

'Cause people have merged things a couple times now without SDK review.

**Breaking changes**

None