### PR TITLE
Add SetWorkerDeploymentRampingVersion and `versioning_info` to DescribeTaskQueue

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -1730,96 +1730,6 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/worker-deployment/{deploymentName}/set-current-version": {
-      "post": {
-        "summary": "Set/unset the Current Version of a Worker Deployment. Automatically unsets the Ramping\nVersion if it is the Version being set as Current.",
-        "operationId": "SetWorkerDeploymentCurrentVersion2",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1SetWorkerDeploymentCurrentVersionResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "deploymentName",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceSetWorkerDeploymentCurrentVersionBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
-    "/api/v1/namespaces/{namespace}/worker-deployment/{deploymentName}/set-ramping-version": {
-      "post": {
-        "summary": "Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for\ngradual ramp to unversioned workers too.",
-        "operationId": "SetWorkerDeploymentRampingVersion2",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1SetWorkerDeploymentRampingVersionResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "deploymentName",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceSetWorkerDeploymentRampingVersionBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
     "/api/v1/namespaces/{namespace}/worker-deployments-version/{version}": {
       "get": {
         "summary": "Describes a worker deployment version.",
@@ -1886,6 +1796,96 @@
             "in": "path",
             "required": true,
             "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}/set-current-version": {
+      "post": {
+        "summary": "Set/unset the Current Version of a Worker Deployment. Automatically unsets the Ramping\nVersion if it is the Version being set as Current.",
+        "operationId": "SetWorkerDeploymentCurrentVersion2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1SetWorkerDeploymentCurrentVersionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceSetWorkerDeploymentCurrentVersionBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}/set-ramping-version": {
+      "post": {
+        "summary": "Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for\ngradual ramp to unversioned workers too.",
+        "operationId": "SetWorkerDeploymentRampingVersion2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1SetWorkerDeploymentRampingVersionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceSetWorkerDeploymentRampingVersionBody"
+            }
           }
         ],
         "tags": [
@@ -4823,96 +4823,6 @@
         ]
       }
     },
-    "/namespaces/{namespace}/worker-deployment/{deploymentName}/set-current-version": {
-      "post": {
-        "summary": "Set/unset the Current Version of a Worker Deployment. Automatically unsets the Ramping\nVersion if it is the Version being set as Current.",
-        "operationId": "SetWorkerDeploymentCurrentVersion",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1SetWorkerDeploymentCurrentVersionResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "deploymentName",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceSetWorkerDeploymentCurrentVersionBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
-    "/namespaces/{namespace}/worker-deployment/{deploymentName}/set-ramping-version": {
-      "post": {
-        "summary": "Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for\ngradual ramp to unversioned workers too.",
-        "operationId": "SetWorkerDeploymentRampingVersion",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1SetWorkerDeploymentRampingVersionResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "deploymentName",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceSetWorkerDeploymentRampingVersionBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
     "/namespaces/{namespace}/worker-deployments-version/{version}": {
       "get": {
         "summary": "Describes a worker deployment version.",
@@ -4979,6 +4889,96 @@
             "in": "path",
             "required": true,
             "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/namespaces/{namespace}/worker-deployments/{deploymentName}/set-current-version": {
+      "post": {
+        "summary": "Set/unset the Current Version of a Worker Deployment. Automatically unsets the Ramping\nVersion if it is the Version being set as Current.",
+        "operationId": "SetWorkerDeploymentCurrentVersion",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1SetWorkerDeploymentCurrentVersionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceSetWorkerDeploymentCurrentVersionBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/namespaces/{namespace}/worker-deployments/{deploymentName}/set-ramping-version": {
+      "post": {
+        "summary": "Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for\ngradual ramp to unversioned workers too.",
+        "operationId": "SetWorkerDeploymentRampingVersion",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1SetWorkerDeploymentRampingVersionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceSetWorkerDeploymentRampingVersionBody"
+            }
           }
         ],
         "tags": [

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -1732,13 +1732,13 @@
     },
     "/api/v1/namespaces/{namespace}/worker-deployment/{deploymentName}/set-current-version": {
       "post": {
-        "summary": "Sets a deployment version as the current version for its deployment.",
-        "operationId": "SetCurrentDeploymentVersion2",
+        "summary": "Set/unset the Current Version of a Worker Deployment. Automatically unsets the Ramping\nVersion if it is the Version being set as Current.",
+        "operationId": "SetWorkerDeploymentCurrentVersion2",
         "responses": {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1SetCurrentDeploymentVersionResponse"
+              "$ref": "#/definitions/v1SetWorkerDeploymentCurrentVersionResponse"
             }
           },
           "default": {
@@ -1766,7 +1766,52 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/WorkflowServiceSetCurrentDeploymentVersionBody"
+              "$ref": "#/definitions/WorkflowServiceSetWorkerDeploymentCurrentVersionBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/api/v1/namespaces/{namespace}/worker-deployment/{deploymentName}/set-ramping-version": {
+      "post": {
+        "summary": "Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for\ngradual ramp to unversioned workers too.",
+        "operationId": "SetWorkerDeploymentRampingVersion2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1SetWorkerDeploymentRampingVersionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceSetWorkerDeploymentRampingVersionBody"
             }
           }
         ],
@@ -4780,13 +4825,13 @@
     },
     "/namespaces/{namespace}/worker-deployment/{deploymentName}/set-current-version": {
       "post": {
-        "summary": "Sets a deployment version as the current version for its deployment.",
-        "operationId": "SetCurrentDeploymentVersion",
+        "summary": "Set/unset the Current Version of a Worker Deployment. Automatically unsets the Ramping\nVersion if it is the Version being set as Current.",
+        "operationId": "SetWorkerDeploymentCurrentVersion",
         "responses": {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1SetCurrentDeploymentVersionResponse"
+              "$ref": "#/definitions/v1SetWorkerDeploymentCurrentVersionResponse"
             }
           },
           "default": {
@@ -4814,7 +4859,52 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/WorkflowServiceSetCurrentDeploymentVersionBody"
+              "$ref": "#/definitions/WorkflowServiceSetWorkerDeploymentCurrentVersionBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/namespaces/{namespace}/worker-deployment/{deploymentName}/set-ramping-version": {
+      "post": {
+        "summary": "Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for\ngradual ramp to unversioned workers too.",
+        "operationId": "SetWorkerDeploymentRampingVersion",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1SetWorkerDeploymentRampingVersionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceSetWorkerDeploymentRampingVersionBody"
             }
           }
         ],
@@ -6559,7 +6649,7 @@
       },
       "title": "[cleanup-wv-pre-release] Pre-release deployment APIs, clean up later"
     },
-    "WorkflowServiceSetCurrentDeploymentVersionBody": {
+    "WorkflowServiceSetWorkerDeploymentCurrentVersionBody": {
       "type": "object",
       "properties": {
         "version": {
@@ -6570,7 +6660,27 @@
           "type": "string",
           "description": "Optional. The identity of the client who initiated this request."
         }
-      }
+      },
+      "description": "Set/unset the Current Version of a Worker Deployment."
+    },
+    "WorkflowServiceSetWorkerDeploymentRampingVersionBody": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string",
+          "title": "The Version to be set as the Ramping Version of the Deployment. Optional when `percentage` is\nzero (unset case), but if given, it must match the current Ramping Version to be unset.\nCan be an empty string and paired with a non-zero `percentage`, in which case it will set the ramp\npercentage without a Ramping Version which means unversioned workers are being ramped.\n(Useful for migrating to unversioned workers from Deployment's Current Version.)"
+        },
+        "percentage": {
+          "type": "number",
+          "format": "float",
+          "description": "Valid range: [0,100]. Zero value will unset the Ramping Version."
+        },
+        "identity": {
+          "type": "string",
+          "description": "Optional. The identity of the client who initiated this request."
+        }
+      },
+      "description": "Set/unset the Ramping Version of a Worker Deployment and its ramp percentage.\nTo unset, pass zero `percentage`.\nTo ramp to unversioned workers (from Deployment's Current Version), pass `version=\"\"` with\nnon-zero `percentage`."
     },
     "WorkflowServiceSignalWithStartWorkflowExecutionBody": {
       "type": "object",
@@ -8734,6 +8844,10 @@
             "$ref": "#/definitions/v1TaskQueueVersionInfo"
           },
           "description": "This map contains Task Queue information for each Build ID. Empty string as key value means unversioned.\nOnly set in `ENHANCED` mode."
+        },
+        "versioningInfo": {
+          "$ref": "#/definitions/v1TaskQueueVersioningInfo",
+          "description": "Specifies which Worker Deployment Version(s) Server routes this Task Queue's tasks to.\nWhen not present, it means the tasks are routed to \"unversioned\" workers. Unversioned workers\nare those with UNVERSIONED (or unspecified) WorkflowVersioningMode.\nTask Queue Versioning info is updated indirectly by calling SetWorkerDeploymentCurrentVersion\nand SetWorkerDeploymentRampingVersion on Worker Deployments.\nNote: This information is not relevant to Pinned workflow executions and their activities as\nthey are always routed to their Pinned Deployment Version. However, new workflow executions\nare typically not Pinned until they complete their first task (unless they are started with\na Pinned VersioningOverride or are Child Workflows of a Pinned parent)."
         }
       }
     },
@@ -11825,12 +11939,26 @@
       },
       "title": "[cleanup-wv-pre-release] Pre-release deployment APIs, clean up later"
     },
-    "v1SetCurrentDeploymentVersionResponse": {
+    "v1SetWorkerDeploymentCurrentVersionResponse": {
       "type": "object",
       "properties": {
         "previousVersion": {
           "type": "string",
-          "description": "Info of the version that was current before executing this operation."
+          "description": "The version that was current before executing this operation."
+        }
+      }
+    },
+    "v1SetWorkerDeploymentRampingVersionResponse": {
+      "type": "object",
+      "properties": {
+        "previousVersion": {
+          "type": "string",
+          "description": "The ramping version before executing this operation."
+        },
+        "previousPercentage": {
+          "type": "number",
+          "format": "float",
+          "description": "The ramping version percentage before executing this operation."
         }
       }
     },
@@ -12643,6 +12771,29 @@
         }
       },
       "description": "Used for specifying versions the caller is interested in."
