### PR TITLE
Replace deployment field in SetCurrentDeploymentRequest

### DIFF
--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1893,13 +1893,16 @@ message ListDeploymentsResponse {
 
 message SetCurrentDeploymentRequest {
     string namespace = 1;
-    temporal.api.deployment.v1.Deployment deployment = 2;
+    // Required. The deployment series whose current deployment would be set.
+    string series_name = 2;
+    // The build ID of the deployment to make current for this series.
+    string build_id = 3;
     // Optional. The identity of the client who initiated this request.
-    string identity = 3;
+    string identity = 4;
     // Optional. Use to add or remove user-defined metadata entries. Metadata entries are exposed
     // when describing a deployment. It is a good place for information such as operator name,
     // links to internal deployment pipelines, etc.
-    temporal.api.deployment.v1.UpdateDeploymentMetadata update_metadata = 4;
+    temporal.api.deployment.v1.UpdateDeploymentMetadata update_metadata = 5;
 }
 
 message SetCurrentDeploymentResponse {


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
Replaced the `deployment` field in `SetCurrentDeploymentRequest` with two top-level fields for `series_name` and `build_id`.


<!-- Tell your future self why have you made these changes -->
**Why?**
This structure is more consistent with `GetCurrentDeploymentRequest` and also allows for supporting "unset" operation by passing empty build ID. (unset part is not documented yet, and will be once we implement it).

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
The change is breaking but this proto is added to the branch yesterday and it is not used in any release. Moreover, `SetCurrentDeploymentRequest` itself is a pre-release API.

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
Server PR will be added by @dnr shortly.