### PR TITLE
Add data plane fields w/ renamed Worker Versioning concepts

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -6119,7 +6119,7 @@
         },
         "deployment": {
           "$ref": "#/definitions/v1Deployment",
-          "description": "Deployment info of the worker that completed this task. Must be present if user has set\n`WorkerDeploymentOptions` regardless of versioning being enabled or not."
+          "description": "Deployment info of the worker that completed this task. Must be present if user has set\n`WorkerDeploymentOptions` regardless of versioning being enabled or not.\nDeprecated."
         }
       }
     },
@@ -6170,7 +6170,7 @@
         },
         "deployment": {
           "$ref": "#/definitions/v1Deployment",
-          "description": "Deployment info of the worker that completed this task. Must be present if user has set\n`WorkerDeploymentOptions` regardless of versioning being enabled or not."
+          "description": "Deployment info of the worker that completed this task. Must be present if user has set\n`WorkerDeploymentOptions` regardless of versioning being enabled or not.\nDeprecated."
         }
       }
     },
@@ -6225,7 +6225,7 @@
         },
         "deployment": {
           "$ref": "#/definitions/v1Deployment",
-          "description": "Deployment info of the worker that completed this task. Must be present if user has set\n`WorkerDeploymentOptions` regardless of versioning being enabled or not."
+          "description": "Deployment info of the worker that completed this task. Must be present if user has set\n`WorkerDeploymentOptions` regardless of versioning being enabled or not.\nDeprecated."
         }
       }
     },
@@ -8284,7 +8284,17 @@
           "description": "The target deployment of the transition. Null means a so-far-versioned workflow is\ntransitioning to unversioned workers."
         }
       },
-      "description": "Holds information about ongoing transition of a workflow execution from one deployment to another.\nExperimental. Deployment transition is experimental and might change in the future."
+      "description": "Holds information about ongoing transition of a workflow execution from one deployment to another.\nDeprecated. Use DeploymentVersionTransition."
+    },
+    "v1DeploymentVersionTransition": {
+      "type": "object",
+      "properties": {
+        "targetVersion": {
+          "type": "string",
+          "description": "The target version of the transition. Absent means a so-far-versioned workflow is\ntransitioning to unversioned workers."
+        }
+      },
+      "description": "Holds information about ongoing transition of a workflow execution from one worker\ndeployment version to another.\nExperimental. Might change in the future."
     },
     "v1DeprecateNamespaceResponse": {
       "type": "object",
@@ -10099,7 +10109,11 @@
         },
         "lastDeployment": {
           "$ref": "#/definitions/v1Deployment",
-          "description": "The deployment this activity was dispatched to most recently. Present only if the activity\nwas dispatched to a versioned worker."
+          "description": "The deployment this activity was dispatched to most recently. Present only if the activity\nwas dispatched to a versioned worker.\nDeprecated. Use `last_worker_deployment_version`."
+        },
+        "lastWorkerDeploymentVersion": {
+          "type": "string",
+          "description": "The worker deployment version this activity was dispatched to most recently."
         }
       }
     },
@@ -10448,7 +10462,11 @@
         },
         "workerVersionCapabilities": {
           "$ref": "#/definitions/v1WorkerVersionCapabilities",
-          "description": "If a worker has opted into the worker versioning feature while polling, its capabilities will\nappear here."
+          "description": "If a worker has opted into the worker versioning feature while polling, its capabilities will\nappear here.\nDeprecated. Replaced by deployment_options."
+        },
+        "deploymentOptions": {
+          "$ref": "#/definitions/v1WorkerDeploymentOptions",
+          "description": "Worker deployment options that SDK sent to server."
         }
       }
     },
@@ -12710,7 +12728,7 @@
         "VERSIONING_BEHAVIOR_AUTO_UPGRADE"
       ],
       "default": "VERSIONING_BEHAVIOR_UNSPECIFIED",
-      "description": " - VERSIONING_BEHAVIOR_UNSPECIFIED: Workflow execution is unversioned. This is the legacy behavior. An unversioned workflow's\ntask may go to any unversioned worker who is polling for the task queue.\n - VERSIONING_BEHAVIOR_PINNED: Workflow will be pinned to the current deployment until completion. Can be overridden\nexplicitly via `UpdateWorkflowExecutionOptions` API.\nActivities of `PINNED` workflows are sent to the same deployment. Exception to this would be\nwhen the activity task queue workers are not present in the workflows deployment, in which\ncase the activity will be sent to the current deployment of its own task queue.\n - VERSIONING_BEHAVIOR_AUTO_UPGRADE: Workflow will automatically move to the current deployment of its task queue when the next\nworkflow task is dispatched.\nActivities of `AUTO_UPGRADE` workflows are sent to the current deployment of the workflow\nexecution based on the last completed workflow task. Exception to this would be when the\nactivity task queue workers are not present in the workflow's deployment, in which case the\nactivity will be sent to the current deployment of its own task queue.\nWorkflows stuck on a backlogged activity will still auto-upgrade if the default deployment\nof their task queue changes, without having to wait for the backlogged activity to complete\non the old deployment."
+      "description": "Versioning Behavior specifies if and how a workflow execution moves between Worker Deployment\nVersions. The Versioning Behavior of a workflow execution is typically specified by the worker\nwho completes the first task of the execution, but is also overridable manually for new and\nexisting workflows (see VersioningOverride).\n\n - VERSIONING_BEHAVIOR_UNSPECIFIED: Workflow execution does not have a Versioning Behavior and is called Unversioned. This is the\nlegacy behavior. An Unversioned workflow's task may go to any worker who is polling for the\nTask Queue and has WorkflowVersioningMode == UNVERSIONED (or has not specified a\nWorkflowVersioningMode).\n - VERSIONING_BEHAVIOR_PINNED: Workflow will be pinned to their Deployment Version (as specified in versioning_info\n.deployment_version) until completion. Can be overridden explicitly via\n`UpdateWorkflowExecutionOptions` API to move the execution to another Deployment Version.\nActivities of `PINNED` workflows are sent to the same Deployment Version. Exception to this\nwould be when the activity Task Queue workers are not present in the workflow's Deployment\nVersion, in which case the activity will be sent to a different Deployment Version according\nto the activity's Task Queue situation.\n - VERSIONING_BEHAVIOR_AUTO_UPGRADE: Workflow will automatically move to the Current Deployment Version of its Task Queue when the\nnext workflow task is dispatched.\nActivities of `AUTO_UPGRADE` workflows are sent to the Deployment Version of the workflow\nexecution (as specified in versioning_info.deployment_version based on the last completed\nworkflow task). Exception to this would be when the activity Task Queue workers are not\npresent in the workflow's Deployment Version, in which case, the activity will be sent to a\ndifferent Deployment Version according to the activity's Task Queue situation.\nWorkflows stuck on a backlogged activity will still auto-upgrade if the Current Deployment\nVersion of their Task Queue changes, without having to wait for the backlogged activity to\ncomplete on the old Version."
     },
     "v1VersioningOverride": {
       "type": "object",
@@ -12721,10 +12739,14 @@
         },
         "deployment": {
           "$ref": "#/definitions/v1Deployment",
-          "description": "Required if behavior is `PINNED`. Must be null if behavior is `AUTO_UPGRADE`.\nIdentifies the worker deployment to pin the workflow to."
+          "description": "Required if behavior is `PINNED`. Must be null if behavior is `AUTO_UPGRADE`.\nIdentifies the worker deployment to pin the workflow to.\nDeprecated. Use `pinned_version`."
+        },
+        "pinnedVersion": {
+          "type": "string",
+          "description": "Required if behavior is `PINNED`. Must be absent if behavior is not `PINNED`.\nIdentifies the worker deployment version to pin the workflow to."
         }
       },