+    },
+    "v1TaskQueueVersioningInfo": {
+      "type": "object",
+      "properties": {
+        "currentVersion": {
+          "$ref": "#/definitions/v1WorkerDeploymentVersion",
+          "title": "Current Version receives all the tasks except the portion that is routed to the Ramping\nVersion according to `ramping_version_percentage`.\nIt is possible that Current Version is not present when user is ramping from unversioned to\nversioned workers. In that case, remaining tasks after `ramping_version_percentage` go to\nunversioned workers. (Unversioned workers are those with UNVERSIONED (or unspecified)\nWorkflowVersioningMode.)"
+        },
+        "rampingVersion": {
+          "$ref": "#/definitions/v1WorkerDeploymentVersion",
+          "description": "Ramping Version is set during gradual rollout of a new Version. It takes a share of tasks\naccording to `ramping_version_percentage`."
+        },
+        "rampingVersionPercentage": {
+          "type": "number",
+          "format": "float",
+          "description": "Percentage of tasks that are routed to the Ramping Version instead of the Current Version.\nSpecial case: it is possible that `ramping_version_percentage` is non-zero while\n`ramping_version` is absent. That case represents gradual migration out of the Current\nVersion to unversioned workers."
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last time versioning information of this Task Queue changed."
+        }
+      }
     },
     "v1TaskReachability": {
       "type": "string",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -1533,82 +1533,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/worker-deployment/{deploymentName}/set-current-version:
-    post:
-      tags:
-        - WorkflowService
-      description: |-
-        Set/unset the Current Version of a Worker Deployment. Automatically unsets the Ramping
-         Version if it is the Version being set as Current.
-      operationId: SetWorkerDeploymentCurrentVersion
-      parameters:
-        - name: namespace
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: deploymentName
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SetWorkerDeploymentCurrentVersionRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SetWorkerDeploymentCurrentVersionResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/worker-deployment/{deploymentName}/set-ramping-version:
-    post:
-      tags:
-        - WorkflowService
-      description: |-
-        Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for
-         gradual ramp to unversioned workers too.
-      operationId: SetWorkerDeploymentRampingVersion
-      parameters:
-        - name: namespace
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: deploymentName
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SetWorkerDeploymentRampingVersionRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SetWorkerDeploymentRampingVersionResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
   /api/v1/namespaces/{namespace}/worker-deployments-version/{version}:
     get:
       tags:
@@ -1662,6 +1586,82 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DescribeWorkerDeploymentResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}/set-current-version:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        Set/unset the Current Version of a Worker Deployment. Automatically unsets the Ramping
+         Version if it is the Version being set as Current.
+      operationId: SetWorkerDeploymentCurrentVersion
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: deploymentName
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetWorkerDeploymentCurrentVersionRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SetWorkerDeploymentCurrentVersionResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}/set-ramping-version:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for
+         gradual ramp to unversioned workers too.
+      operationId: SetWorkerDeploymentRampingVersion
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: deploymentName
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetWorkerDeploymentRampingVersionRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SetWorkerDeploymentRampingVersionResponse'
         default:
           description: Default error response
           content:
