### PR TITLE
Add original_start_time to the workflow execution started event

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -13157,6 +13157,11 @@
           "type": "string",
           "description": "This is the run id when the WorkflowExecutionStarted event was written.\nA workflow reset changes the execution run_id, but preserves this field."
         },
+        "originalExecutionStartTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "This is the start time when the WorkflowExecutionStarted event was written.\nA workflow reset will change execution start time, but will preserve this field."
+        },
         "identity": {
           "type": "string",
           "title": "Identity of the client who requested this execution"
@@ -13230,11 +13235,6 @@
         "versioningOverride": {
           "$ref": "#/definitions/v1VersioningOverride",
           "description": "Versioning override applied to this workflow when it was started."
-        },
-        "originalExecutionStartTime": {
-          "type": "string",
-          "format": "date-time",
-          "description": "This is the start time when the WorkflowExecutionStarted event was written.\nA workflow reset will change execution start time, but will preserve this field."
         }
       },
       "title": "Always the first event in workflow history"

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -13230,6 +13230,11 @@
         "versioningOverride": {
           "$ref": "#/definitions/v1VersioningOverride",
           "description": "Versioning override applied to this workflow when it was started."
+        },
+        "originalExecutionStartTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "This is the start time when the WorkflowExecutionStarted event was written.\nA workflow reset will change execution start time, but will preserve this field."
         }
       },
       "title": "Always the first event in workflow history"

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -10743,6 +10743,12 @@ components:
           allOf:
             - $ref: '#/components/schemas/VersioningOverride'
           description: Versioning override applied to this workflow when it was started.
+        originalExecutionStartTime:
+          type: string
+          description: |-
+            This is the start time when the WorkflowExecutionStarted event was written.
+             A workflow reset will change execution start time, but will preserve this field.
+          format: date-time
       description: Always the first event in workflow history
     WorkflowExecutionTerminatedEventAttributes:
       type: object

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -10655,6 +10655,12 @@ components:
           description: |-
             This is the run id when the WorkflowExecutionStarted event was written.
              A workflow reset changes the execution run_id, but preserves this field.
+        originalExecutionStartTime:
+          type: string
+          description: |-
+            This is the start time when the WorkflowExecutionStarted event was written.
+             A workflow reset will change execution start time, but will preserve this field.
+          format: date-time
         identity:
           type: string
           description: Identity of the client who requested this execution
@@ -10743,12 +10749,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/VersioningOverride'
           description: Versioning override applied to this workflow when it was started.
-        originalExecutionStartTime:
-          type: string
-          description: |-
-            This is the start time when the WorkflowExecutionStarted event was written.
-             A workflow reset will change execution start time, but will preserve this field.
-          format: date-time
       description: Always the first event in workflow history
     WorkflowExecutionTerminatedEventAttributes:
       type: object

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -77,6 +77,10 @@ message WorkflowExecutionStartedEventAttributes {
     // This is the run id when the WorkflowExecutionStarted event was written.
     // A workflow reset changes the execution run_id, but preserves this field.
     string original_execution_run_id = 14;
+    // This is the start time when the WorkflowExecutionStarted event was written.
+    // A workflow reset will change execution start time, but will preserve this field.
+    google.protobuf.Timestamp original_execution_start_time = 34;
+
     // Identity of the client who requested this execution
     string identity = 15;
     // This is the very first runId along the chain of ContinueAsNew, Retry, Cron and Reset.
@@ -133,10 +137,6 @@ message WorkflowExecutionStartedEventAttributes {
     string inherited_build_id = 32;
     // Versioning override applied to this workflow when it was started.
     temporal.api.workflow.v1.VersioningOverride versioning_override = 33;
-
-    // This is the start time when the WorkflowExecutionStarted event was written.
-    // A workflow reset will change execution start time, but will preserve this field.
-    google.protobuf.Timestamp original_execution_start_time = 34;
 }
 
 message WorkflowExecutionCompletedEventAttributes {

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -133,6 +133,10 @@ message WorkflowExecutionStartedEventAttributes {
     string inherited_build_id = 32;
     // Versioning override applied to this workflow when it was started.
     temporal.api.workflow.v1.VersioningOverride versioning_override = 33;
+
+    // This is the start time when the WorkflowExecutionStarted event was written.
+    // A workflow reset will change execution start time, but will preserve this field.
+    google.protobuf.Timestamp original_execution_start_time = 34;
 }
 
 message WorkflowExecutionCompletedEventAttributes {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Add `original_execution_start_time` field to `WorkflowExecutionStartedEventAttributes`.

<!-- Tell your future self why have you made these changes -->
**Why?**

To preserve original execution start time. It will be later used to populate extended info for workflow execution during `DescribeWorkflow` calls.