-      "description": "Used to override the versioning behavior and deployment of a specific workflow execution. If set,\ntakes precedence over the worker-sent values. See `WorkflowExecutionInfo.VersioningInfo` for more\ninformation. To remove the override, call `UpdateWorkflowExecutionOptions` with a null\n`VersioningOverride`, and use the `update_mask` to indicate that it should be mutated."
+      "description": "Used to override the versioning behavior (and pinned deployment version, if applicable) of a\nspecific workflow execution. If set, takes precedence over the worker-sent values. See\n`WorkflowExecutionInfo.VersioningInfo` for more information. To remove the override, call\n`UpdateWorkflowExecutionOptions` with a null `VersioningOverride`, and use the `update_mask`\nto indicate that it should be mutated."
     },
     "v1WaitPolicy": {
       "type": "object",
@@ -12735,6 +12757,24 @@
         }
       },
       "description": "Specifies client's intent to wait for Update results."
+    },
+    "v1WorkerDeploymentOptions": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Required. Worker deployment name."
+        },
+        "version": {
+          "type": "string",
+          "description": "Required. Worker deployment version."
+        },
+        "workflowVersioningMode": {
+          "$ref": "#/definitions/v1WorkflowVersioningMode",
+          "description": "Required. Workflow versioning mode for this deployment version. Must be the same for all\npollers in a given deployment version, across all task queues."
+        }
+      },
+      "description": "Worker Deployment options set in SDK that need to be sent to server in every poll."
     },
     "v1WorkerVersionCapabilities": {
       "type": "object",
@@ -12752,7 +12792,7 @@
           "description": "Must be sent if user has set a deployment series name (versioning-3)."
         }
       },