@@ -4278,82 +4278,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/worker-deployment/{deploymentName}/set-current-version:
-    post:
-      tags:
-        - WorkflowService
-      description: |-
-        Set/unset the Current Version of a Worker Deployment. Automatically unsets the Ramping
-         Version if it is the Version being set as Current.
-      operationId: SetWorkerDeploymentCurrentVersion
-      parameters:
-        - name: namespace
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: deploymentName
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SetWorkerDeploymentCurrentVersionRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SetWorkerDeploymentCurrentVersionResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/worker-deployment/{deploymentName}/set-ramping-version:
-    post:
-      tags:
-        - WorkflowService
-      description: |-
-        Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for
-         gradual ramp to unversioned workers too.
-      operationId: SetWorkerDeploymentRampingVersion
-      parameters:
-        - name: namespace
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: deploymentName
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SetWorkerDeploymentRampingVersionRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SetWorkerDeploymentRampingVersionResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
   /namespaces/{namespace}/worker-deployments-version/{version}:
     get:
       tags:
@@ -4407,6 +4331,82 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DescribeWorkerDeploymentResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/worker-deployments/{deploymentName}/set-current-version:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        Set/unset the Current Version of a Worker Deployment. Automatically unsets the Ramping
+         Version if it is the Version being set as Current.
+      operationId: SetWorkerDeploymentCurrentVersion
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: deploymentName
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetWorkerDeploymentCurrentVersionRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SetWorkerDeploymentCurrentVersionResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/worker-deployments/{deploymentName}/set-ramping-version:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for
+         gradual ramp to unversioned workers too.
+      operationId: SetWorkerDeploymentRampingVersion
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: deploymentName
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetWorkerDeploymentRampingVersionRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SetWorkerDeploymentRampingVersionResponse'
         default:
           description: Default error response
           content:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -1537,8 +1537,10 @@ paths:
     post:
       tags:
         - WorkflowService
