### PR TITLE
Add links to StartOperationResponse_Sync

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -5673,6 +5673,13 @@
       "properties": {
         "payload": {
           "$ref": "#/definitions/v1Payload"
+        },
+        "links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apinexusv1Link"
+          }
         }
       },
       "description": "An operation completed successfully."

--- a/temporal/api/nexus/v1/message.proto
+++ b/temporal/api/nexus/v1/message.proto
@@ -109,6 +109,7 @@ message StartOperationResponse {
     // An operation completed successfully.
     message Sync {
         temporal.api.common.v1.Payload payload = 1;
+        repeated Link links = 2;
     }
 
     // The operation will complete asynchronously.


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
Added new fields for links to Nexus `StartOperationResult_Sync`

<!-- Tell your future self why have you made these changes -->
**Why?**
So that links can be attached to sync operations

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
