### PR TITLE
add activity_paused flag to ByID heartbeat response (#517)

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -10537,6 +10537,10 @@
         "cancelRequested": {
           "type": "boolean",
           "description": "Will be set to true if the activity has been asked to cancel itself. The SDK should then\nnotify the activity of cancellation if it is still running."
+        },
+        "activityPaused": {
+          "type": "boolean",
+          "description": "Will be set to true if the activity is paused."
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -7906,6 +7906,9 @@ components:
           description: |-
             Will be set to true if the activity has been asked to cancel itself. The SDK should then
              notify the activity of cancellation if it is still running.
+        activityPaused:
+          type: boolean
+          description: Will be set to true if the activity is paused.
     RecordActivityTaskHeartbeatRequest:
       type: object
       properties:

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -518,6 +518,9 @@ message RecordActivityTaskHeartbeatByIdResponse {
     // Will be set to true if the activity has been asked to cancel itself. The SDK should then
     // notify the activity of cancellation if it is still running.
     bool cancel_requested = 1;
+
+    // Will be set to true if the activity is paused.
+    bool activity_paused = 2;
 }
 
 message RespondActivityTaskCompletedRequest {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add "activity_paused" flag to RecordActivityTaskHeartbeatByIdResponse.

<!-- Tell your future self why have you made these changes -->
**Why?**
1. It is needed to let long-running activity know that activity was
paused on the server.
2. Because it is missing in RecordActivityTaskHeartbeatByIdResponse but
present in RecordActivityTaskHeartbeatResponse

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
No.

_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