-      description: Sets a deployment version as the current version for its deployment.
-      operationId: SetCurrentDeploymentVersion
+      description: |-
+        Set/unset the Current Version of a Worker Deployment. Automatically unsets the Ramping
+         Version if it is the Version being set as Current.
+      operationId: SetWorkerDeploymentCurrentVersion
       parameters:
         - name: namespace
           in: path
@@ -1554,7 +1556,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SetCurrentDeploymentVersionRequest'
+              $ref: '#/components/schemas/SetWorkerDeploymentCurrentVersionRequest'
         required: true
       responses:
         "200":
@@ -1562,7 +1564,45 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SetCurrentDeploymentVersionResponse'
+                $ref: '#/components/schemas/SetWorkerDeploymentCurrentVersionResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/worker-deployment/{deploymentName}/set-ramping-version:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for
+         gradual ramp to unversioned workers too.
+      operationId: SetWorkerDeploymentRampingVersion
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: deploymentName
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetWorkerDeploymentRampingVersionRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SetWorkerDeploymentRampingVersionResponse'
         default:
           description: Default error response
           content:
@@ -4242,8 +4282,10 @@ paths:
     post:
       tags:
         - WorkflowService
-      description: Sets a deployment version as the current version for its deployment.
-      operationId: SetCurrentDeploymentVersion
+      description: |-
+        Set/unset the Current Version of a Worker Deployment. Automatically unsets the Ramping
+         Version if it is the Version being set as Current.
+      operationId: SetWorkerDeploymentCurrentVersion
       parameters:
         - name: namespace
           in: path
