### PR TITLE
[Requires repository secret addition] Add Publish to Buf Github Action

### DIFF
--- a/.github/workflows/push-to-buf.yml
+++ b/.github/workflows/push-to-buf.yml
@@ -3,7 +3,7 @@ name: Push to Buf Registry
 on:
   push:
     tags:
-      - '**'
+      - 'v**'
     branches:
       - master
 permissions:
@@ -17,4 +17,4 @@ jobs:
       - uses: bufbuild/buf-action@v1
         with:
           version: 1.49.0
-          token: ${{ secrets.BUF_TOKEN }}
+          token: ${{ secrets.BUF_TEMPORALIO_TOKEN }}

--- a/.github/workflows/push-to-buf.yml
+++ b/.github/workflows/push-to-buf.yml
@@ -2,6 +2,8 @@ name: Push to Buf Registry
 
 on:
   push:
+    tags:
+      - '**'
     branches:
       - master
 permissions:
@@ -14,4 +16,5 @@ jobs:
         uses: actions/checkout@v4
       - uses: bufbuild/buf-action@v1
         with:
+          version: 1.49.0
           token: ${{ secrets.BUF_TOKEN }}

--- a/.github/workflows/push-to-buf.yml
+++ b/.github/workflows/push-to-buf.yml
@@ -2,6 +2,10 @@ name: Push to Buf Registry
 
 on:
   push:
+    tags:
+      - 'v**'
+    branches:
+      - master
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/push-to-buf.yml
+++ b/.github/workflows/push-to-buf.yml
@@ -1,0 +1,24 @@
+name: Push to Buf
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  BUF_TOKEN: ${{ secrets.BUF_API_TOKEN }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 7
+      - name: Install modules
+        run: pnpm install
+      - name: Push Buf protos to the buf registry
+        run: pnpm push

--- a/.github/workflows/push-to-buf.yml
+++ b/.github/workflows/push-to-buf.yml
@@ -1,24 +1,17 @@
-name: Push to Buf
+name: Push to Buf Registry
 
 on:
   push:
     branches:
       - master
-
-env:
-  BUF_TOKEN: ${{ secrets.BUF_API_TOKEN }}
-
+permissions:
+  contents: read
 jobs:
   publish:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v4
+        uses: actions/checkout@v4
+      - uses: bufbuild/buf-action@v1
         with:
-          version: 7
-      - name: Install modules
-        run: pnpm install
-      - name: Push Buf protos to the buf registry
-        run: pnpm push
+          token: ${{ secrets.BUF_TOKEN }}

--- a/.github/workflows/push-to-buf.yml
+++ b/.github/workflows/push-to-buf.yml
@@ -2,10 +2,6 @@ name: Push to Buf Registry
 
 on:
   push:
-    tags:
-      - 'v**'
-    branches:
-      - master
 permissions:
   contents: read
 jobs:

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,5 +1,5 @@
 version: v1
-name: buf.build/temporal/api
+name: buf.build/temporalio/api
 deps:
   - buf.build/grpc-ecosystem/grpc-gateway
   - buf.build/googleapis/googleapis

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,4 +1,5 @@
 version: v1
+name: buf.build/temporal/api
 deps:
   - buf.build/grpc-ecosystem/grpc-gateway
   - buf.build/googleapis/googleapis


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
Adds a GitHub Actions workflow to automate the process of pushing protocol buffers to the Buf registry on every push to the main branch.

We need to set the `BUF_TOKEN` secret before merging this PR.

<!-- Tell your future self why have you made these changes -->
**Why?**
We want to be able to depend on server protos from other repositories (e.g. api-cloud) using the buf package manager.


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
None.

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
NA