### PR TITLE
Reserve RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -10860,11 +10860,10 @@
         "RESET_REAPPLY_EXCLUDE_TYPE_UNSPECIFIED",
         "RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL",
         "RESET_REAPPLY_EXCLUDE_TYPE_UPDATE",
-        "RESET_REAPPLY_EXCLUDE_TYPE_NEXUS",
-        "RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST"
+        "RESET_REAPPLY_EXCLUDE_TYPE_NEXUS"
       ],
       "default": "RESET_REAPPLY_EXCLUDE_TYPE_UNSPECIFIED",
-      "description": "Event types to exclude when reapplying events beyond the reset point.\n\n - RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: Exclude signals when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: Exclude updates when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_NEXUS: Exclude nexus events when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST: Exclude cancel request events when reapplying events beyond the reset point."
+      "description": "Event types to exclude when reapplying events beyond the reset point.\n\n - RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: Exclude signals when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: Exclude updates when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_NEXUS: Exclude nexus events when reapplying events beyond the reset point."
     },
     "v1ResetReapplyType": {
       "type": "string",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -10864,7 +10864,7 @@
         "RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST"
       ],
       "default": "RESET_REAPPLY_EXCLUDE_TYPE_UNSPECIFIED",
-      "description": "Event types to exclude when reapplying events beyond the reset point.\n\n - RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: Exclude signals when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: Exclude updates when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_NEXUS: Exclude nexus events when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST: Exclude cancel request events when reapplying events beyond the reset point."
+      "description": "Event types to exclude when reapplying events beyond the reset point.\n\n - RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: Exclude signals when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: Exclude updates when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_NEXUS: Exclude nexus events when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST: Deprecated, unimplemented option."
     },
     "v1ResetReapplyType": {
       "type": "string",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -10860,10 +10860,11 @@
         "RESET_REAPPLY_EXCLUDE_TYPE_UNSPECIFIED",
         "RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL",
         "RESET_REAPPLY_EXCLUDE_TYPE_UPDATE",
-        "RESET_REAPPLY_EXCLUDE_TYPE_NEXUS"
+        "RESET_REAPPLY_EXCLUDE_TYPE_NEXUS",
+        "RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST"
       ],
       "default": "RESET_REAPPLY_EXCLUDE_TYPE_UNSPECIFIED",
-      "description": "Event types to exclude when reapplying events beyond the reset point.\n\n - RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: Exclude signals when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: Exclude updates when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_NEXUS: Exclude nexus events when reapplying events beyond the reset point."
+      "description": "Event types to exclude when reapplying events beyond the reset point.\n\n - RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: Exclude signals when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: Exclude updates when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_NEXUS: Exclude nexus events when reapplying events beyond the reset point.\n - RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST: Exclude cancel request events when reapplying events beyond the reset point."
     },
     "v1ResetReapplyType": {
       "type": "string",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -8163,7 +8163,6 @@ components:
               - RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL
               - RESET_REAPPLY_EXCLUDE_TYPE_UPDATE
               - RESET_REAPPLY_EXCLUDE_TYPE_NEXUS
-              - RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST
             type: string
             format: enum
           description: Event types not to be reapplied
@@ -8250,7 +8249,6 @@ components:
               - RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL
               - RESET_REAPPLY_EXCLUDE_TYPE_UPDATE
               - RESET_REAPPLY_EXCLUDE_TYPE_NEXUS
-              - RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST
             type: string
             format: enum
           description: Event types not to be reapplied

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -8163,6 +8163,7 @@ components:
               - RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL
               - RESET_REAPPLY_EXCLUDE_TYPE_UPDATE
               - RESET_REAPPLY_EXCLUDE_TYPE_NEXUS
+              - RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST
             type: string
             format: enum
           description: Event types not to be reapplied
@@ -8249,6 +8250,7 @@ components:
               - RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL
               - RESET_REAPPLY_EXCLUDE_TYPE_UPDATE
               - RESET_REAPPLY_EXCLUDE_TYPE_NEXUS
+              - RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST
             type: string
             format: enum
           description: Event types not to be reapplied

--- a/temporal/api/enums/v1/reset.proto
+++ b/temporal/api/enums/v1/reset.proto
@@ -40,8 +40,8 @@ enum ResetReapplyExcludeType {
     RESET_REAPPLY_EXCLUDE_TYPE_UPDATE = 2;
     // Exclude nexus events when reapplying events beyond the reset point.
     RESET_REAPPLY_EXCLUDE_TYPE_NEXUS = 3;
-    reserved 4;
-    reserved "RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST";
+    // Exclude cancel request events when reapplying events beyond the reset point.
+    RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST = 4 [deprecated=true];
 }
 
 // Event types to include when reapplying events. Deprecated: applications

--- a/temporal/api/enums/v1/reset.proto
+++ b/temporal/api/enums/v1/reset.proto
@@ -40,8 +40,8 @@ enum ResetReapplyExcludeType {
     RESET_REAPPLY_EXCLUDE_TYPE_UPDATE = 2;
     // Exclude nexus events when reapplying events beyond the reset point.
     RESET_REAPPLY_EXCLUDE_TYPE_NEXUS = 3;
-    // Exclude cancel request events when reapplying events beyond the reset point.
-    RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST = 4 [deprecated=true];
+    reserved 4;
+    reserved "RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST";
 }
 
 // Event types to include when reapplying events. Deprecated: applications

--- a/temporal/api/enums/v1/reset.proto
+++ b/temporal/api/enums/v1/reset.proto
@@ -40,8 +40,8 @@ enum ResetReapplyExcludeType {
     RESET_REAPPLY_EXCLUDE_TYPE_UPDATE = 2;
     // Exclude nexus events when reapplying events beyond the reset point.
     RESET_REAPPLY_EXCLUDE_TYPE_NEXUS = 3;
-    // Exclude cancel request events when reapplying events beyond the reset point.
-    RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST = 4;
+    reserved 4;
+    reserved "RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST";
 }
 
 // Event types to include when reapplying events. Deprecated: applications

--- a/temporal/api/enums/v1/reset.proto
+++ b/temporal/api/enums/v1/reset.proto
@@ -40,7 +40,7 @@ enum ResetReapplyExcludeType {
     RESET_REAPPLY_EXCLUDE_TYPE_UPDATE = 2;
     // Exclude nexus events when reapplying events beyond the reset point.
     RESET_REAPPLY_EXCLUDE_TYPE_NEXUS = 3;
-    // Exclude cancel request events when reapplying events beyond the reset point.
+    // Deprecated, unimplemented option.
     RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST = 4 [deprecated=true];
 }
 


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
Reserve RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST option.

<!-- Tell your future self why have you made these changes -->
**Why?**
Cancel request should be reapplied only in conflict resolution case. There is no option to exclude it for reset.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