@@ -4259,7 +4301,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SetCurrentDeploymentVersionRequest'
+              $ref: '#/components/schemas/SetWorkerDeploymentCurrentVersionRequest'
         required: true
       responses:
         "200":
@@ -4267,7 +4309,45 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SetCurrentDeploymentVersionResponse'
+                $ref: '#/components/schemas/SetWorkerDeploymentCurrentVersionResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/worker-deployment/{deploymentName}/set-ramping-version:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for
+         gradual ramp to unversioned workers too.
+      operationId: SetWorkerDeploymentRampingVersion
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: deploymentName
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetWorkerDeploymentRampingVersionRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SetWorkerDeploymentRampingVersionResponse'
         default:
           description: Default error response
           content:
@@ -6349,6 +6429,19 @@ components:
           description: |-
             This map contains Task Queue information for each Build ID. Empty string as key value means unversioned.
              Only set in `ENHANCED` mode.
+        versioningInfo:
+          allOf:
+            - $ref: '#/components/schemas/TaskQueueVersioningInfo'
+          description: |-
+            Specifies which Worker Deployment Version(s) Server routes this Task Queue's tasks to.
+             When not present, it means the tasks are routed to "unversioned" workers. Unversioned workers
+             are those with UNVERSIONED (or unspecified) WorkflowVersioningMode.
+             Task Queue Versioning info is updated indirectly by calling SetWorkerDeploymentCurrentVersion
+             and SetWorkerDeploymentRampingVersion on Worker Deployments.
+             Note: This information is not relevant to Pinned workflow executions and their activities as
+             they are always routed to their Pinned Deployment Version. However, new workflow executions
+             are typically not Pinned until they complete their first task (unless they are started with
+             a Pinned VersioningOverride or are Child Workflows of a Pinned parent).
     DescribeWorkerDeploymentResponse:
       type: object
       properties:
@@ -9150,7 +9243,7 @@ components:
             - $ref: '#/components/schemas/DeploymentInfo'
           description: Info of the deployment that was current before executing this operation.
       description: '[cleanup-wv-pre-release] Pre-release deployment APIs, clean up later'
-    SetCurrentDeploymentVersionRequest:
+    SetWorkerDeploymentCurrentVersionRequest:
       type: object
       properties:
         namespace:
@@ -9163,12 +9256,50 @@ components:
         identity:
           type: string
           description: Optional. The identity of the client who initiated this request.
-    SetCurrentDeploymentVersionResponse:
+      description: Set/unset the Current Version of a Worker Deployment.
+    SetWorkerDeploymentCurrentVersionResponse:
       type: object
       properties:
         previousVersion:
           type: string
