### PR TITLE
Add OnConflictOptions to StartWorkflowExecutionRequest

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -6536,7 +6536,7 @@
         },
         "onConflictOptions": {
           "$ref": "#/definitions/v1OnConflictOptions",
-          "description": "It defines actions to be done to the existing running workflow when the conflict policy\nWORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING is used. If not set (ie., nil value) or set to a\nempty object (ie., all options with default value), it won't do anything to the existing\nrunning workflow. If set, it will add a history event to the running workflow."
+          "description": "Defines actions to be done to the existing running workflow when the conflict policy\nWORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING is used. If not set (ie., nil value) or set to a\nempty object (ie., all options with default value), it won't do anything to the existing\nrunning workflow. If set, it will add a history event to the running workflow."
         }
       }
     },
@@ -12044,7 +12044,7 @@
         },
         "onConflictOptions": {
           "$ref": "#/definitions/v1OnConflictOptions",
-          "description": "It defines actions to be done to the existing running workflow when the conflict policy\nWORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING is used. If not set (ie., nil value) or set to a\nempty object (ie., all options with default value), it won't do anything to the existing\nrunning workflow. If set, it will add a history event to the running workflow."
+          "description": "Defines actions to be done to the existing running workflow when the conflict policy\nWORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING is used. If not set (ie., nil value) or set to a\nempty object (ie., all options with default value), it won't do anything to the existing\nrunning workflow. If set, it will add a history event to the running workflow."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -13122,7 +13122,7 @@
         },
         "attachedRequestId": {
           "type": "string",
-          "description": "Attached request ID to the running workflow execution so that additional requests with same\nrequest ID will be deduped."
+          "description": "Request ID attachedto the running workflow execution so that subsequent requests with same\nrequest ID will be deduped."
         },
         "attachedCompletionCallbacks": {
           "type": "array",
@@ -13130,7 +13130,7 @@
             "type": "object",
             "$ref": "#/definitions/v1Callback"
           },
-          "description": "Attached completion callbacks to the running workflow execution."
+          "description": "Completion callbacks attached to the running workflow execution."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -6536,7 +6536,7 @@
         },
         "onConflictOptions": {
           "$ref": "#/definitions/v1OnConflictOptions",
-          "description": "It defines behaviors to be executed when the WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING\nconflict policy is used. If set to non-nil object, it will attach the RequestID to the\nexisting running workflow (for deduping), and perform actions specified in the object.\nIf not set (ie., nil value), it won't do anything to the existing running workflow."
+          "description": "It defines actions to be done to the existing running workflow when the conflict policy\nWORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING is used. If not set (ie., nil value) or set to a\nempty object (ie., all options with default value), it won't do anything to the existing\nrunning workflow. If set, it will add a history event to the running workflow."
         }
       }
     },
@@ -9993,14 +9993,20 @@
     "v1OnConflictOptions": {
       "type": "object",
       "properties": {
+        "attachRequestId": {
+          "type": "boolean",
+          "description": "Attaches the request ID to the running workflow."
+        },
         "attachCompletionCallbacks": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Attaches the completion callbacks to the running workflow."
         },
         "attachLinks": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Attaches the links to the WorkflowExecutionOptionsUpdatedEvent history event."
         }
       },