-      "description": "Identifies the version that a worker is compatible with when polling or identifying itself,\nand whether or not this worker is opting into the build-id based versioning feature. This is\nused by matching to determine which workers ought to receive what tasks."
+      "description": "Identifies the version that a worker is compatible with when polling or identifying itself,\nand whether or not this worker is opting into the build-id based versioning feature. This is\nused by matching to determine which workers ought to receive what tasks.\nDeprecated. Use WorkerDeploymentOptions instead."
     },
     "v1WorkerVersionStamp": {
       "type": "object",
@@ -13372,15 +13412,27 @@
         },
         "deployment": {
           "$ref": "#/definitions/v1Deployment",
-          "description": "The worker deployment that completed the last workflow task of this workflow execution. Must\nbe present if `behavior` is set. Absent value means no workflow task is completed, or the\nlast workflow task was completed by an unversioned worker. Unversioned workers may still send\na deployment value which will be stored here, so the right way to check if an execution is\nversioned if an execution is versioned or not is via the `behavior` field.\nNote that `deployment` is overridden by `versioning_override` if the latter is present."
+          "description": "The worker deployment that completed the last workflow task of this workflow execution. Must\nbe present if `behavior` is set. Absent value means no workflow task is completed, or the\nlast workflow task was completed by an unversioned worker. Unversioned workers may still send\na deployment value which will be stored here, so the right way to check if an execution is\nversioned if an execution is versioned or not is via the `behavior` field.\nNote that `deployment` is overridden by `versioning_override` if the latter is present.\nDeprecated. Use deployment_version and deployment_name."
+        },
+        "deploymentName": {
+          "type": "string",
+          "description": "The deployment name of worker that completed the last workflow task of this workflow\nexecution. Absent value means no workflow task is completed, or the last workflow task was\ncompleted by a legacy worker who does not pass deployment_name."
+        },
+        "deploymentVersion": {
+          "type": "string",
+          "description": "The deployment version of worker that completed the last workflow task of this workflow\nexecution. Must be present if `behavior` is set. Absent value means no workflow task is\ncompleted, or the last workflow task was completed by a legacy worker who does not pass\ndeployment_version.\nNote that if `versioning_override.behavior`."
         },
         "versioningOverride": {
           "$ref": "#/definitions/v1VersioningOverride",
-          "description": "Present if user has set an execution-specific versioning override. This override takes\nprecedence over SDK-sent `behavior` (and `deployment` when override is PINNED). An override\ncan be set when starting a new execution, as well as afterwards by calling the\n`UpdateWorkflowExecutionOptions` API."
+          "description": "Present if user has set an execution-specific versioning override. This override takes\nprecedence over SDK-sent `behavior` (and `deployment_version` when override is PINNED). An\noverride can be set when starting a new execution, as well as afterwards by calling the\n`UpdateWorkflowExecutionOptions` API."
         },
         "deploymentTransition": {
           "$ref": "#/definitions/v1DeploymentTransition",
-          "description": "When present, indicates the workflow is transitioning to a different deployment. Can\nindicate one of the following transitions: unversioned -> versioned, versioned -> versioned\non a different deployment, or versioned -> unversioned.\nNot applicable to workflows with PINNED behavior.\nWhen a workflow with AUTO_UPGRADE behavior creates a new workflow task, it will automatically\nstart a transition to the task queue's current deployment if the task queue's current\ndeployment is different from the workflow's deployment.\nIf the AUTO_UPGRADE workflow is stuck due to backlogged activity or workflow tasks, those\ntasks will be redirected to the task queue's current deployment. As soon as a poller from\nthat deployment is available to receive the task, the workflow will automatically start a\ntransition to that deployment and continue execution there.\nA deployment transition can only exist while there is a pending or started workflow task.\nOnce the pending workflow task completes on the transition's target deployment, the\ntransition completes and the workflow's `deployment` and `behavior` fields are updated per\nthe worker's task completion response.\nPending activities will not start new attempts during a transition. Once the transition is\ncompleted, pending activities will start their next attempt on the new deployment."
+          "description": "When present, indicates the workflow is transitioning to a different deployment. Can\nindicate one of the following transitions: unversioned -> versioned, versioned -> versioned\non a different deployment, or versioned -> unversioned.\nNot applicable to workflows with PINNED behavior.\nWhen a workflow with AUTO_UPGRADE behavior creates a new workflow task, it will automatically\nstart a transition to the task queue's current deployment if the task queue's current\ndeployment is different from the workflow's deployment.\nIf the AUTO_UPGRADE workflow is stuck due to backlogged activity or workflow tasks, those\ntasks will be redirected to the task queue's current deployment. As soon as a poller from\nthat deployment is available to receive the task, the workflow will automatically start a\ntransition to that deployment and continue execution there.\nA deployment transition can only exist while there is a pending or started workflow task.\nOnce the pending workflow task completes on the transition's target deployment, the\ntransition completes and the workflow's `deployment` and `behavior` fields are updated per\nthe worker's task completion response.\nPending activities will not start new attempts during a transition. Once the transition is\ncompleted, pending activities will start their next attempt on the new deployment.\nDeprecated. Use version_transition."
+        },
+        "versionTransition": {
+          "$ref": "#/definitions/v1DeploymentVersionTransition",
+          "description": "When present, indicates the workflow is transitioning to a different deployment version\n(which may belong to the same deployment name or another). Can indicate one of the following\ntransitions: unversioned -> versioned, versioned -> versioned\non a different build, or versioned -> unversioned.\nNot applicable to workflows with PINNED behavior.\nWhen a workflow with AUTO_UPGRADE behavior creates a new workflow task, it will automatically\nstart a transition to the task queue's current version if the task queue's current version is\ndifferent from the workflow's current deployment version.\nIf the AUTO_UPGRADE workflow is stuck due to backlogged activity or workflow tasks, those\ntasks will be redirected to the task queue's current version. As soon as a poller from\nthat build is available to receive the task, the workflow will automatically start a\ntransition to that build and continue execution there.\nA version transition can only exist while there is a pending or started workflow task.\nOnce the pending workflow task completes on the transition's target version, the\ntransition completes and the workflow's `behavior`, `deployment_name`, and\n`deployment_version` fields are updated per the worker's task completion response.\nPending activities will not start new attempts during a transition. Once the transition is\ncompleted, pending activities will start their next attempt on the new version."
         }
       },
       "description": "Holds all the information about versioning for a workflow execution.\nExperimental. Versioning info is experimental and might change in the future."
@@ -13523,11 +13575,19 @@
         },
         "deployment": {
           "$ref": "#/definitions/v1Deployment",
-          "description": "The deployment that completed this task. May or may not be set for unversioned workers,\ndepending on whether a value is sent by the SDK. This value updates workflow execution's\n`versioning_info.deployment`."
+          "description": "The deployment that completed this task. May or may not be set for unversioned workers,\ndepending on whether a value is sent by the SDK. This value updates workflow execution's\n`versioning_info.deployment`.\nDeprecated. Replaced with `deployment_name` and `deployment_version`."
         },
         "versioningBehavior": {
           "$ref": "#/definitions/v1VersioningBehavior",
           "description": "Versioning behavior sent by the worker that completed this task for this particular workflow\nexecution. UNSPECIFIED means the task was completed by an unversioned worker. This value\nupdates workflow execution's `versioning_info.behavior`."
+        },
+        "deploymentName": {
+          "type": "string",
+          "description": "The deployment name of the worker that completed this task. Must be set if\n`versioning_behavior` is set. This value updates workflow execution's\n`versioning_info.deployment_name`."
+        },
+        "deploymentVersion": {
+          "type": "string",
+          "description": "The deployment version of the worker that completed this task. Must be set if\n`versioning_behavior` is set. This value updates workflow execution's\n`versioning_info.deployment_version`."
         }
       }
     },
@@ -13739,6 +13799,16 @@
           "type": "string"
         }
       }
