### PR TITLE
add unset_versioning_override to WorkflowExecutionOptionsUpdatedEventAttributes

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -13073,7 +13073,11 @@
       "properties": {
         "versioningOverride": {
           "$ref": "#/definitions/v1VersioningOverride",
-          "description": "Versioning override in the mutable state after event has been applied."
+          "description": "Versioning override upserted in this event."
+        },
+        "unsetVersioningOverride": {
+          "type": "boolean",
+          "description": "Versioning override removed in this event. Can't be set when versioning_override is set."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -13077,11 +13077,11 @@
       "properties": {
         "versioningOverride": {
           "$ref": "#/definitions/v1VersioningOverride",
-          "description": "Versioning override upserted in this event."
+          "description": "Versioning override upserted in this event.\nIgnored if nil or if unset_versioning_override is true."
         },
         "unsetVersioningOverride": {
           "type": "boolean",
-          "description": "Versioning override removed in this event. Can't be set when versioning_override is set."
+          "description": "Versioning override removed in this event."
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -10572,10 +10572,12 @@ components:
         versioningOverride:
           allOf:
             - $ref: '#/components/schemas/VersioningOverride'
-          description: Versioning override upserted in this event.
+          description: |-
+            Versioning override upserted in this event.
+             Ignored if nil or if unset_versioning_override is true.
         unsetVersioningOverride:
           type: boolean
-          description: Versioning override removed in this event. Can't be set when versioning_override is set.
+          description: Versioning override removed in this event.
     WorkflowExecutionSignaledEventAttributes:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -10569,7 +10569,10 @@ components:
         versioningOverride:
           allOf:
             - $ref: '#/components/schemas/VersioningOverride'
-          description: Versioning override in the mutable state after event has been applied.
+          description: Versioning override upserted in this event.
+        unsetVersioningOverride:
+          type: boolean
+          description: Versioning override removed in this event. Can't be set when versioning_override is set.
     WorkflowExecutionSignaledEventAttributes:
       type: object
       properties:

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -741,8 +741,10 @@ message ChildWorkflowExecutionTerminatedEventAttributes {
 }
 
 message WorkflowExecutionOptionsUpdatedEventAttributes {
-    // Versioning override in the mutable state after event has been applied.
+    // Versioning override upserted in this event.
     temporal.api.workflow.v1.VersioningOverride versioning_override = 1;
+    // Versioning override removed in this event. Can't be set when versioning_override is set.
+    bool unset_versioning_override = 2;
 }
 
 // Not used anywhere. Use case is replaced by WorkflowExecutionOptionsUpdatedEventAttributes

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -742,8 +742,9 @@ message ChildWorkflowExecutionTerminatedEventAttributes {
 
 message WorkflowExecutionOptionsUpdatedEventAttributes {
     // Versioning override upserted in this event.
+    // Ignored if nil or if unset_versioning_override is true.
     temporal.api.workflow.v1.VersioningOverride versioning_override = 1;
-    // Versioning override removed in this event. Can't be set when versioning_override is set.
+    // Versioning override removed in this event.
     bool unset_versioning_override = 2;
 }
 


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
### What:

Add unset_versioning_override to WorkflowExecutionOptionsUpdatedEventAttributes

<!-- Tell your future self why have you made these changes -->
### Why:

So that users of this event don't need to load VersioningOverride from mutable state every time they create this event.
This change was prompted because the event is now being used for non-version-override-related things, and I received feedback that it is inefficient / awkward / error-prone to have to load and pass in the current versioning override every time anyone writes to this event.

Now, a nil Versioning Override in this event means "no change" instead of "remove".
This reduces the chance that someone accidentally unsets an override in the future, and also is more efficient.
We've discussed this change internally in the server team and are ok with changing the meaning of this history event, because it is such a small change and the scope of impact is small (pre-release versioning users who have unset a versioning override and are building mutable state from that history).


<!-- Are there any breaking changes on binary or code level? -->
### Breaking changes?

Now, a nil Versioning Override in this event means "no change" instead of "remove".
If an event exists with the previous meaning and the mutable state is rebuilt, the Versioning Override would not be removed.
But the chance of that happening is very low.

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
https://github.com/temporalio/temporal/pull/7091