-      "description": "When StartWorkflowExecution uses the WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING conflict policy and\nthere is already an existing running workflow, OnConflictOptions defines actions to be taken on\nthe existing running workflow."
+      "description": "When StartWorkflowExecution uses the conflict policy WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING and\nthere is already an existing running workflow, OnConflictOptions defines actions to be taken on\nthe existing running workflow. In this case, it will create a WorkflowExecutionOptionsUpdatedEvent\nhistory event in the running workflow with the changes requested in this object."
     },
     "v1Outcome": {
       "type": "object",
@@ -12038,7 +12044,7 @@
         },
         "onConflictOptions": {
           "$ref": "#/definitions/v1OnConflictOptions",
-          "description": "It defines behaviors to be executed when the WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING\nconflict policy is used. If set to non-nil object, it will attach the RequestID to the\nexisting running workflow (for deduping), and perform actions specified in the object.\nIf not set (ie., nil value), it won't do anything to the existing running workflow."
+          "description": "It defines actions to be done to the existing running workflow when the conflict policy\nWORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING is used. If not set (ie., nil value) or set to a\nempty object (ie., all options with default value), it won't do anything to the existing\nrunning workflow. If set, it will add a history event to the running workflow."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -6533,6 +6533,10 @@
         "versioningOverride": {
           "$ref": "#/definitions/v1VersioningOverride",
           "description": "If set, takes precedence over the Versioning Behavior sent by the SDK on Workflow Task completion.\nTo unset the override after the workflow is running, use UpdateWorkflowExecutionOptions."
+        },
+        "onConflictOptions": {
+          "$ref": "#/definitions/v1OnConflictOptions",
+          "description": "It defines behaviors to be executed when the WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING\nconflict policy is used. If set to non-nil object, it will attach the RequestID to the\nexisting running workflow (for deduping), and perform actions specified in the object.\nIf not set (ie., nil value), it won't do anything to the existing running workflow."
         }
       }
     },
@@ -9986,6 +9990,18 @@
       },
       "description": "Nexus operation timed out."
     },
+    "v1OnConflictOptions": {
+      "type": "object",
+      "properties": {
+        "attachCompletionCallbacks": {
+          "type": "boolean"
+        },
+        "attachLinks": {
+          "type": "boolean"
+        }
+      },
+      "description": "When StartWorkflowExecution uses the WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING conflict policy and\nthere is already an existing running workflow, OnConflictOptions defines actions to be taken on\nthe existing running workflow."
+    },
     "v1Outcome": {
       "type": "object",
       "properties": {
@@ -12019,6 +12035,10 @@
         "versioningOverride": {
           "$ref": "#/definitions/v1VersioningOverride",
           "description": "If set, takes precedence over the Versioning Behavior sent by the SDK on Workflow Task completion.\nTo unset the override after the workflow is running, use UpdateWorkflowExecutionOptions."
+        },
+        "onConflictOptions": {
+          "$ref": "#/definitions/v1OnConflictOptions",
+          "description": "It defines behaviors to be executed when the WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING\nconflict policy is used. If set to non-nil object, it will attach the RequestID to the\nexisting running workflow (for deduping), and perform actions specified in the object.\nIf not set (ie., nil value), it won't do anything to the existing running workflow."
         }
       }
     },
@@ -13093,6 +13113,18 @@
         "unsetVersioningOverride": {
           "type": "boolean",
           "description": "Versioning override removed in this event."
+        },
+        "attachedRequestId": {
+          "type": "string",
+          "description": "Attached request ID to the running workflow execution so that additional requests with same\nrequest ID will be deduped."
+        },
+        "attachedCompletionCallbacks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1Callback"
+          },
+          "description": "Attached completion callbacks to the running workflow execution."
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -7474,6 +7474,17 @@ components:
           type: string
           description: The request ID allocated at schedule time.
       description: Nexus operation timed out.
+    OnConflictOptions:
+      type: object
+      properties:
+        attachCompletionCallbacks:
+          type: boolean
+        attachLinks:
+          type: boolean
+      description: |-
+        When StartWorkflowExecution uses the WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING conflict policy and
+         there is already an existing running workflow, OnConflictOptions defines actions to be taken on
+         the existing running workflow.
     Outcome:
       type: object
       properties:
@@ -9411,6 +9422,14 @@ components:
           description: |-
             If set, takes precedence over the Versioning Behavior sent by the SDK on Workflow Task completion.
              To unset the override after the workflow is running, use UpdateWorkflowExecutionOptions.
+        onConflictOptions:
+          allOf:
+            - $ref: '#/components/schemas/OnConflictOptions'
+          description: |-
+            It defines behaviors to be executed when the WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING
+             conflict policy is used. If set to non-nil object, it will attach the RequestID to the
+             existing running workflow (for deduping), and perform actions specified in the object.
+             If not set (ie., nil value), it won't do anything to the existing running workflow.
     StartWorkflowExecutionResponse:
       type: object
       properties:
@@ -10591,6 +10610,16 @@ components:
         unsetVersioningOverride:
           type: boolean
           description: Versioning override removed in this event.