+    },
+    "v1WorkflowVersioningMode": {
+      "type": "string",
+      "enum": [
+        "WORKFLOW_VERSIONING_MODE_UNSPECIFIED",
+        "WORKFLOW_VERSIONING_MODE_UNVERSIONED",
+        "WORKFLOW_VERSIONING_MODE_VERSIONING_BEHAVIORS"
+      ],
+      "default": "WORKFLOW_VERSIONING_MODE_UNSPECIFIED",
+      "description": "Workflow Versioning Mode for a particular Worker Deployment Version. This value is\nconfigured by the app developer in the worker code.\n\n - WORKFLOW_VERSIONING_MODE_UNVERSIONED: Workflows processed by this Deployment Version will be unversioned and user\nneeds to use Patching to keep the new code compatible with prior versions.\nThis mode is recommended to be used along with Rolling Upgrade deployment\nstrategies.\nDeployment Versions with this mode can not be set as the Current or Ramping\nVersion of their Deployment, and are not distinguished from each other for\ntask routing.\n - WORKFLOW_VERSIONING_MODE_VERSIONING_BEHAVIORS: Workflow Versioning Behaviors are enabled in this Deployment Version. Each\nworkflow type must choose between the Pinned and AutoUpgrade behaviors.\nDeployment Versions with this mode can be set as the Current or Ramping\nVersion of their Deployment and hence are the best option for Blue/Green\nand Rainbow strategies (but typically not suitable for Rolling upgrades.)"
     }
   }
 }

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -6004,7 +6004,19 @@ components:
              transitioning to unversioned workers.
       description: |-
         Holds information about ongoing transition of a workflow execution from one deployment to another.
-         Experimental. Deployment transition is experimental and might change in the future.
+         Deprecated. Use DeploymentVersionTransition.
+    DeploymentVersionTransition:
+      type: object
+      properties:
+        targetVersion:
+          type: string
+          description: |-
+            The target version of the transition. Absent means a so-far-versioned workflow is
+             transitioning to unversioned workers.
+      description: |-
+        Holds information about ongoing transition of a workflow execution from one worker
+         deployment version to another.
+         Experimental. Might change in the future.
     DescribeBatchOperationResponse:
       type: object
       properties:
@@ -7589,6 +7601,10 @@ components:
           description: |-
             The deployment this activity was dispatched to most recently. Present only if the activity
              was dispatched to a versioned worker.
+             Deprecated. Use `last_worker_deployment_version`.
+        lastWorkerDeploymentVersion:
+          type: string
+          description: The worker deployment version this activity was dispatched to most recently.
     PendingChildExecutionInfo:
       type: object
       properties:
@@ -7807,6 +7823,11 @@ components:
           description: |-
             If a worker has opted into the worker versioning feature while polling, its capabilities will
              appear here.
+             Deprecated. Replaced by deployment_options.
+        deploymentOptions:
+          allOf:
+            - $ref: '#/components/schemas/WorkerDeploymentOptions'
+          description: Worker deployment options that SDK sent to server.
     QueryRejected:
       type: object
       properties:
@@ -8321,6 +8342,7 @@ components:
           description: |-
             Deployment info of the worker that completed this task. Must be present if user has set
              `WorkerDeploymentOptions` regardless of versioning being enabled or not.
+             Deprecated.
     RespondActivityTaskCanceledResponse:
       type: object
       properties: {}
@@ -8379,6 +8401,7 @@ components:
           description: |-
             Deployment info of the worker that completed this task. Must be present if user has set
              `WorkerDeploymentOptions` regardless of versioning being enabled or not.
+             Deprecated.
     RespondActivityTaskCompletedResponse:
       type: object
       properties: {}
@@ -8452,6 +8475,7 @@ components:
           description: |-
             Deployment info of the worker that completed this task. Must be present if user has set
              `WorkerDeploymentOptions` regardless of versioning being enabled or not.
+             Deprecated.
     RespondActivityTaskFailedResponse:
       type: object
       properties:
@@ -10146,11 +10170,18 @@ components:
           description: |-
             Required if behavior is `PINNED`. Must be null if behavior is `AUTO_UPGRADE`.
              Identifies the worker deployment to pin the workflow to.
+             Deprecated. Use `pinned_version`.
+        pinnedVersion:
+          type: string
+          description: |-
+            Required if behavior is `PINNED`. Must be absent if behavior is not `PINNED`.
+             Identifies the worker deployment version to pin the workflow to.
       description: |-
-        Used to override the versioning behavior and deployment of a specific workflow execution. If set,
-         takes precedence over the worker-sent values. See `WorkflowExecutionInfo.VersioningInfo` for more
-         information. To remove the override, call `UpdateWorkflowExecutionOptions` with a null
-         `VersioningOverride`, and use the `update_mask` to indicate that it should be mutated.
+        Used to override the versioning behavior (and pinned deployment version, if applicable) of a
+         specific workflow execution. If set, takes precedence over the worker-sent values. See
+         `WorkflowExecutionInfo.VersioningInfo` for more information. To remove the override, call
+         `UpdateWorkflowExecutionOptions` with a null `VersioningOverride`, and use the `update_mask`
+         to indicate that it should be mutated.
     WaitPolicy:
       type: object
       properties:
@@ -10169,6 +10200,26 @@ components:
              user specified timeout, API call returns even if specified stage is not reached.
           format: enum
       description: Specifies client's intent to wait for Update results.
+    WorkerDeploymentOptions:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Required. Worker deployment name.
+        version:
+          type: string
+          description: Required. Worker deployment version.
+        workflowVersioningMode:
+          enum:
+            - WORKFLOW_VERSIONING_MODE_UNSPECIFIED
+            - WORKFLOW_VERSIONING_MODE_UNVERSIONED
+            - WORKFLOW_VERSIONING_MODE_VERSIONING_BEHAVIORS
+          type: string
+          description: |-
+            Required. Workflow versioning mode for this deployment version. Must be the same for all
+             pollers in a given deployment version, across all task queues.
+          format: enum
+      description: Worker Deployment options set in SDK that need to be sent to server in every poll.
     WorkerVersionCapabilities:
       type: object
       properties:
@@ -10187,6 +10238,7 @@ components:
         Identifies the version that a worker is compatible with when polling or identifying itself,
          and whether or not this worker is opting into the build-id based versioning feature. This is
          used by matching to determine which workers ought to receive what tasks.
