### PR TITLE
some changes to ManageActivities API

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -5983,25 +5983,17 @@
     "WorkflowServiceManageActivityBody": {
       "type": "object",
       "properties": {
-        "workflowId": {
-          "type": "string",
-          "description": "ID of the workflow which scheduled this activity."
+        "workflowExecution": {
+          "$ref": "#/definitions/v1WorkflowExecution",
+          "title": "Execution info of the requesting workflow"
         },
-        "runId": {
+        "id": {
           "type": "string",
-          "description": "Run ID of the workflow which scheduled this activity.\nIf empty - latest workflow is used."
+          "description": "Activity ID of the activity to manage."
         },
-        "requestId": {
-          "type": "string",
-          "description": "Used to de-dupe requests."
-        },
-        "activityId": {
-          "type": "string",
-          "description": "ID of the activity we're pausing."
-        },
-        "activityType": {
-          "type": "string",
-          "description": "Type of the activity."
+        "type": {
+          "$ref": "#/definitions/v1ActivityType",
+          "description": "Activity type of the activities to manage."
         },
         "operations": {
           "type": "array",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -7135,23 +7135,17 @@ components:
         namespace:
           type: string
           description: Namespace of the workflow which scheduled this activity.
-        workflowId:
+        workflowExecution:
+          allOf:
+            - $ref: '#/components/schemas/WorkflowExecution'
+          description: Execution info of the requesting workflow
+        id:
           type: string
-          description: ID of the workflow which scheduled this activity.
-        runId:
-          type: string
-          description: |-
-            Run ID of the workflow which scheduled this activity.
-             If empty - latest workflow is used.
-        requestId:
-          type: string
-          description: Used to de-dupe requests.
-        activityId:
-          type: string
-          description: ID of the activity we're pausing.
-        activityType:
-          type: string
-          description: Type of the activity.
+          description: Activity ID of the activity to manage.
+        type:
+          allOf:
+            - $ref: '#/components/schemas/ActivityType'
+          description: Activity type of the activities to manage.
         operations:
           type: array
           items:

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1953,20 +1953,16 @@ message GetDeploymentReachabilityResponse {
 message ManageActivityRequest {
     // Namespace of the workflow which scheduled this activity.
     string namespace = 1;
-    // ID of the workflow which scheduled this activity.
-    string workflow_id = 2;
-    // Run ID of the workflow which scheduled this activity.
-    // If empty - latest workflow is used.
-    string run_id = 3;
 
-    // Used to de-dupe requests.
-    string request_id = 4;
+    // Execution info of the requesting workflow
+    temporal.api.common.v1.WorkflowExecution workflow_execution = 2;
 
-    // ID of the activity we're pausing.
-    string activity_id = 5;
-
-    // Type of the activity.
-    string activity_type = 6;
+    oneof activity {
+        // Activity ID of the activity to manage.
+        string id = 4;
+        // Activity type of the activities to manage.
+        temporal.api.common.v1.ActivityType type = 5;
+    }
 
     // Pausing the activity. Either id or type should be provided
     // If type is provided, all activities of this type will be paused


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
1. Remove "workflow_id" and "run_id", add "workflow_execution"
2. Combine "activity_id" and "activity_type" into a single "oneof" message. They are mutually exclusive.

<!-- Tell your future self why have you made these changes -->
**Why?**
Feedback in previous PR.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