+        attachedRequestId:
+          type: string
+          description: |-
+            Attached request ID to the running workflow execution so that additional requests with same
+             request ID will be deduped.
+        attachedCompletionCallbacks:
+          type: array
+          items:
+            $ref: '#/components/schemas/Callback'
+          description: Attached completion callbacks to the running workflow execution.
     WorkflowExecutionSignaledEventAttributes:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -10619,13 +10619,13 @@ components:
         attachedRequestId:
           type: string
           description: |-
-            Attached request ID to the running workflow execution so that additional requests with same
+            Request ID attachedto the running workflow execution so that subsequent requests with same
              request ID will be deduped.
         attachedCompletionCallbacks:
           type: array
           items:
             $ref: '#/components/schemas/Callback'
-          description: Attached completion callbacks to the running workflow execution.
+          description: Completion callbacks attached to the running workflow execution.
     WorkflowExecutionSignaledEventAttributes:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9432,7 +9432,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/OnConflictOptions'
           description: |-
-            It defines actions to be done to the existing running workflow when the conflict policy
+            Defines actions to be done to the existing running workflow when the conflict policy
              WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING is used. If not set (ie., nil value) or set to a
              empty object (ie., all options with default value), it won't do anything to the existing
              running workflow. If set, it will add a history event to the running workflow.

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -7477,14 +7477,20 @@ components:
     OnConflictOptions:
       type: object
       properties:
+        attachRequestId:
+          type: boolean
+          description: Attaches the request ID to the running workflow.
         attachCompletionCallbacks:
           type: boolean
+          description: Attaches the completion callbacks to the running workflow.
         attachLinks:
           type: boolean
+          description: Attaches the links to the WorkflowExecutionOptionsUpdatedEvent history event.
       description: |-
-        When StartWorkflowExecution uses the WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING conflict policy and
+        When StartWorkflowExecution uses the conflict policy WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING and
          there is already an existing running workflow, OnConflictOptions defines actions to be taken on
-         the existing running workflow.
+         the existing running workflow. In this case, it will create a WorkflowExecutionOptionsUpdatedEvent
+         history event in the running workflow with the changes requested in this object.
     Outcome:
       type: object
       properties:
@@ -9426,10 +9432,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/OnConflictOptions'
           description: |-
-            It defines behaviors to be executed when the WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING
-             conflict policy is used. If set to non-nil object, it will attach the RequestID to the
-             existing running workflow (for deduping), and perform actions specified in the object.
-             If not set (ie., nil value), it won't do anything to the existing running workflow.
+            It defines actions to be done to the existing running workflow when the conflict policy
+             WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING is used. If not set (ie., nil value) or set to a
+             empty object (ie., all options with default value), it won't do anything to the existing
+             running workflow. If set, it will add a history event to the running workflow.
     StartWorkflowExecutionResponse:
       type: object
       properties:

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -746,10 +746,10 @@ message WorkflowExecutionOptionsUpdatedEventAttributes {
     temporal.api.workflow.v1.VersioningOverride versioning_override = 1;
     // Versioning override removed in this event.
     bool unset_versioning_override = 2;
-    // Attached request ID to the running workflow execution so that additional requests with same
+    // Request ID attachedto the running workflow execution so that subsequent requests with same
     // request ID will be deduped.
     string attached_request_id = 3;
-    // Attached completion callbacks to the running workflow execution.
+    // Completion callbacks attached to the running workflow execution.
     repeated temporal.api.common.v1.Callback attached_completion_callbacks = 4;
 }
 

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -746,6 +746,11 @@ message WorkflowExecutionOptionsUpdatedEventAttributes {
     temporal.api.workflow.v1.VersioningOverride versioning_override = 1;
     // Versioning override removed in this event.
     bool unset_versioning_override = 2;
+    // Attached request ID to the running workflow execution so that additional requests with same
+    // request ID will be deduped.
+    string attached_request_id = 3;
+    // Attached completion callbacks to the running workflow execution.
+    repeated temporal.api.common.v1.Callback attached_completion_callbacks = 4;
 }
 
 // Not used anywhere. Use case is replaced by WorkflowExecutionOptionsUpdatedEventAttributes

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -440,3 +440,11 @@ message VersioningOverride {
     // Identifies the worker deployment to pin the workflow to.
     temporal.api.deployment.v1.Deployment deployment = 2;
 }