+         Deprecated. Use WorkerDeploymentOptions instead.
     WorkerVersionStamp:
       type: object
       properties:
@@ -10875,13 +10927,28 @@ components:
              a deployment value which will be stored here, so the right way to check if an execution is
              versioned if an execution is versioned or not is via the `behavior` field.
              Note that `deployment` is overridden by `versioning_override` if the latter is present.
+             Deprecated. Use deployment_version and deployment_name.
+        deploymentName:
+          type: string
+          description: |-
+            The deployment name of worker that completed the last workflow task of this workflow
+             execution. Absent value means no workflow task is completed, or the last workflow task was
+             completed by a legacy worker who does not pass deployment_name.
+        deploymentVersion:
+          type: string
+          description: |-
+            The deployment version of worker that completed the last workflow task of this workflow
+             execution. Must be present if `behavior` is set. Absent value means no workflow task is
+             completed, or the last workflow task was completed by a legacy worker who does not pass
+             deployment_version.
+             Note that if `versioning_override.behavior`.
         versioningOverride:
           allOf:
             - $ref: '#/components/schemas/VersioningOverride'
           description: |-
             Present if user has set an execution-specific versioning override. This override takes
-             precedence over SDK-sent `behavior` (and `deployment` when override is PINNED). An override
-             can be set when starting a new execution, as well as afterwards by calling the
+             precedence over SDK-sent `behavior` (and `deployment_version` when override is PINNED). An
+             override can be set when starting a new execution, as well as afterwards by calling the
              `UpdateWorkflowExecutionOptions` API.
         deploymentTransition:
           allOf:
@@ -10904,6 +10971,29 @@ components:
              the worker's task completion response.
              Pending activities will not start new attempts during a transition. Once the transition is
              completed, pending activities will start their next attempt on the new deployment.
+             Deprecated. Use version_transition.
+        versionTransition:
+          allOf:
+            - $ref: '#/components/schemas/DeploymentVersionTransition'
+          description: |-
+            When present, indicates the workflow is transitioning to a different deployment version
+             (which may belong to the same deployment name or another). Can indicate one of the following
+             transitions: unversioned -> versioned, versioned -> versioned
+             on a different build, or versioned -> unversioned.
+             Not applicable to workflows with PINNED behavior.
+             When a workflow with AUTO_UPGRADE behavior creates a new workflow task, it will automatically
+             start a transition to the task queue's current version if the task queue's current version is
+             different from the workflow's current deployment version.
+             If the AUTO_UPGRADE workflow is stuck due to backlogged activity or workflow tasks, those
+             tasks will be redirected to the task queue's current version. As soon as a poller from
+             that build is available to receive the task, the workflow will automatically start a
+             transition to that build and continue execution there.
+             A version transition can only exist while there is a pending or started workflow task.
+             Once the pending workflow task completes on the transition's target version, the
+             transition completes and the workflow's `behavior`, `deployment_name`, and
+             `deployment_version` fields are updated per the worker's task completion response.
+             Pending activities will not start new attempts during a transition. Once the transition is
+             completed, pending activities will start their next attempt on the new version.
       description: |-
         Holds all the information about versioning for a workflow execution.
          Experimental. Versioning info is experimental and might change in the future.
@@ -11000,6 +11090,7 @@ components:
             The deployment that completed this task. May or may not be set for unversioned workers,
              depending on whether a value is sent by the SDK. This value updates workflow execution's
              `versioning_info.deployment`.
+             Deprecated. Replaced with `deployment_name` and `deployment_version`.
         versioningBehavior:
           enum:
             - VERSIONING_BEHAVIOR_UNSPECIFIED
@@ -11011,6 +11102,18 @@ components:
              execution. UNSPECIFIED means the task was completed by an unversioned worker. This value
              updates workflow execution's `versioning_info.behavior`.
           format: enum
+        deploymentName:
+          type: string
+          description: |-
+            The deployment name of the worker that completed this task. Must be set if
+             `versioning_behavior` is set. This value updates workflow execution's
+             `versioning_info.deployment_name`.
+        deploymentVersion:
+          type: string
+          description: |-
+            The deployment version of the worker that completed this task. Must be set if
+             `versioning_behavior` is set. This value updates workflow execution's
+             `versioning_info.deployment_version`.
     WorkflowTaskCompletedMetadata:
       type: object
       properties:

--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -35,6 +35,7 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 
 import "temporal/api/enums/v1/common.proto";
+import "temporal/api/enums/v1/deployment.proto";
 import "temporal/api/enums/v1/event_type.proto";
 import "temporal/api/enums/v1/reset.proto";
 
