### PR TITLE
Add workflow expiration and run timestamps to execution info

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -13015,12 +13015,12 @@
           "$ref": "#/definitions/v1WorkflowExecutionVersioningInfo",
           "description": "Absent value means the workflow execution is not versioned. When present, the execution might\nbe versioned or unversioned, depending on `versioning_info.behavior` and `versioning_info.versioning_override`.\nExperimental. Versioning info is experimental and might change in the future."
         },
-        "workflowExecutionExpirationTime": {
+        "executionExpirationTime": {
           "type": "string",
           "format": "date-time",
           "description": "Workflow execution expiration time is defined as workflow start time plus expiration timeout.\nWorkflow start time may change after workflow reset."
         },
-        "workflowRunExpirationTime": {
+        "runExpirationTime": {
           "type": "string",
           "format": "date-time",
           "description": "Workflow run expiration time is defined as current workflow run start time plus workflow run timeout."

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -13014,6 +13014,16 @@
         "versioningInfo": {
           "$ref": "#/definitions/v1WorkflowExecutionVersioningInfo",
           "description": "Absent value means the workflow execution is not versioned. When present, the execution might\nbe versioned or unversioned, depending on `versioning_info.behavior` and `versioning_info.versioning_override`.\nExperimental. Versioning info is experimental and might change in the future."
+        },
+        "workflowExecutionExpirationTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Workflow execution expiration time is defined as workflow start time plus expiration timeout.\nWorkflow start time may change after workflow reset."
+        },
+        "workflowRunExpirationTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Workflow run expiration time is defined as current workflow run start time plus workflow run timeout."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -12925,9 +12925,14 @@
           "type": "string",
           "format": "date-time",
           "description": "Last workflow reset time. Nil if the workflow was never reset."
+        },
+        "originalStartTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Original workflow start time."
         }
       },
-      "description": "Holds all the extra information about workflow execution."
+      "description": "Holds all the extra information about workflow execution that is not part of Visibility."
     },
     "v1WorkflowExecutionFailedEventAttributes": {
       "type": "object",
@@ -13043,7 +13048,8 @@
           "$ref": "#/definitions/v1WorkflowExecutionVersioningInfo",
           "description": "Absent value means the workflow execution is not versioned. When present, the execution might\nbe versioned or unversioned, depending on `versioning_info.behavior` and `versioning_info.versioning_override`.\nExperimental. Versioning info is experimental and might change in the future."
         }
-      }
+      },
+      "description": "Hold basic information about a workflow execution.\nThis structure is a part of visibility, and thus contain a limited subset of information."
     },
     "v1WorkflowExecutionOptions": {
       "type": "object",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -8466,6 +8466,9 @@
             "type": "object",
             "$ref": "#/definitions/v1PendingNexusOperationInfo"
           }
+        },
+        "workflowExtendedInfo": {
+          "$ref": "#/definitions/v1WorkflowExecutionExtendedInfo"
         }
       }
     },
@@ -12901,6 +12904,31 @@
         }
       }
     },