+
+// When StartWorkflowExecution uses the WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING conflict policy and
+// there is already an existing running workflow, OnConflictOptions defines actions to be taken on
+// the existing running workflow.
+message OnConflictOptions {
+    bool attach_completion_callbacks = 1;
+    bool attach_links = 2;
+}

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -441,10 +441,15 @@ message VersioningOverride {
     temporal.api.deployment.v1.Deployment deployment = 2;
 }
 
-// When StartWorkflowExecution uses the WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING conflict policy and
+// When StartWorkflowExecution uses the conflict policy WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING and
 // there is already an existing running workflow, OnConflictOptions defines actions to be taken on
-// the existing running workflow.
+// the existing running workflow. In this case, it will create a WorkflowExecutionOptionsUpdatedEvent
+// history event in the running workflow with the changes requested in this object.
 message OnConflictOptions {
-    bool attach_completion_callbacks = 1;
-    bool attach_links = 2;
+    // Attaches the request ID to the running workflow.
+    bool attach_request_id = 1;
+    // Attaches the completion callbacks to the running workflow.
+    bool attach_completion_callbacks = 2;
+    // Attaches the links to the WorkflowExecutionOptionsUpdatedEvent history event.
+    bool attach_links = 3;
 }

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -206,7 +206,7 @@ message StartWorkflowExecutionRequest {
     // If set, takes precedence over the Versioning Behavior sent by the SDK on Workflow Task completion.
     // To unset the override after the workflow is running, use UpdateWorkflowExecutionOptions.
     temporal.api.workflow.v1.VersioningOverride versioning_override = 25;
-    // It defines actions to be done to the existing running workflow when the conflict policy
+    // Defines actions to be done to the existing running workflow when the conflict policy
     // WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING is used. If not set (ie., nil value) or set to a
     // empty object (ie., all options with default value), it won't do anything to the existing
     // running workflow. If set, it will add a history event to the running workflow.

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -206,10 +206,10 @@ message StartWorkflowExecutionRequest {
     // If set, takes precedence over the Versioning Behavior sent by the SDK on Workflow Task completion.
     // To unset the override after the workflow is running, use UpdateWorkflowExecutionOptions.
     temporal.api.workflow.v1.VersioningOverride versioning_override = 25;
-    // It defines behaviors to be executed when the WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING
-    // conflict policy is used. If set to non-nil object, it will attach the RequestID to the
-    // existing running workflow (for deduping), and perform actions specified in the object.
-    // If not set (ie., nil value), it won't do anything to the existing running workflow.
+    // It defines actions to be done to the existing running workflow when the conflict policy
+    // WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING is used. If not set (ie., nil value) or set to a
+    // empty object (ie., all options with default value), it won't do anything to the existing
+    // running workflow. If set, it will add a history event to the running workflow.
     temporal.api.workflow.v1.OnConflictOptions on_conflict_options = 26;
 }
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -206,6 +206,11 @@ message StartWorkflowExecutionRequest {
     // If set, takes precedence over the Versioning Behavior sent by the SDK on Workflow Task completion.
     // To unset the override after the workflow is running, use UpdateWorkflowExecutionOptions.
     temporal.api.workflow.v1.VersioningOverride versioning_override = 25;
+    // It defines behaviors to be executed when the WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING
+    // conflict policy is used. If set to non-nil object, it will attach the RequestID to the
+    // existing running workflow (for deduping), and perform actions specified in the object.
+    // If not set (ie., nil value), it won't do anything to the existing running workflow.
+    temporal.api.workflow.v1.OnConflictOptions on_conflict_options = 26;
 }
 
 message StartWorkflowExecutionResponse {


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
Add `OnConflictOptions` to `StartWorkflowExecutionRequest`

<!-- Tell your future self why have you made these changes -->
**Why?**
When the workflow id conflict policy is `USE_EXISTING`, `OnConflictOptions` add the ability to change the existing running workflow.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
https://github.com/temporalio/temporal/pull/7080