@@ -140,6 +141,7 @@ message WorkerVersionStamp {
 // Identifies the version that a worker is compatible with when polling or identifying itself,
 // and whether or not this worker is opting into the build-id based versioning feature. This is
 // used by matching to determine which workers ought to receive what tasks.
+// Deprecated. Use WorkerDeploymentOptions instead.
 message WorkerVersionCapabilities {
     // An opaque whole-worker identifier
     string build_id = 1;
@@ -152,6 +154,17 @@ message WorkerVersionCapabilities {
     string deployment_series_name = 4;
 
     // Later, may include info like "I can process WASM and/or JS bundles"
+}
+
+// Worker Deployment options set in SDK that need to be sent to server in every poll.
+message WorkerDeploymentOptions {
+    // Required. Worker deployment name.
+    string name = 1;
+    // Required. Worker deployment version.
+    string version = 2;
+    // Required. Workflow versioning mode for this deployment version. Must be the same for all
+    // pollers in a given deployment version, across all task queues.
+    temporal.api.enums.v1.WorkflowVersioningMode workflow_versioning_mode = 3;
 }
 
 // Describes where and how to reset a workflow, used for batch reset currently

--- a/temporal/api/enums/v1/deployment.proto
+++ b/temporal/api/enums/v1/deployment.proto
@@ -47,3 +47,23 @@ enum DeploymentReachability {
     // deployment went out of retention period. The deployment can be decommissioned safely.
     DEPLOYMENT_REACHABILITY_UNREACHABLE = 3;
 }
+
+// Workflow Versioning Mode for a particular Worker Deployment Version. This value is
+// configured by the app developer in the worker code.
+enum WorkflowVersioningMode {
+    WORKFLOW_VERSIONING_MODE_UNSPECIFIED = 0;
+    // Workflows processed by this Deployment Version will be unversioned and user
+    // needs to use Patching to keep the new code compatible with prior versions.
+    // This mode is recommended to be used along with Rolling Upgrade deployment
+    // strategies.
+    // Deployment Versions with this mode can not be set as the Current or Ramping
+    // Version of their Deployment, and are not distinguished from each other for
+    // task routing.
+    WORKFLOW_VERSIONING_MODE_UNVERSIONED = 1;
+    // Workflow Versioning Behaviors are enabled in this Deployment Version. Each
+    // workflow type must choose between the Pinned and AutoUpgrade behaviors.
+    // Deployment Versions with this mode can be set as the Current or Ramping
+    // Version of their Deployment and hence are the best option for Blue/Green
+    // and Rainbow strategies (but typically not suitable for Rolling upgrades.)
+    WORKFLOW_VERSIONING_MODE_VERSIONING_BEHAVIORS = 2;
+}

--- a/temporal/api/enums/v1/workflow.proto
+++ b/temporal/api/enums/v1/workflow.proto
@@ -139,24 +139,33 @@ enum TimeoutType {
     TIMEOUT_TYPE_HEARTBEAT = 4;
 }
 
+// Versioning Behavior specifies if and how a workflow execution moves between Worker Deployment
+// Versions. The Versioning Behavior of a workflow execution is typically specified by the worker
+// who completes the first task of the execution, but is also overridable manually for new and
+// existing workflows (see VersioningOverride).
 enum VersioningBehavior {
-    // Workflow execution is unversioned. This is the legacy behavior. An unversioned workflow's
-    // task may go to any unversioned worker who is polling for the task queue.
+    // Workflow execution does not have a Versioning Behavior and is called Unversioned. This is the
+    // legacy behavior. An Unversioned workflow's task may go to any worker who is polling for the
+    // Task Queue and has WorkflowVersioningMode == UNVERSIONED (or has not specified a
+    // WorkflowVersioningMode).
     VERSIONING_BEHAVIOR_UNSPECIFIED = 0;
-    // Workflow will be pinned to the current deployment until completion. Can be overridden
-    // explicitly via `UpdateWorkflowExecutionOptions` API.
-    // Activities of `PINNED` workflows are sent to the same deployment. Exception to this would be
-    // when the activity task queue workers are not present in the workflows deployment, in which
-    // case the activity will be sent to the current deployment of its own task queue.
+    // Workflow will be pinned to their Deployment Version (as specified in versioning_info
+    // .deployment_version) until completion. Can be overridden explicitly via
+    // `UpdateWorkflowExecutionOptions` API to move the execution to another Deployment Version.
+    // Activities of `PINNED` workflows are sent to the same Deployment Version. Exception to this
+    // would be when the activity Task Queue workers are not present in the workflow's Deployment
+    // Version, in which case the activity will be sent to a different Deployment Version according
+    // to the activity's Task Queue situation.
     VERSIONING_BEHAVIOR_PINNED = 1;
-    // Workflow will automatically move to the current deployment of its task queue when the next
-    // workflow task is dispatched.
-    // Activities of `AUTO_UPGRADE` workflows are sent to the current deployment of the workflow
-    // execution based on the last completed workflow task. Exception to this would be when the
-    // activity task queue workers are not present in the workflow's deployment, in which case the
-    // activity will be sent to the current deployment of its own task queue.
-    // Workflows stuck on a backlogged activity will still auto-upgrade if the default deployment
-    // of their task queue changes, without having to wait for the backlogged activity to complete
-    // on the old deployment.
+    // Workflow will automatically move to the Current Deployment Version of its Task Queue when the
+    // next workflow task is dispatched.
+    // Activities of `AUTO_UPGRADE` workflows are sent to the Deployment Version of the workflow
+    // execution (as specified in versioning_info.deployment_version based on the last completed
+    // workflow task). Exception to this would be when the activity Task Queue workers are not
+    // present in the workflow's Deployment Version, in which case, the activity will be sent to a
+    // different Deployment Version according to the activity's Task Queue situation.
+    // Workflows stuck on a backlogged activity will still auto-upgrade if the Current Deployment
+    // Version of their Task Queue changes, without having to wait for the backlogged activity to
+    // complete on the old Version.
     VERSIONING_BEHAVIOR_AUTO_UPGRADE = 2;
 }

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -251,11 +251,20 @@ message WorkflowTaskCompletedEventAttributes {
     // The deployment that completed this task. May or may not be set for unversioned workers,
     // depending on whether a value is sent by the SDK. This value updates workflow execution's
     // `versioning_info.deployment`.
+    // Deprecated. Replaced with `deployment_name` and `deployment_version`.
     temporal.api.deployment.v1.Deployment deployment = 7;
     // Versioning behavior sent by the worker that completed this task for this particular workflow
     // execution. UNSPECIFIED means the task was completed by an unversioned worker. This value
     // updates workflow execution's `versioning_info.behavior`.
     temporal.api.enums.v1.VersioningBehavior versioning_behavior = 8;
+    // The deployment name of the worker that completed this task. Must be set if
+    // `versioning_behavior` is set. This value updates workflow execution's
+    // `versioning_info.deployment_name`.
+    string deployment_name = 9;
+    // The deployment version of the worker that completed this task. Must be set if
+    // `versioning_behavior` is set. This value updates workflow execution's
+    // `versioning_info.deployment_version`.
+    string deployment_version = 10;
 }
 
 message WorkflowTaskTimedOutEventAttributes {

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -163,7 +163,10 @@ message PollerInfo {
     double rate_per_second = 3;
     // If a worker has opted into the worker versioning feature while polling, its capabilities will
     // appear here.
+    // Deprecated. Replaced by deployment_options.
     temporal.api.common.v1.WorkerVersionCapabilities worker_version_capabilities = 4;
+    // Worker deployment options that SDK sent to server.
+    temporal.api.common.v1.WorkerDeploymentOptions deployment_options = 5;
 }
 
 message StickyExecutionAttributes {

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -148,10 +148,21 @@ message WorkflowExecutionVersioningInfo {
     // a deployment value which will be stored here, so the right way to check if an execution is
     // versioned if an execution is versioned or not is via the `behavior` field.
     // Note that `deployment` is overridden by `versioning_override` if the latter is present.
+    // Deprecated. Use deployment_version and deployment_name.
     temporal.api.deployment.v1.Deployment deployment = 2;
+    // The deployment name of worker that completed the last workflow task of this workflow
+    // execution. Absent value means no workflow task is completed, or the last workflow task was
+    // completed by a legacy worker who does not pass deployment_name.
+    string deployment_name = 5;
+    // The deployment version of worker that completed the last workflow task of this workflow
+    // execution. Must be present if `behavior` is set. Absent value means no workflow task is
+    // completed, or the last workflow task was completed by a legacy worker who does not pass
+    // deployment_version.
+    // Note that if `versioning_override.behavior`.
+    string deployment_version = 6;
     // Present if user has set an execution-specific versioning override. This override takes
-    // precedence over SDK-sent `behavior` (and `deployment` when override is PINNED). An override
-    // can be set when starting a new execution, as well as afterwards by calling the
+    // precedence over SDK-sent `behavior` (and `deployment_version` when override is PINNED). An
+    // override can be set when starting a new execution, as well as afterwards by calling the
     // `UpdateWorkflowExecutionOptions` API.
     VersioningOverride versioning_override = 3;
     // When present, indicates the workflow is transitioning to a different deployment. Can
@@ -171,15 +182,46 @@ message WorkflowExecutionVersioningInfo {
     // the worker's task completion response.
     // Pending activities will not start new attempts during a transition. Once the transition is
     // completed, pending activities will start their next attempt on the new deployment.
+    // Deprecated. Use version_transition.
     DeploymentTransition deployment_transition = 4;
+    // When present, indicates the workflow is transitioning to a different deployment version
+    // (which may belong to the same deployment name or another). Can indicate one of the following
+    // transitions: unversioned -> versioned, versioned -> versioned
+    // on a different build, or versioned -> unversioned.
+    // Not applicable to workflows with PINNED behavior.
+    // When a workflow with AUTO_UPGRADE behavior creates a new workflow task, it will automatically
+    // start a transition to the task queue's current version if the task queue's current version is
+    // different from the workflow's current deployment version.
+    // If the AUTO_UPGRADE workflow is stuck due to backlogged activity or workflow tasks, those
+    // tasks will be redirected to the task queue's current version. As soon as a poller from
+    // that build is available to receive the task, the workflow will automatically start a
+    // transition to that build and continue execution there.
+    // A version transition can only exist while there is a pending or started workflow task.
+    // Once the pending workflow task completes on the transition's target version, the
+    // transition completes and the workflow's `behavior`, `deployment_name`, and
+    // `deployment_version` fields are updated per the worker's task completion response.
+    // Pending activities will not start new attempts during a transition. Once the transition is
+    // completed, pending activities will start their next attempt on the new version.
+    DeploymentVersionTransition version_transition = 7;
 }
 
 // Holds information about ongoing transition of a workflow execution from one deployment to another.
-// Experimental. Deployment transition is experimental and might change in the future.
+// Deprecated. Use DeploymentVersionTransition.
 message DeploymentTransition {
     // The target deployment of the transition. Null means a so-far-versioned workflow is
     // transitioning to unversioned workers.
     temporal.api.deployment.v1.Deployment deployment = 1;
+
+    // Later: safe transition info
+}
+
+// Holds information about ongoing transition of a workflow execution from one worker
+// deployment version to another.
+// Experimental. Might change in the future.
+message DeploymentVersionTransition {
+    // The target version of the transition. Absent means a so-far-versioned workflow is
+    // transitioning to unversioned workers.
+    string target_version = 1;
 
     // Later: safe transition info
 }
@@ -241,7 +283,10 @@ message PendingActivityInfo {
 
     // The deployment this activity was dispatched to most recently. Present only if the activity
     // was dispatched to a versioned worker.
+    // Deprecated. Use `last_worker_deployment_version`.
     temporal.api.deployment.v1.Deployment last_deployment = 20;
+    // The worker deployment version this activity was dispatched to most recently.
+    string last_worker_deployment_version = 21;
 }
 
 message PendingChildExecutionInfo {
@@ -428,15 +473,21 @@ message WorkflowExecutionOptions {
     VersioningOverride versioning_override = 1;
 }
 
-// Used to override the versioning behavior and deployment of a specific workflow execution. If set,
-// takes precedence over the worker-sent values. See `WorkflowExecutionInfo.VersioningInfo` for more
-// information. To remove the override, call `UpdateWorkflowExecutionOptions` with a null
-// `VersioningOverride`, and use the `update_mask` to indicate that it should be mutated.
+// Used to override the versioning behavior (and pinned deployment version, if applicable) of a
+// specific workflow execution. If set, takes precedence over the worker-sent values. See
+// `WorkflowExecutionInfo.VersioningInfo` for more information. To remove the override, call
+// `UpdateWorkflowExecutionOptions` with a null `VersioningOverride`, and use the `update_mask`
+// to indicate that it should be mutated.
 message VersioningOverride {
     // Required.
     temporal.api.enums.v1.VersioningBehavior behavior = 1;
 
     // Required if behavior is `PINNED`. Must be null if behavior is `AUTO_UPGRADE`.
     // Identifies the worker deployment to pin the workflow to.
+    // Deprecated. Use `pinned_version`.
     temporal.api.deployment.v1.Deployment deployment = 2;
+
+    // Required if behavior is `PINNED`. Must be absent if behavior is not `PINNED`.
+    // Identifies the worker deployment version to pin the workflow to.
+    string pinned_version = 3;
 }

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -269,7 +269,10 @@ message PollWorkflowTaskQueueRequest {
     string binary_checksum = 4;
     // Information about this worker's build identifier and if it is choosing to use the versioning
     // feature. See the `WorkerVersionCapabilities` docstring for more.
+    // Deprecated. Replaced by deployment_options.
     temporal.api.common.v1.WorkerVersionCapabilities worker_version_capabilities = 5;
+    // Worker deployment options that user has set in the worker.
+    temporal.api.common.v1.WorkerDeploymentOptions deployment_options = 6;
 }
 
 message PollWorkflowTaskQueueResponse {
@@ -364,10 +367,17 @@ message RespondWorkflowTaskCompletedRequest {
     Capabilities capabilities = 14;
     // Deployment info of the worker that completed this task. Must be present if user has set
     // `WorkerDeploymentOptions` regardless of versioning being enabled or not.
+    // Deprecated. Pass deployment_name and deployment_version instead.
     temporal.api.deployment.v1.Deployment deployment = 15;
     // Versioning behavior of this workflow execution as set on the worker that completed this task.
     // UNSPECIFIED means versioning is not enabled in the worker.
     temporal.api.enums.v1.VersioningBehavior versioning_behavior = 16;
+    // Deployment name of the worker that completed this task. Must be present if user has set
+    // `WorkerDeploymentOptions` regardless of versioning behavior being specified or not.
+    string deployment_name = 17;
+    // Deployment version of the worker that completed this task. Must be present if
+    // `deployment_name` is present.
+    string deployment_version = 18;
 
     // SDK capability details.
     message Capabilities {
@@ -415,7 +425,11 @@ message RespondWorkflowTaskFailedRequest {
     temporal.api.common.v1.WorkerVersionStamp worker_version = 8 [deprecated = true];
     // Deployment info of the worker that completed this task. Must be present if user has set
     // `WorkerDeploymentOptions` regardless of versioning being enabled or not.
+    // Deprecated. use `worker_build_id`.
     temporal.api.deployment.v1.Deployment deployment = 9;
+    // Build ID of the worker that failed this task. Must be present if user has set
+    // `WorkerDeploymentOptions` regardless of versioning being enabled or not.
+    string worker_build_id = 10;
 }
 
 message RespondWorkflowTaskFailedResponse {
@@ -429,7 +443,10 @@ message PollActivityTaskQueueRequest {
     temporal.api.taskqueue.v1.TaskQueueMetadata task_queue_metadata = 4;
     // Information about this worker's build identifier and if it is choosing to use the versioning
     // feature. See the `WorkerVersionCapabilities` docstring for more.
+    // Deprecated. Replaced by deployment_options.
     temporal.api.common.v1.WorkerVersionCapabilities worker_version_capabilities = 5;
+    // Worker deployment options that user has set in the worker.
+    temporal.api.common.v1.WorkerDeploymentOptions deployment_options = 6;
 }
 
 message PollActivityTaskQueueResponse {
@@ -535,6 +552,7 @@ message RespondActivityTaskCompletedRequest {
     temporal.api.common.v1.WorkerVersionStamp worker_version = 5 [deprecated = true];
     // Deployment info of the worker that completed this task. Must be present if user has set
     // `WorkerDeploymentOptions` regardless of versioning being enabled or not.
+    // Deprecated.
     temporal.api.deployment.v1.Deployment deployment = 6;
 }
 
@@ -576,6 +594,7 @@ message RespondActivityTaskFailedRequest {
     temporal.api.common.v1.WorkerVersionStamp worker_version = 6 [deprecated = true];
     // Deployment info of the worker that completed this task. Must be present if user has set
     // `WorkerDeploymentOptions` regardless of versioning being enabled or not.
+    // Deprecated.
     temporal.api.deployment.v1.Deployment deployment = 7;
 }
 
@@ -623,6 +642,7 @@ message RespondActivityTaskCanceledRequest {
     temporal.api.common.v1.WorkerVersionStamp worker_version = 5 [deprecated = true];
     // Deployment info of the worker that completed this task. Must be present if user has set
     // `WorkerDeploymentOptions` regardless of versioning being enabled or not.
+    // Deprecated.
     temporal.api.deployment.v1.Deployment deployment = 6;
 }
 
@@ -1668,7 +1688,10 @@ message PollNexusTaskQueueRequest {
     temporal.api.taskqueue.v1.TaskQueue task_queue = 3;
     // Information about this worker's build identifier and if it is choosing to use the versioning
     // feature. See the `WorkerVersionCapabilities` docstring for more.
+    // Deprecated. Replaced by deployment_options.
     temporal.api.common.v1.WorkerVersionCapabilities worker_version_capabilities = 4;
+    // Worker deployment options that user has set in the worker.
+    temporal.api.common.v1.WorkerDeploymentOptions deployment_options = 6;
 }
 
 message PollNexusTaskQueueResponse {


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
The following concepts in Worker Versioning V3 is being renamed. This PR adds the data plane fields with new names so SDK can populate them like the old ones.
`DeploymentSeries` -> `WorkerDeployment`
`Deployment` -> `WorkerDeploymentVersion`

Also `WorkerVersionCapabilities` and its `use_versioning` boolean are replaced with `WorkerDeploymentOptions` and  `WorkflowVersioningMode` enum to be more compatible with V3 changes and also extensible in the future.

`RespondActivityTask*Request` used to send `deployment` but that is now deprecated. Since Server does not have any anticipated use for these values, I did not add a replacement for them at the moment.

<!-- Tell your future self why have you made these changes -->
**Why?**
See ^^

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
Not breaking, some things are deprecated that will be cleaned up at a later time with other old Versioning stuff.

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
Server PR will follow soon. But these changes should not break server compile because methods are not touched.