-          description: Info of the version that was current before executing this operation.
+          description: The version that was current before executing this operation.
+    SetWorkerDeploymentRampingVersionRequest:
+      type: object
+      properties:
+        namespace:
+          type: string
+        deploymentName:
+          type: string
+        version:
+          type: string
+          description: |-
+            The Version to be set as the Ramping Version of the Deployment. Optional when `percentage` is
+             zero (unset case), but if given, it must match the current Ramping Version to be unset.
+             Can be an empty string and paired with a non-zero `percentage`, in which case it will set the ramp
+             percentage without a Ramping Version which means unversioned workers are being ramped.
+             (Useful for migrating to unversioned workers from Deployment's Current Version.)
+        percentage:
+          type: number
+          description: 'Valid range: [0,100]. Zero value will unset the Ramping Version.'
+          format: float
+        identity:
+          type: string
+          description: Optional. The identity of the client who initiated this request.
+      description: |-
+        Set/unset the Ramping Version of a Worker Deployment and its ramp percentage.
+         To unset, pass zero `percentage`.
+         To ramp to unversioned workers (from Deployment's Current Version), pass `version=""` with
+         non-zero `percentage`.
+    SetWorkerDeploymentRampingVersionResponse:
+      type: object
+      properties:
+        previousVersion:
+          type: string
+          description: The ramping version before executing this operation.
+        previousPercentage:
+          type: number
+          description: The ramping version percentage before executing this operation.
+          format: float
     SignalExternalWorkflowExecutionFailedEventAttributes:
       type: object
       properties:
@@ -9926,6 +10057,37 @@ components:
              who inherit the parent/previous workflow's Build ID but not its Task Queue. In those cases, make
              sure to query reachability for the parent/previous workflow's Task Queue as well.
           format: enum
+    TaskQueueVersioningInfo:
+      type: object
+      properties:
+        currentVersion:
+          allOf:
+            - $ref: '#/components/schemas/WorkerDeploymentVersion'
+          description: |-
+            Current Version receives all the tasks except the portion that is routed to the Ramping
+             Version according to `ramping_version_percentage`.
+             It is possible that Current Version is not present when user is ramping from unversioned to
+             versioned workers. In that case, remaining tasks after `ramping_version_percentage` go to
+             unversioned workers. (Unversioned workers are those with UNVERSIONED (or unspecified)
+             WorkflowVersioningMode.)
+        rampingVersion:
+          allOf:
+            - $ref: '#/components/schemas/WorkerDeploymentVersion'
+          description: |-
+            Ramping Version is set during gradual rollout of a new Version. It takes a share of tasks
+             according to `ramping_version_percentage`.
+        rampingVersionPercentage:
+          type: number
+          description: |-
+            Percentage of tasks that are routed to the Ramping Version instead of the Current Version.
+             Special case: it is possible that `ramping_version_percentage` is non-zero while
+             `ramping_version` is absent. That case represents gradual migration out of the Current
+             Version to unversioned workers.
+          format: float
+        updateTime:
+          type: string
+          description: Last time versioning information of this Task Queue changed.
+          format: date-time
     TerminateWorkflowExecutionRequest:
       type: object
       properties:

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -55,6 +55,26 @@ message TaskQueueMetadata {
     google.protobuf.DoubleValue max_tasks_per_second = 1;
 }
 
+message TaskQueueVersioningInfo {
+    // Current Version receives all the tasks except the portion that is routed to the Ramping
+    // Version according to `ramping_version_percentage`.
+    // It is possible that Current Version is not present when user is ramping from unversioned to
+    // versioned workers. In that case, remaining tasks after `ramping_version_percentage` go to
+    // unversioned workers. (Unversioned workers are those with UNVERSIONED (or unspecified)
+    // WorkflowVersioningMode.)
+    temporal.api.deployment.v1.WorkerDeploymentVersion current_version = 1;
+    // Ramping Version is set during gradual rollout of a new Version. It takes a share of tasks
+    // according to `ramping_version_percentage`.
+    temporal.api.deployment.v1.WorkerDeploymentVersion ramping_version = 2;
+    // Percentage of tasks that are routed to the Ramping Version instead of the Current Version.
+    // Special case: it is possible that `ramping_version_percentage` is non-zero while
+    // `ramping_version` is absent. That case represents gradual migration out of the Current
+    // Version to unversioned workers.
+    float ramping_version_percentage = 3;
+    // Last time versioning information of this Task Queue changed.
+    google.protobuf.Timestamp update_time = 4;
+}
+
 // Used for specifying versions the caller is interested in.
 message TaskQueueVersionSelection {
     // Include specific Build IDs.

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -61,9 +61,11 @@ import "temporal/api/batch/v1/message.proto";
 import "temporal/api/sdk/v1/task_complete_metadata.proto";
 import "temporal/api/sdk/v1/user_metadata.proto";
 import "temporal/api/nexus/v1/message.proto";
+
 import "google/protobuf/duration.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
 
 message RegisterNamespaceRequest {
     string namespace = 1;
@@ -1052,6 +1054,17 @@ message DescribeTaskQueueResponse {
     // This map contains Task Queue information for each Build ID. Empty string as key value means unversioned.
     // Only set in `ENHANCED` mode.
     map<string, temporal.api.taskqueue.v1.TaskQueueVersionInfo> versions_info = 3;
+
+    // Specifies which Worker Deployment Version(s) Server routes this Task Queue's tasks to.
+    // When not present, it means the tasks are routed to "unversioned" workers. Unversioned workers
+    // are those with UNVERSIONED (or unspecified) WorkflowVersioningMode.
+    // Task Queue Versioning info is updated indirectly by calling SetWorkerDeploymentCurrentVersion
+    // and SetWorkerDeploymentRampingVersion on Worker Deployments.
+    // Note: This information is not relevant to Pinned workflow executions and their activities as
+    // they are always routed to their Pinned Deployment Version. However, new workflow executions
+    // are typically not Pinned until they complete their first task (unless they are started with
+    // a Pinned VersioningOverride or are Child Workflows of a Pinned parent).
+    temporal.api.taskqueue.v1.TaskQueueVersioningInfo versioning_info = 4;
 }
 
 message GetClusterInfoRequest {
@@ -1973,18 +1986,47 @@ message SetCurrentDeploymentResponse {
     temporal.api.deployment.v1.DeploymentInfo previous_deployment_info = 2;
 }
 
-message SetCurrentDeploymentVersionRequest {
+// Set/unset the Current Version of a Worker Deployment.
+message SetWorkerDeploymentCurrentVersionRequest {
     string namespace = 1;
     string deployment_name = 2;
     // Must be a Versioned Build. Pass empty string to unset.
-    string version = 3;
+    google.protobuf.StringValue version = 3;
     // Optional. The identity of the client who initiated this request.
     string identity = 4;
 }
 
-message SetCurrentDeploymentVersionResponse {
-    // Info of the version that was current before executing this operation.
+message SetWorkerDeploymentCurrentVersionResponse {
+    // The version that was current before executing this operation.
     string previous_version = 1;
+}
+
+// Set/unset the Ramping Version of a Worker Deployment and its ramp percentage.
+// To unset, pass zero `percentage`.
+// To ramp to unversioned workers (from Deployment's Current Version), pass `version=""` with
+// non-zero `percentage`.
+message SetWorkerDeploymentRampingVersionRequest {
+    string namespace = 1;
+    string deployment_name = 2;
+
+    // The Version to be set as the Ramping Version of the Deployment. Optional when `percentage` is
+    // zero (unset case), but if given, it must match the current Ramping Version to be unset.
+    // Can be an empty string and paired with a non-zero `percentage`, in which case it will set the ramp
+    // percentage without a Ramping Version which means unversioned workers are being ramped.
+    // (Useful for migrating to unversioned workers from Deployment's Current Version.)
+    google.protobuf.StringValue version = 3;
+    // Valid range: [0,100]. Zero value will unset the Ramping Version.
+    float percentage = 6;
+
+    // Optional. The identity of the client who initiated this request.
+    string identity = 7;
+}
+
+message SetWorkerDeploymentRampingVersionResponse {
+    // The ramping version before executing this operation.
+    string previous_version = 1;
+    // The ramping version percentage before executing this operation.
+    float previous_percentage = 2;
 }
 
 // Returns the Current Deployment of a deployment series.

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -851,8 +851,9 @@ service WorkflowService {
         };
     }
 
-    // Sets a deployment version as the current version for its deployment.
-    rpc SetCurrentDeploymentVersion (SetCurrentDeploymentVersionRequest) returns (SetCurrentDeploymentVersionResponse) {
+    // Set/unset the Current Version of a Worker Deployment. Automatically unsets the Ramping
+    // Version if it is the Version being set as Current.
+    rpc SetWorkerDeploymentCurrentVersion (SetWorkerDeploymentCurrentVersionRequest) returns (SetWorkerDeploymentCurrentVersionResponse) {
         option (google.api.http) = {
             post: "/namespaces/{namespace}/worker-deployment/{deployment_name}/set-current-version"
             body: "*"
@@ -868,6 +869,19 @@ service WorkflowService {
             get: "/namespaces/{namespace}/worker-deployments/{deployment_name}"
             additional_bindings {
                 get: "/api/v1/namespaces/{namespace}/worker-deployments/{deployment_name}"
+            }
+        };
+    }
+
+    // Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for
+    // gradual ramp to unversioned workers too.
+    rpc SetWorkerDeploymentRampingVersion (SetWorkerDeploymentRampingVersionRequest) returns (SetWorkerDeploymentRampingVersionResponse) {
+        option (google.api.http) = {
+            post: "/namespaces/{namespace}/worker-deployment/{deployment_name}/set-ramping-version"
+            body: "*"
+            additional_bindings {
+                post: "/api/v1/namespaces/{namespace}/worker-deployment/{deployment_name}/set-ramping-version"
+                body: "*"
             }
         };
     }

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -855,10 +855,10 @@ service WorkflowService {
     // Version if it is the Version being set as Current.
     rpc SetWorkerDeploymentCurrentVersion (SetWorkerDeploymentCurrentVersionRequest) returns (SetWorkerDeploymentCurrentVersionResponse) {
         option (google.api.http) = {
-            post: "/namespaces/{namespace}/worker-deployment/{deployment_name}/set-current-version"
+            post: "/namespaces/{namespace}/worker-deployments/{deployment_name}/set-current-version"
             body: "*"
             additional_bindings {
-                post: "/api/v1/namespaces/{namespace}/worker-deployment/{deployment_name}/set-current-version"
+                post: "/api/v1/namespaces/{namespace}/worker-deployments/{deployment_name}/set-current-version"
                 body: "*"
             }
         };
@@ -877,10 +877,10 @@ service WorkflowService {
     // gradual ramp to unversioned workers too.
     rpc SetWorkerDeploymentRampingVersion (SetWorkerDeploymentRampingVersionRequest) returns (SetWorkerDeploymentRampingVersionResponse) {
         option (google.api.http) = {
-            post: "/namespaces/{namespace}/worker-deployment/{deployment_name}/set-ramping-version"
+            post: "/namespaces/{namespace}/worker-deployments/{deployment_name}/set-ramping-version"
             body: "*"
             additional_bindings {
-                post: "/api/v1/namespaces/{namespace}/worker-deployment/{deployment_name}/set-ramping-version"
+                post: "/api/v1/namespaces/{namespace}/worker-deployments/{deployment_name}/set-ramping-version"
                 body: "*"
             }
         };


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
- Title

<!-- Tell your future self why have you made these changes -->
**Why?**
- Versioning-3.1

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
- soon to come (developing `SetWorkerDeploymentCurrentVersion` and Ramping functionality :) )