+    "v1WorkflowExecutionExtendedInfo": {
+      "type": "object",
+      "properties": {
+        "executionExpirationTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Workflow execution expiration time is defined as workflow start time plus expiration timeout.\nWorkflow start time may change after workflow reset."
+        },
+        "runExpirationTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Workflow run expiration time is defined as current workflow run start time plus workflow run timeout."
+        },
+        "cancelRequested": {
+          "type": "boolean",
+          "title": "indicates if the workflow received a cancel request"
+        },
+        "lastResetTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last workflow reset time. Nil if the workflow was never reset."
+        }
+      },
+      "description": "Holds all the extra information about workflow execution."
+    },
     "v1WorkflowExecutionFailedEventAttributes": {
       "type": "object",
       "properties": {
@@ -13014,16 +13042,6 @@
         "versioningInfo": {
           "$ref": "#/definitions/v1WorkflowExecutionVersioningInfo",
           "description": "Absent value means the workflow execution is not versioned. When present, the execution might\nbe versioned or unversioned, depending on `versioning_info.behavior` and `versioning_info.versioning_override`.\nExperimental. Versioning info is experimental and might change in the future."
-        },
-        "executionExpirationTime": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Workflow execution expiration time is defined as workflow start time plus expiration timeout.\nWorkflow start time may change after workflow reset."
-        },
-        "runExpirationTime": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Workflow run expiration time is defined as current workflow run start time plus workflow run timeout."
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -10526,6 +10526,16 @@ components:
             Absent value means the workflow execution is not versioned. When present, the execution might
              be versioned or unversioned, depending on `versioning_info.behavior` and `versioning_info.versioning_override`.
              Experimental. Versioning info is experimental and might change in the future.
+        workflowExecutionExpirationTime:
+          type: string
+          description: |-
+            Workflow execution expiration time is defined as workflow start time plus expiration timeout.
+             Workflow start time may change after workflow reset.
+          format: date-time
+        workflowRunExpirationTime:
+          type: string
+          description: Workflow run expiration time is defined as current workflow run start time plus workflow run timeout.
+          format: date-time
     WorkflowExecutionOptions:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -10412,7 +10412,11 @@ components:
           type: string
           description: Last workflow reset time. Nil if the workflow was never reset.
           format: date-time
-      description: Holds all the extra information about workflow execution.
+        originalStartTime:
+          type: string
+          description: Original workflow start time.
+          format: date-time
+      description: Holds all the extra information about workflow execution that is not part of Visibility.
     WorkflowExecutionFailedEventAttributes:
       type: object
       properties:
@@ -10549,6 +10553,9 @@ components:
             Absent value means the workflow execution is not versioned. When present, the execution might
              be versioned or unversioned, depending on `versioning_info.behavior` and `versioning_info.versioning_override`.
              Experimental. Versioning info is experimental and might change in the future.
+      description: |-
+        Hold basic information about a workflow execution.
+         This structure is a part of visibility, and thus contain a limited subset of information.
     WorkflowExecutionOptions:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -6157,6 +6157,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PendingNexusOperationInfo'
+        workflowExtendedInfo:
+          $ref: '#/components/schemas/WorkflowExecutionExtendedInfo'
     Endpoint:
       type: object
       properties:
@@ -10390,6 +10392,27 @@ components:
           description: |-
             If this is set, the new execution inherits the Build ID of the current execution. Otherwise,
              the assignment rules will be used to independently assign a Build ID to the new execution.
+    WorkflowExecutionExtendedInfo:
+      type: object
+      properties:
+        executionExpirationTime:
+          type: string
+          description: |-
+            Workflow execution expiration time is defined as workflow start time plus expiration timeout.
+             Workflow start time may change after workflow reset.
+          format: date-time
+        runExpirationTime:
+          type: string
+          description: Workflow run expiration time is defined as current workflow run start time plus workflow run timeout.
+          format: date-time
+        cancelRequested:
+          type: boolean
+          description: indicates if the workflow received a cancel request
+        lastResetTime:
+          type: string
+          description: Last workflow reset time. Nil if the workflow was never reset.
+          format: date-time
+      description: Holds all the extra information about workflow execution.
     WorkflowExecutionFailedEventAttributes:
       type: object
       properties:
@@ -10526,16 +10549,6 @@ components:
             Absent value means the workflow execution is not versioned. When present, the execution might
              be versioned or unversioned, depending on `versioning_info.behavior` and `versioning_info.versioning_override`.
              Experimental. Versioning info is experimental and might change in the future.
-        executionExpirationTime:
-          type: string
-          description: |-
-            Workflow execution expiration time is defined as workflow start time plus expiration timeout.
-             Workflow start time may change after workflow reset.
-          format: date-time
-        runExpirationTime:
-          type: string
-          description: Workflow run expiration time is defined as current workflow run start time plus workflow run timeout.
-          format: date-time
     WorkflowExecutionOptions:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -10526,13 +10526,13 @@ components:
             Absent value means the workflow execution is not versioned. When present, the execution might
              be versioned or unversioned, depending on `versioning_info.behavior` and `versioning_info.versioning_override`.
              Experimental. Versioning info is experimental and might change in the future.
-        workflowExecutionExpirationTime:
+        executionExpirationTime:
           type: string
           description: |-
             Workflow execution expiration time is defined as workflow start time plus expiration timeout.
              Workflow start time may change after workflow reset.
           format: date-time
-        workflowRunExpirationTime:
+        runExpirationTime:
           type: string
           description: Workflow run expiration time is defined as current workflow run start time plus workflow run timeout.
           format: date-time

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -110,10 +110,10 @@ message WorkflowExecutionInfo {
 
     // Workflow execution expiration time is defined as workflow start time plus expiration timeout.
     // Workflow start time may change after workflow reset.
-    google.protobuf.Timestamp workflow_execution_expiration_time = 23;
+    google.protobuf.Timestamp execution_expiration_time = 23;
 
     // Workflow run expiration time is defined as current workflow run start time plus workflow run timeout.
-    google.protobuf.Timestamp workflow_run_expiration_time = 24;
+    google.protobuf.Timestamp run_expiration_time = 24;
 }
 
 // Holds all the information about versioning for a workflow execution.

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -43,6 +43,9 @@ import "temporal/api/failure/v1/message.proto";
 import "temporal/api/taskqueue/v1/message.proto";
 import "temporal/api/sdk/v1/user_metadata.proto";
 
+
+// Hold basic information about a workflow execution.
+// This structure is a part of visibility, and thus contain a limited subset of information.
 message WorkflowExecutionInfo {
     temporal.api.common.v1.WorkflowExecution execution = 1;
     temporal.api.common.v1.WorkflowType type = 2;
@@ -109,7 +112,7 @@ message WorkflowExecutionInfo {
     WorkflowExecutionVersioningInfo versioning_info = 22;
 }
 
-// Holds all the extra information about workflow execution.
+// Holds all the extra information about workflow execution that is not part of Visibility.
 message WorkflowExecutionExtendedInfo {
     // Workflow execution expiration time is defined as workflow start time plus expiration timeout.
     // Workflow start time may change after workflow reset.
@@ -123,6 +126,9 @@ message WorkflowExecutionExtendedInfo {
 
     // Last workflow reset time. Nil if the workflow was never reset.
     google.protobuf.Timestamp last_reset_time = 4;
+
+    // Original workflow start time.
+    google.protobuf.Timestamp original_start_time = 5;
 }
 
 // Holds all the information about versioning for a workflow execution.

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -107,13 +107,22 @@ message WorkflowExecutionInfo {
     // be versioned or unversioned, depending on `versioning_info.behavior` and `versioning_info.versioning_override`.
     // Experimental. Versioning info is experimental and might change in the future.
     WorkflowExecutionVersioningInfo versioning_info = 22;
+}
 
+// Holds all the extra information about workflow execution.
+message WorkflowExecutionExtendedInfo {
     // Workflow execution expiration time is defined as workflow start time plus expiration timeout.
     // Workflow start time may change after workflow reset.
-    google.protobuf.Timestamp execution_expiration_time = 23;
+    google.protobuf.Timestamp execution_expiration_time = 1;
 
     // Workflow run expiration time is defined as current workflow run start time plus workflow run timeout.
-    google.protobuf.Timestamp run_expiration_time = 24;
+    google.protobuf.Timestamp run_expiration_time = 2;
+
+    // indicates if the workflow received a cancel request
+    bool cancel_requested = 3;
+
+    // Last workflow reset time. Nil if the workflow was never reset.
+    google.protobuf.Timestamp last_reset_time = 4;
 }
 
 // Holds all the information about versioning for a workflow execution.

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -107,6 +107,13 @@ message WorkflowExecutionInfo {
     // be versioned or unversioned, depending on `versioning_info.behavior` and `versioning_info.versioning_override`.
     // Experimental. Versioning info is experimental and might change in the future.
     WorkflowExecutionVersioningInfo versioning_info = 22;
+
+    // Workflow execution expiration time is defined as workflow start time plus expiration timeout.
+    // Workflow start time may change after workflow reset.
+    google.protobuf.Timestamp workflow_execution_expiration_time = 23;
+
+    // Workflow run expiration time is defined as current workflow run start time plus workflow run timeout.
+    google.protobuf.Timestamp workflow_run_expiration_time = 24;
 }
 
 // Holds all the information about versioning for a workflow execution.

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -982,6 +982,7 @@ message DescribeWorkflowExecutionResponse {
     temporal.api.workflow.v1.PendingWorkflowTaskInfo pending_workflow_task = 5;
     repeated temporal.api.workflow.v1.CallbackInfo callbacks = 6;
     repeated temporal.api.workflow.v1.PendingNexusOperationInfo pending_nexus_operations = 7;
+    temporal.api.workflow.v1.WorkflowExecutionExtendedInfo workflow_extended_info = 8;
 }
 
 // (-- api-linter: core::0203::optional=disabled

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -1016,7 +1016,7 @@ service WorkflowService {
             additional_bindings {
                 post: "/api/v1/namespaces/{namespace}/activities/reset-by-id"
                 body: "*"
-            }   x
+            }
         };
     }
 }

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -1016,7 +1016,7 @@ service WorkflowService {
             additional_bindings {
                 post: "/api/v1/namespaces/{namespace}/activities/reset-by-id"
                 body: "*"
-            }
+            }   x
         };
     }
 }


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
Add new structure -WorkflowExecutionExtendedInfo

That structure has few fields:
* execution timeout time
* run timeout time
* last reset time
* cancel requested

(the last one from https://github.com/temporalio/api/pull/339)

<!-- Tell your future self why have you made these changes -->
**Why?**
Per customer request.
Execution timeout timestamp may change after workflow reset, and in this case customers have no idea when it will fire.
WorkflowExecutionInfo is reused in other server calls, like ListWorkflow, etc.
Because of that we either add any new field to ES, or it will be nil which is bad user experience.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
No

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
N/A