### PR TITLE
remove ManageActivity, cleanup/extend existing activity API

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -5609,7 +5609,7 @@
       "properties": {
         "startWorkflow": {
           "$ref": "#/definitions/v1StartWorkflowExecutionRequest",
-          "title": "Additional restrictions:\n- setting `cron_schedule` is invalid\n- setting `request_eager_execution` is invalid\n- setting `workflow_start_delay` is invalid, but only if UpdateWorkflowExecutionRequest present"
+          "title": "Additional restrictions:\n- setting `cron_schedule` is invalid\n- setting `request_eager_execution` is invalid\n- setting `workflow_start_delay` is invalid"
         },
         "updateWorkflow": {
           "$ref": "#/definitions/v1UpdateWorkflowExecutionRequest",
@@ -5850,7 +5850,7 @@
             "type": "object",
             "$ref": "#/definitions/ExecuteMultiOperationRequestOperation"
           },
-          "description": "List of operations to execute within a single workflow.\n\nPreconditions:\n- The list of operations must not be empty.\n- The workflow ids must match across operations.\n- The only valid list of operations at this time is [StartWorkflow, UpdateWorkflow], in this order.\nOnly this order is supported:\n\nNote that additional operation-specific restrictions have to be considered."
+          "description": "List of operations to execute within a single workflow.\n\nPreconditions:\n- The list of operations must not be empty.\n- The workflow ids must match across operations.\n- The only valid list of operations at this time is [StartWorkflow, UpdateWorkflow], in this order.\n\nNote that additional operation-specific restrictions have to be considered."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -477,50 +477,10 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/activities/manage": {
-      "post": {
-        "summary": "ManageActivity apply reset/pause/unpause/update operations to an activity specified by its ID and/or type.\nEither activity id or activity type must be provided.\nSupported operations:\n1. Reset operation. Resets the activity to its initial state.\nResetting the activity. This operation will reset the number of attempts.\nIf activity is paused - activity will be unpaused bt default (see 'keep_paused' flag).\nIf activity is currently waiting for retry - it will be scheduled immediately.\nFlags:\n'reset_heartbeats' indicates that activity should reset heartbeat details.\n'keep_paused'- prevents activity from being unpaused.\n2. Pause operation. Pauses the activity. If activity was already paused it is no-op.\n3. Unpause operation. Unpauses the activity. If activity was not paused this will be a no-op.\nIf activity was waiting for retry - it will be scheduled immediately.\nUnpause operation supports the following flags:\n* jitter - if set, the activity will start at a random time within the specified jitter duration.\n4. Update operation - updates the activity options.\nfor details see UnpauseActivityById.\nReturns a `NotFound` error if there is no pending activity with the provided ID or type.",
-        "operationId": "ManageActivity2",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1ManageActivityResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "description": "Namespace of the workflow which scheduled this activity.",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceManageActivityBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
     "/api/v1/namespaces/{namespace}/activities/pause-by-id": {
       "post": {
         "summary": "PauseActivityById pauses the execution of an activity specified by its ID.\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
-        "description": "Pausing an activity means:\n- If the activity is currently waiting for a retry or is running and subsequently fails,\n  it will not be rescheduled until it is unpaused.\n- If the activity is already paused, calling this method will have no effect.\n- If the activity is running and finishes successfully, the activity will be completed.\n- If the activity is running and finishes with failure:\n  * if there is no retry left - the activity will be completed.\n  * if there are more retries left - the activity will be paused.\nFor long-running activities:\n- activities in paused state will send a cancellation with \"activity_paused\" set to 'true' in response to 'RecordActivityTaskHeartbeat'.\n- The activity should respond to the cancellation accordingly.",
+        "description": "Pausing an activity means:\n- If the activity is currently waiting for a retry or is running and subsequently fails,\n  it will not be rescheduled until it is unpause.\n- If the activity is already paused, calling this method will have no effect.\n- If the activity is running and finishes successfully, the activity will be completed.\n- If the activity is running and finishes with failure:\n  * if there is no retry left - the activity will be completed.\n  * if there are more retries left - the activity will be paused.\nFor long-running activities:\n- activities in paused state will send a cancellation with \"activity_paused\" set to 'true' in response to 'RecordActivityTaskHeartbeat'.\n- The activity should respond to the cancellation accordingly.",
         "operationId": "PauseActivityById2",
         "responses": {
           "200": {
@@ -560,7 +520,8 @@
     },
     "/api/v1/namespaces/{namespace}/activities/reset-by-id": {
       "post": {
-        "summary": "ResetActivityById unpauses the execution of an activity specified by its ID.\nReturns a `NotFound` error if there is no pending activity with the provided ID.\nResetting an activity means:\n* number of attempts will be reset to 0.\n* activity timeouts will be resetted.\nIf the activity currently running:\n*  if 'no_wait' flag is provided, a new instance of the activity will be scheduled immediately.\n*  if 'no_wait' flag is not provided, a new instance of the  activity will be scheduled after current instance completes if needed.\nIf 'reset_heartbeats' flag is set, the activity heartbeat timer and heartbeats will be reset.",
+        "summary": "ResetActivityById resets the execution of an activity specified by its ID.",
+        "description": "Resetting an activity means:\n* number of attempts will be reset to 0.\n* activity timeouts will be reset.\n* if the activity is waiting for retry, and it is not paused or 'keep_paused' is not provided:\n   it will be scheduled immediately (* see 'jitter' flag),\n\nFlags:\n\n'jitter': the activity will be scheduled at a random time within the jitter duration.\nIf the activity currently paused it will be unpause, unless 'keep_paused' flag is provided.\n'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.\n'keep_paused': if the activity is paused, it will remain paused.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
         "operationId": "ResetActivityById2",
         "responses": {
           "200": {
@@ -600,7 +561,8 @@
     },
     "/api/v1/namespaces/{namespace}/activities/unpause-by-id": {
       "post": {
-        "summary": "UnpauseActivityById unpauses the execution of an activity specified by its ID.\nReturns a `NotFound` error if there is no pending activity with the provided ID.\nThere are two 'modes' of unpausing an activity:\n'resume' - If the activity is paused, it will be resumed and scheduled for execution.\n   * If the activity is currently running Unpause with 'resume' has no effect.\n   * if 'no_wait' flag is set and the activity is waiting, the activity will be scheduled immediately.\n'reset' - If the activity is paused, it will be reset to its initial state and (depending on parameters) scheduled for execution.\n   * If the activity is currently running, Unpause with 'reset' will reset the number of attempts.\n   * if 'no_wait' flag is set, the activity will be scheduled immediately.\n   * if 'reset_heartbeats' flag is set, the activity heartbeat timer and heartbeats will be reset.\nIf the activity is in waiting for retry and past it retry timeout, it will be scheduled immediately.\nOnce the activity is unpaused, all timeout timers will be regenerated.",
+        "summary": "UnpauseActivityById unpauses the execution of an activity specified by its ID.",
+        "description": "If activity is not paused, this call will have no effect.\nIf the activity is waiting for retry, it will be scheduled immediately (* see 'jitter' flag).\nOnce the activity is unpause, all timeout timers will be regenerated.\n\nFlags:\n'jitter': the activity will be scheduled at a random time within the jitter duration.\n'reset_attempts': the number of attempts will be reset.\n'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
         "operationId": "UnpauseActivityById2",
         "responses": {
           "200": {
@@ -3517,50 +3479,10 @@
         ]
       }
     },
-    "/namespaces/{namespace}/activities/manage": {
-      "post": {
-        "summary": "ManageActivity apply reset/pause/unpause/update operations to an activity specified by its ID and/or type.\nEither activity id or activity type must be provided.\nSupported operations:\n1. Reset operation. Resets the activity to its initial state.\nResetting the activity. This operation will reset the number of attempts.\nIf activity is paused - activity will be unpaused bt default (see 'keep_paused' flag).\nIf activity is currently waiting for retry - it will be scheduled immediately.\nFlags:\n'reset_heartbeats' indicates that activity should reset heartbeat details.\n'keep_paused'- prevents activity from being unpaused.\n2. Pause operation. Pauses the activity. If activity was already paused it is no-op.\n3. Unpause operation. Unpauses the activity. If activity was not paused this will be a no-op.\nIf activity was waiting for retry - it will be scheduled immediately.\nUnpause operation supports the following flags:\n* jitter - if set, the activity will start at a random time within the specified jitter duration.\n4. Update operation - updates the activity options.\nfor details see UnpauseActivityById.\nReturns a `NotFound` error if there is no pending activity with the provided ID or type.",
-        "operationId": "ManageActivity",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1ManageActivityResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "description": "Namespace of the workflow which scheduled this activity.",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceManageActivityBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
     "/namespaces/{namespace}/activities/pause-by-id": {
       "post": {
         "summary": "PauseActivityById pauses the execution of an activity specified by its ID.\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
-        "description": "Pausing an activity means:\n- If the activity is currently waiting for a retry or is running and subsequently fails,\n  it will not be rescheduled until it is unpaused.\n- If the activity is already paused, calling this method will have no effect.\n- If the activity is running and finishes successfully, the activity will be completed.\n- If the activity is running and finishes with failure:\n  * if there is no retry left - the activity will be completed.\n  * if there are more retries left - the activity will be paused.\nFor long-running activities:\n- activities in paused state will send a cancellation with \"activity_paused\" set to 'true' in response to 'RecordActivityTaskHeartbeat'.\n- The activity should respond to the cancellation accordingly.",
+        "description": "Pausing an activity means:\n- If the activity is currently waiting for a retry or is running and subsequently fails,\n  it will not be rescheduled until it is unpause.\n- If the activity is already paused, calling this method will have no effect.\n- If the activity is running and finishes successfully, the activity will be completed.\n- If the activity is running and finishes with failure:\n  * if there is no retry left - the activity will be completed.\n  * if there are more retries left - the activity will be paused.\nFor long-running activities:\n- activities in paused state will send a cancellation with \"activity_paused\" set to 'true' in response to 'RecordActivityTaskHeartbeat'.\n- The activity should respond to the cancellation accordingly.",
         "operationId": "PauseActivityById",
         "responses": {
           "200": {
@@ -3600,7 +3522,8 @@
     },
     "/namespaces/{namespace}/activities/reset-by-id": {
       "post": {
-        "summary": "ResetActivityById unpauses the execution of an activity specified by its ID.\nReturns a `NotFound` error if there is no pending activity with the provided ID.\nResetting an activity means:\n* number of attempts will be reset to 0.\n* activity timeouts will be resetted.\nIf the activity currently running:\n*  if 'no_wait' flag is provided, a new instance of the activity will be scheduled immediately.\n*  if 'no_wait' flag is not provided, a new instance of the  activity will be scheduled after current instance completes if needed.\nIf 'reset_heartbeats' flag is set, the activity heartbeat timer and heartbeats will be reset.",
+        "summary": "ResetActivityById resets the execution of an activity specified by its ID.",
+        "description": "Resetting an activity means:\n* number of attempts will be reset to 0.\n* activity timeouts will be reset.\n* if the activity is waiting for retry, and it is not paused or 'keep_paused' is not provided:\n   it will be scheduled immediately (* see 'jitter' flag),\n\nFlags:\n\n'jitter': the activity will be scheduled at a random time within the jitter duration.\nIf the activity currently paused it will be unpause, unless 'keep_paused' flag is provided.\n'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.\n'keep_paused': if the activity is paused, it will remain paused.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
         "operationId": "ResetActivityById",
         "responses": {
           "200": {
@@ -3640,7 +3563,8 @@
     },
     "/namespaces/{namespace}/activities/unpause-by-id": {
       "post": {
-        "summary": "UnpauseActivityById unpauses the execution of an activity specified by its ID.\nReturns a `NotFound` error if there is no pending activity with the provided ID.\nThere are two 'modes' of unpausing an activity:\n'resume' - If the activity is paused, it will be resumed and scheduled for execution.\n   * If the activity is currently running Unpause with 'resume' has no effect.\n   * if 'no_wait' flag is set and the activity is waiting, the activity will be scheduled immediately.\n'reset' - If the activity is paused, it will be reset to its initial state and (depending on parameters) scheduled for execution.\n   * If the activity is currently running, Unpause with 'reset' will reset the number of attempts.\n   * if 'no_wait' flag is set, the activity will be scheduled immediately.\n   * if 'reset_heartbeats' flag is set, the activity heartbeat timer and heartbeats will be reset.\nIf the activity is in waiting for retry and past it retry timeout, it will be scheduled immediately.\nOnce the activity is unpaused, all timeout timers will be regenerated.",
+        "summary": "UnpauseActivityById unpauses the execution of an activity specified by its ID.",
+        "description": "If activity is not paused, this call will have no effect.\nIf the activity is waiting for retry, it will be scheduled immediately (* see 'jitter' flag).\nOnce the activity is unpause, all timeout timers will be regenerated.\n\nFlags:\n'jitter': the activity will be scheduled at a random time within the jitter duration.\n'reset_attempts': the number of attempts will be reset.\n'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
         "operationId": "UnpauseActivityById",
         "responses": {
           "200": {
@@ -5680,6 +5604,19 @@
       },
       "description": "Target a worker polling on a Nexus task queue in a specific namespace."
     },
+    "ExecuteMultiOperationRequestOperation": {
+      "type": "object",
+      "properties": {
+        "startWorkflow": {
+          "$ref": "#/definitions/v1StartWorkflowExecutionRequest",
+          "title": "Additional restrictions:\n- setting `cron_schedule` is invalid\n- setting `request_eager_execution` is invalid\n- setting `workflow_start_delay` is invalid, but only if UpdateWorkflowExecutionRequest present"
+        },
+        "updateWorkflow": {
+          "$ref": "#/definitions/v1UpdateWorkflowExecutionRequest",
+          "title": "Additional restrictions:\n- setting `first_execution_run_id` is invalid\n- setting `workflow_execution.run_id` is invalid"
+        }
+      }
+    },
     "LinkBatchJob": {
       "type": "object",
       "properties": {
@@ -5703,47 +5640,6 @@
         },
         "eventRef": {
           "$ref": "#/definitions/WorkflowEventEventReference"
-        }
-      }
-    },
-    "ManageActivityRequestPauseActivityRequest": {
-      "type": "object",
-      "title": "Pausing the activity. Either id or type should be provided\nIf type is provided, all activities of this type will be paused"
-    },
-    "ManageActivityRequestResetActivityRequest": {
-      "type": "object",
-      "properties": {
-        "keepPaused": {
-          "type": "boolean",
-          "description": "If this flag is provided and activity is currently paused - it will stay paused."
-        },
-        "resetHeartbeat": {
-          "type": "boolean",
-          "description": "Indicates that activity should reset heartbeat details.\nThis flag will be applied only to the new instance of the activity."
-        }
-      },
-      "description": "Resetting the activity. This operation will reset the number of attempts.\nIf activity is paused - activity will be unpaused.\nIf activity is currently waiting for retry - it will be scheduled immediately."
-    },
-    "ManageActivityRequestUnpauseActivityRequest": {
-      "type": "object",
-      "properties": {
-        "jitter": {
-          "type": "string",
-          "description": "If set, the activity will start at a random time within the specified jitter\nduration, introducing variability to the start time."
-        }
-      },
-      "description": "Unpausing the activity. If activity was not paused this will be a no-op.\nIf activity was waiting for retry - it will be scheduled immediately."
-    },
-    "ManageActivityRequestUpdateActivityOptionsRequest": {
-      "type": "object",
-      "properties": {
-        "activityOptions": {
-          "$ref": "#/definitions/v1ActivityOptions",
-          "title": "Activity options. Partial updates are accepted and controlled by update_mask"
-        },
-        "updateMask": {
-          "type": "string",
-          "title": "Controls which fields from `activity_options` will be applied"
         }
       }
     },
@@ -5791,28 +5687,6 @@
         }
       },
       "description": "An operation completed successfully."
-    },
-    "UnpauseActivityByIdRequestResetOperation": {
-      "type": "object",
-      "properties": {
-        "noWait": {
-          "type": "boolean",
-          "description": "Indicates that the activity should be scheduled immediately.\nNote that this may run simultaneously with any existing executions of the activity."
-        },
-        "resetHeartbeat": {
-          "type": "boolean",
-          "title": "If set, the Heartbeat Details will be cleared out to make the Activity start over from the beginning"
-        }
-      }
-    },
-    "UnpauseActivityByIdRequestResumeOperation": {
-      "type": "object",
-      "properties": {
-        "noWait": {
-          "type": "boolean",
-          "description": "Indicates that if the activity is waiting to retry, it will  be scheduled immediately."
-        }
-      }
     },
     "UpdateWorkerBuildIdCompatibilityRequestAddNewCompatibleVersion": {
       "type": "object",
@@ -5974,33 +5848,9 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/v1ExecuteMultiOperationRequestOperation"
+            "$ref": "#/definitions/ExecuteMultiOperationRequestOperation"
           },
-          "description": "List of operations to execute within a single workflow.\n\nPreconditions:\n- The list of operations must not be empty.\n- The workflow ids must match across operations.\n- The only valid list of operations at this time is [StartWorkflow, UpdateWorkflow], in this order.\n\nNote that additional operation-specific restrictions have to be considered."
-        }
-      }
-    },
-    "WorkflowServiceManageActivityBody": {
-      "type": "object",
-      "properties": {
-        "workflowExecution": {
-          "$ref": "#/definitions/v1WorkflowExecution",
-          "title": "Execution info of the requesting workflow"
-        },
-        "id": {
-          "type": "string",
-          "description": "Activity ID of the activity to manage."
-        },
-        "type": {
-          "$ref": "#/definitions/v1ActivityType",
-          "description": "Activity type of the activities to manage."
-        },
-        "operations": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/v1ManageActivityRequestOperation"
-          }
+          "description": "List of operations to execute within a single workflow.\n\nPreconditions:\n- The list of operations must not be empty.\n- The workflow ids must match across operations.\n- The only valid list of operations at this time is [StartWorkflow, UpdateWorkflow], in this order.\nOnly this order is supported:\n\nNote that additional operation-specific restrictions have to be considered."
         }
       }
     },
@@ -6038,10 +5888,6 @@
         "identity": {
           "type": "string",
           "description": "The identity of the client who initiated this request."
-        },
-        "requestId": {
-          "type": "string",
-          "description": "Used to de-dupe requests."
         }
       }
     },
@@ -6177,17 +6023,17 @@
           "type": "string",
           "description": "The identity of the client who initiated this request."
         },
-        "requestId": {
-          "type": "string",
-          "description": "Used to de-dupe requests."
-        },
-        "noWait": {
-          "type": "boolean",
-          "description": "Indicates that activity should be scheduled immediately.\nIf this flag doesn't set, and activity currently running - temporal will wait until activity is completed."
-        },
         "resetHeartbeat": {
           "type": "boolean",
           "description": "Indicates that activity should reset heartbeat details.\nThis flag will be applied only to the new instance of the activity."
+        },
+        "keepPaused": {
+          "type": "boolean",
+          "title": "if activity is paused, it will remain paused after reset"
+        },
+        "jitter": {
+          "type": "string",
+          "title": "If set, and activity is in backoff, the activity will start at a random time within the specified jitter duration.\n(unless it is paused and keep_paused is set)"
         }
       }
     },
@@ -6759,15 +6605,17 @@
           "type": "string",
           "description": "The identity of the client who initiated this request."
         },
-        "requestId": {
+        "resetAttempts": {
+          "type": "boolean",
+          "title": "unpause can also reset the number of attempts"
+        },
+        "resetHeartbeat": {
+          "type": "boolean",
+          "title": "unpause can also reset the heartbeat details"
+        },
+        "jitter": {
           "type": "string",
-          "description": "Used to de-dupe requests."
-        },
-        "resume": {
-          "$ref": "#/definitions/UnpauseActivityByIdRequestResumeOperation"
-        },
-        "reset": {
-          "$ref": "#/definitions/UnpauseActivityByIdRequestResetOperation"
+          "description": "If set, the activity will start at a random time within the specified jitter duration."
         }
       }
     },
@@ -8777,19 +8625,6 @@
       "description": "- EVENT_TYPE_UNSPECIFIED: Place holder and should never appear in a Workflow execution history\n - EVENT_TYPE_WORKFLOW_EXECUTION_STARTED: Workflow execution has been triggered/started\nIt contains Workflow execution inputs, as well as Workflow timeout configurations\n - EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED: Workflow execution has successfully completed and contains Workflow execution results\n - EVENT_TYPE_WORKFLOW_EXECUTION_FAILED: Workflow execution has unsuccessfully completed and contains the Workflow execution error\n - EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT: Workflow execution has timed out by the Temporal Server\nUsually due to the Workflow having not been completed within timeout settings\n - EVENT_TYPE_WORKFLOW_TASK_SCHEDULED: Workflow Task has been scheduled and the SDK client should now be able to process any new history events\n - EVENT_TYPE_WORKFLOW_TASK_STARTED: Workflow Task has started and the SDK client has picked up the Workflow Task and is processing new history events\n - EVENT_TYPE_WORKFLOW_TASK_COMPLETED: Workflow Task has completed\nThe SDK client picked up the Workflow Task and processed new history events\nSDK client may or may not ask the Temporal Server to do additional work, such as:\nEVENT_TYPE_ACTIVITY_TASK_SCHEDULED\nEVENT_TYPE_TIMER_STARTED\nEVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES\nEVENT_TYPE_MARKER_RECORDED\nEVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED\nEVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED\nEVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED\nEVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED\nEVENT_TYPE_WORKFLOW_EXECUTION_FAILED\nEVENT_TYPE_WORKFLOW_EXECUTION_CANCELED\nEVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW\n - EVENT_TYPE_WORKFLOW_TASK_TIMED_OUT: Workflow Task encountered a timeout\nEither an SDK client with a local cache was not available at the time, or it took too long for the SDK client to process the task\n - EVENT_TYPE_WORKFLOW_TASK_FAILED: Workflow Task encountered a failure\nUsually this means that the Workflow was non-deterministic\nHowever, the Workflow reset functionality also uses this event\n - EVENT_TYPE_ACTIVITY_TASK_SCHEDULED: Activity Task was scheduled\nThe SDK client should pick up this activity task and execute\nThis event type contains activity inputs, as well as activity timeout configurations\n - EVENT_TYPE_ACTIVITY_TASK_STARTED: Activity Task has started executing\nThe SDK client has picked up the Activity Task and is processing the Activity invocation\n - EVENT_TYPE_ACTIVITY_TASK_COMPLETED: Activity Task has finished successfully\nThe SDK client has picked up and successfully completed the Activity Task\nThis event type contains Activity execution results\n - EVENT_TYPE_ACTIVITY_TASK_FAILED: Activity Task has finished unsuccessfully\nThe SDK picked up the Activity Task but unsuccessfully completed it\nThis event type contains Activity execution errors\n - EVENT_TYPE_ACTIVITY_TASK_TIMED_OUT: Activity has timed out according to the Temporal Server\nActivity did not complete within the timeout settings\n - EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED: A request to cancel the Activity has occurred\nThe SDK client will be able to confirm cancellation of an Activity during an Activity heartbeat\n - EVENT_TYPE_ACTIVITY_TASK_CANCELED: Activity has been cancelled\n - EVENT_TYPE_TIMER_STARTED: A timer has started\n - EVENT_TYPE_TIMER_FIRED: A timer has fired\n - EVENT_TYPE_TIMER_CANCELED: A time has been cancelled\n - EVENT_TYPE_WORKFLOW_EXECUTION_CANCEL_REQUESTED: A request has been made to cancel the Workflow execution\n - EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED: SDK client has confirmed the cancellation request and the Workflow execution has been cancelled\n - EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED: Workflow has requested that the Temporal Server try to cancel another Workflow\n - EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_FAILED: Temporal Server could not cancel the targeted Workflow\nThis is usually because the target Workflow could not be found\n - EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_CANCEL_REQUESTED: Temporal Server has successfully requested the cancellation of the target Workflow\n - EVENT_TYPE_MARKER_RECORDED: A marker has been recorded.\nThis event type is transparent to the Temporal Server\nThe Server will only store it and will not try to understand it.\n - EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED: Workflow has received a Signal event\nThe event type contains the Signal name, as well as a Signal payload\n - EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED: Workflow execution has been forcefully terminated\nThis is usually because the terminate Workflow API was called\n - EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW: Workflow has successfully completed and a new Workflow has been started within the same transaction\nContains last Workflow execution results as well as new Workflow execution inputs\n - EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED: Temporal Server will try to start a child Workflow\n - EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_FAILED: Child Workflow execution cannot be started/triggered\nUsually due to a child Workflow ID collision\n - EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED: Child Workflow execution has successfully started/triggered\n - EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_COMPLETED: Child Workflow execution has successfully completed\n - EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_FAILED: Child Workflow execution has unsuccessfully completed\n - EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_CANCELED: Child Workflow execution has been cancelled\n - EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_TIMED_OUT: Child Workflow execution has timed out by the Temporal Server\n - EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_TERMINATED: Child Workflow execution has been terminated\n - EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED: Temporal Server will try to Signal the targeted Workflow\nContains the Signal name, as well as a Signal payload\n - EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED: Temporal Server cannot Signal the targeted Workflow\nUsually because the Workflow could not be found\n - EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_SIGNALED: Temporal Server has successfully Signaled the targeted Workflow\n - EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES: Workflow search attributes should be updated and synchronized with the visibility store\n - EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ADMITTED: An update was admitted. Note that not all admitted updates result in this\nevent. See UpdateAdmittedEventOrigin for situations in which this event\nis created.\n - EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED: An update was accepted (i.e. passed validation, perhaps because no validator was defined)\n - EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_REJECTED: This event is never written to history.\n - EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_COMPLETED: An update completed\n - EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED_EXTERNALLY: Some property or properties of the workflow as a whole have changed by non-workflow code.\nThe distinction of external vs. command-based modification is important so the SDK can\nmaintain determinism when using the command-based approach.\n - EVENT_TYPE_ACTIVITY_PROPERTIES_MODIFIED_EXTERNALLY: Some property or properties of an already-scheduled activity have changed by non-workflow code.\nThe distinction of external vs. command-based modification is important so the SDK can\nmaintain determinism when using the command-based approach.\n - EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED: Workflow properties modified by user workflow code\n - EVENT_TYPE_NEXUS_OPERATION_SCHEDULED: A Nexus operation was scheduled using a ScheduleNexusOperation command.\n - EVENT_TYPE_NEXUS_OPERATION_STARTED: An asynchronous Nexus operation was started by a Nexus handler.\n - EVENT_TYPE_NEXUS_OPERATION_COMPLETED: A Nexus operation completed successfully.\n - EVENT_TYPE_NEXUS_OPERATION_FAILED: A Nexus operation failed.\n - EVENT_TYPE_NEXUS_OPERATION_CANCELED: A Nexus operation completed as canceled.\n - EVENT_TYPE_NEXUS_OPERATION_TIMED_OUT: A Nexus operation timed out.\n - EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED: A Nexus operation was requested to be canceled using a RequestCancelNexusOperation command.\n - EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED: Workflow execution options updated by user.",
       "title": "Whenever this list of events is changed do change the function shouldBufferEvent in mutableStateBuilder.go to make sure to do the correct event ordering"
     },
-    "v1ExecuteMultiOperationRequestOperation": {
-      "type": "object",
-      "properties": {
-        "startWorkflow": {
-          "$ref": "#/definitions/v1StartWorkflowExecutionRequest",
-          "title": "Additional restrictions:\n- setting `cron_schedule` is invalid\n- setting `request_eager_execution` is invalid\n- setting `workflow_start_delay` is invalid"
-        },
-        "updateWorkflow": {
-          "$ref": "#/definitions/v1UpdateWorkflowExecutionRequest",
-          "title": "Additional restrictions:\n- setting `first_execution_run_id` is invalid\n- setting `workflow_execution.run_id` is invalid"
-        }
-      }
-    },
     "v1ExecuteMultiOperationResponse": {
       "type": "object",
       "properties": {
@@ -9625,26 +9460,6 @@
           "format": "byte"
         }
       }
-    },
-    "v1ManageActivityRequestOperation": {
-      "type": "object",
-      "properties": {
-        "pause": {
-          "$ref": "#/definitions/ManageActivityRequestPauseActivityRequest"
-        },
-        "unpause": {
-          "$ref": "#/definitions/ManageActivityRequestUnpauseActivityRequest"
-        },
-        "reset": {
-          "$ref": "#/definitions/ManageActivityRequestResetActivityRequest"
-        },
-        "updateOptions": {
-          "$ref": "#/definitions/ManageActivityRequestUpdateActivityOptionsRequest"
-        }
-      }
-    },
-    "v1ManageActivityResponse": {
-      "type": "object"
     },
     "v1MarkerRecordedEventAttributes": {
       "type": "object",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -416,58 +416,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/activities/manage:
-    post:
-      tags:
-        - WorkflowService
-      description: |-
-        ManageActivity apply reset/pause/unpause/update operations to an activity specified by its ID and/or type.
-         Either activity id or activity type must be provided.
-         Supported operations:
-         1. Reset operation. Resets the activity to its initial state.
-         Resetting the activity. This operation will reset the number of attempts.
-         If activity is paused - activity will be unpaused bt default (see 'keep_paused' flag).
-         If activity is currently waiting for retry - it will be scheduled immediately.
-         Flags:
-         'reset_heartbeats' indicates that activity should reset heartbeat details.
-         'keep_paused'- prevents activity from being unpaused.
-         2. Pause operation. Pauses the activity. If activity was already paused it is no-op.
-         3. Unpause operation. Unpauses the activity. If activity was not paused this will be a no-op.
-         If activity was waiting for retry - it will be scheduled immediately.
-         Unpause operation supports the following flags:
-         * jitter - if set, the activity will start at a random time within the specified jitter duration.
-         4. Update operation - updates the activity options.
-         for details see UnpauseActivityById.
-         Returns a `NotFound` error if there is no pending activity with the provided ID or type.
-         (-- api-linter: core::0136::prepositions=disabled
-             aip.dev/not-precedent: "By" is used to indicate request type. --)
-      operationId: ManageActivity
-      parameters:
-        - name: namespace
-          in: path
-          description: Namespace of the workflow which scheduled this activity.
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ManageActivityRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ManageActivityResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
   /api/v1/namespaces/{namespace}/activities/pause-by-id:
     post:
       tags:
@@ -478,7 +426,7 @@ paths:
 
          Pausing an activity means:
          - If the activity is currently waiting for a retry or is running and subsequently fails,
-           it will not be rescheduled until it is unpaused.
+           it will not be rescheduled until it is unpause.
          - If the activity is already paused, calling this method will have no effect.
          - If the activity is running and finishes successfully, the activity will be completed.
          - If the activity is running and finishes with failure:
@@ -521,15 +469,22 @@ paths:
       tags:
         - WorkflowService
       description: |-
-        ResetActivityById unpauses the execution of an activity specified by its ID.
-         Returns a `NotFound` error if there is no pending activity with the provided ID.
+        ResetActivityById resets the execution of an activity specified by its ID.
+
          Resetting an activity means:
          * number of attempts will be reset to 0.
-         * activity timeouts will be resetted.
-         If the activity currently running:
-         *  if 'no_wait' flag is provided, a new instance of the activity will be scheduled immediately.
-         *  if 'no_wait' flag is not provided, a new instance of the  activity will be scheduled after current instance completes if needed.
-         If 'reset_heartbeats' flag is set, the activity heartbeat timer and heartbeats will be reset.
+         * activity timeouts will be reset.
+         * if the activity is waiting for retry, and it is not paused or 'keep_paused' is not provided:
+            it will be scheduled immediately (* see 'jitter' flag),
+
+         Flags:
+
+         'jitter': the activity will be scheduled at a random time within the jitter duration.
+         If the activity currently paused it will be unpause, unless 'keep_paused' flag is provided.
+         'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.
+         'keep_paused': if the activity is paused, it will remain paused.
+
+         Returns a `NotFound` error if there is no pending activity with the provided ID.
          (-- api-linter: core::0136::prepositions=disabled
              aip.dev/not-precedent: "By" is used to indicate request type. --)
       operationId: ResetActivityById
@@ -565,17 +520,17 @@ paths:
         - WorkflowService
       description: |-
         UnpauseActivityById unpauses the execution of an activity specified by its ID.
+
+         If activity is not paused, this call will have no effect.
+         If the activity is waiting for retry, it will be scheduled immediately (* see 'jitter' flag).
+         Once the activity is unpause, all timeout timers will be regenerated.
+
+         Flags:
+         'jitter': the activity will be scheduled at a random time within the jitter duration.
+         'reset_attempts': the number of attempts will be reset.
+         'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.
+
          Returns a `NotFound` error if there is no pending activity with the provided ID.
-         There are two 'modes' of unpausing an activity:
-         'resume' - If the activity is paused, it will be resumed and scheduled for execution.
-            * If the activity is currently running Unpause with 'resume' has no effect.
-            * if 'no_wait' flag is set and the activity is waiting, the activity will be scheduled immediately.
-         'reset' - If the activity is paused, it will be reset to its initial state and (depending on parameters) scheduled for execution.
-            * If the activity is currently running, Unpause with 'reset' will reset the number of attempts.
-            * if 'no_wait' flag is set, the activity will be scheduled immediately.
-            * if 'reset_heartbeats' flag is set, the activity heartbeat timer and heartbeats will be reset.
-         If the activity is in waiting for retry and past it retry timeout, it will be scheduled immediately.
-         Once the activity is unpaused, all timeout timers will be regenerated.
          (-- api-linter: core::0136::prepositions=disabled
              aip.dev/not-precedent: "By" is used to indicate request type. --)
       operationId: UnpauseActivityById
@@ -3131,58 +3086,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/activities/manage:
-    post:
-      tags:
-        - WorkflowService
-      description: |-
-        ManageActivity apply reset/pause/unpause/update operations to an activity specified by its ID and/or type.
-         Either activity id or activity type must be provided.
-         Supported operations:
-         1. Reset operation. Resets the activity to its initial state.
-         Resetting the activity. This operation will reset the number of attempts.
-         If activity is paused - activity will be unpaused bt default (see 'keep_paused' flag).
-         If activity is currently waiting for retry - it will be scheduled immediately.
-         Flags:
-         'reset_heartbeats' indicates that activity should reset heartbeat details.
-         'keep_paused'- prevents activity from being unpaused.
-         2. Pause operation. Pauses the activity. If activity was already paused it is no-op.
-         3. Unpause operation. Unpauses the activity. If activity was not paused this will be a no-op.
-         If activity was waiting for retry - it will be scheduled immediately.
-         Unpause operation supports the following flags:
-         * jitter - if set, the activity will start at a random time within the specified jitter duration.
-         4. Update operation - updates the activity options.
-         for details see UnpauseActivityById.
-         Returns a `NotFound` error if there is no pending activity with the provided ID or type.
-         (-- api-linter: core::0136::prepositions=disabled
-             aip.dev/not-precedent: "By" is used to indicate request type. --)
-      operationId: ManageActivity
-      parameters:
-        - name: namespace
-          in: path
-          description: Namespace of the workflow which scheduled this activity.
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ManageActivityRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ManageActivityResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
   /namespaces/{namespace}/activities/pause-by-id:
     post:
       tags:
@@ -3193,7 +3096,7 @@ paths:
 
          Pausing an activity means:
          - If the activity is currently waiting for a retry or is running and subsequently fails,
-           it will not be rescheduled until it is unpaused.
+           it will not be rescheduled until it is unpause.
          - If the activity is already paused, calling this method will have no effect.
          - If the activity is running and finishes successfully, the activity will be completed.
          - If the activity is running and finishes with failure:
@@ -3236,15 +3139,22 @@ paths:
       tags:
         - WorkflowService
       description: |-
-        ResetActivityById unpauses the execution of an activity specified by its ID.
-         Returns a `NotFound` error if there is no pending activity with the provided ID.
+        ResetActivityById resets the execution of an activity specified by its ID.
+
          Resetting an activity means:
          * number of attempts will be reset to 0.
-         * activity timeouts will be resetted.
-         If the activity currently running:
-         *  if 'no_wait' flag is provided, a new instance of the activity will be scheduled immediately.
-         *  if 'no_wait' flag is not provided, a new instance of the  activity will be scheduled after current instance completes if needed.
-         If 'reset_heartbeats' flag is set, the activity heartbeat timer and heartbeats will be reset.
+         * activity timeouts will be reset.
+         * if the activity is waiting for retry, and it is not paused or 'keep_paused' is not provided:
+            it will be scheduled immediately (* see 'jitter' flag),
+
+         Flags:
+
+         'jitter': the activity will be scheduled at a random time within the jitter duration.
+         If the activity currently paused it will be unpause, unless 'keep_paused' flag is provided.
+         'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.
+         'keep_paused': if the activity is paused, it will remain paused.
+
+         Returns a `NotFound` error if there is no pending activity with the provided ID.
          (-- api-linter: core::0136::prepositions=disabled
              aip.dev/not-precedent: "By" is used to indicate request type. --)
       operationId: ResetActivityById
@@ -3280,17 +3190,17 @@ paths:
         - WorkflowService
       description: |-
         UnpauseActivityById unpauses the execution of an activity specified by its ID.
+
+         If activity is not paused, this call will have no effect.
+         If the activity is waiting for retry, it will be scheduled immediately (* see 'jitter' flag).
+         Once the activity is unpause, all timeout timers will be regenerated.
+
+         Flags:
+         'jitter': the activity will be scheduled at a random time within the jitter duration.
+         'reset_attempts': the number of attempts will be reset.
+         'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.
+
          Returns a `NotFound` error if there is no pending activity with the provided ID.
-         There are two 'modes' of unpausing an activity:
-         'resume' - If the activity is paused, it will be resumed and scheduled for execution.
-            * If the activity is currently running Unpause with 'resume' has no effect.
-            * if 'no_wait' flag is set and the activity is waiting, the activity will be scheduled immediately.
-         'reset' - If the activity is paused, it will be reset to its initial state and (depending on parameters) scheduled for execution.
-            * If the activity is currently running, Unpause with 'reset' will reset the number of attempts.
-            * if 'no_wait' flag is set, the activity will be scheduled immediately.
-            * if 'reset_heartbeats' flag is set, the activity heartbeat timer and heartbeats will be reset.
-         If the activity is in waiting for retry and past it retry timeout, it will be scheduled immediately.
-         Once the activity is unpaused, all timeout timers will be regenerated.
          (-- api-linter: core::0136::prepositions=disabled
              aip.dev/not-precedent: "By" is used to indicate request type. --)
       operationId: UnpauseActivityById
@@ -6384,6 +6294,7 @@ components:
              - The list of operations must not be empty.
              - The workflow ids must match across operations.
              - The only valid list of operations at this time is [StartWorkflow, UpdateWorkflow], in this order.
+             Only this order is supported:
 
              Note that additional operation-specific restrictions have to be considered.
     ExecuteMultiOperationRequest_Operation:
@@ -6396,7 +6307,7 @@ components:
             Additional restrictions:
              - setting `cron_schedule` is invalid
              - setting `request_eager_execution` is invalid
-             - setting `workflow_start_delay` is invalid
+             - setting `workflow_start_delay` is invalid, but only if UpdateWorkflowExecutionRequest present
         updateWorkflow:
           allOf:
             - $ref: '#/components/schemas/UpdateWorkflowExecutionRequest'
@@ -7129,85 +7040,6 @@ components:
         nextPageToken:
           type: string
           format: bytes
-    ManageActivityRequest:
-      type: object
-      properties:
-        namespace:
-          type: string
-          description: Namespace of the workflow which scheduled this activity.
-        workflowExecution:
-          allOf:
-            - $ref: '#/components/schemas/WorkflowExecution'
-          description: Execution info of the requesting workflow
-        id:
-          type: string
-          description: Activity ID of the activity to manage.
-        type:
-          allOf:
-            - $ref: '#/components/schemas/ActivityType'
-          description: Activity type of the activities to manage.
-        operations:
-          type: array
-          items:
-            $ref: '#/components/schemas/ManageActivityRequest_Operation'
-    ManageActivityRequest_Operation:
-      type: object
-      properties:
-        pause:
-          $ref: '#/components/schemas/ManageActivityRequest_PauseActivityRequest'
-        unpause:
-          $ref: '#/components/schemas/ManageActivityRequest_UnpauseActivityRequest'
-        reset:
-          $ref: '#/components/schemas/ManageActivityRequest_ResetActivityRequest'
-        updateOptions:
-          $ref: '#/components/schemas/ManageActivityRequest_UpdateActivityOptionsRequest'
-    ManageActivityRequest_PauseActivityRequest:
-      type: object
-      properties: {}
-      description: |-
-        Pausing the activity. Either id or type should be provided
-         If type is provided, all activities of this type will be paused
-    ManageActivityRequest_ResetActivityRequest:
-      type: object
-      properties:
-        keepPaused:
-          type: boolean
-          description: If this flag is provided and activity is currently paused - it will stay paused.
-        resetHeartbeat:
-          type: boolean
-          description: |-
-            Indicates that activity should reset heartbeat details.
-             This flag will be applied only to the new instance of the activity.
-      description: |-
-        Resetting the activity. This operation will reset the number of attempts.
-         If activity is paused - activity will be unpaused.
-         If activity is currently waiting for retry - it will be scheduled immediately.
-    ManageActivityRequest_UnpauseActivityRequest:
-      type: object
-      properties:
-        jitter:
-          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
-          type: string
-          description: |-
-            If set, the activity will start at a random time within the specified jitter
-             duration, introducing variability to the start time.
-      description: |-
-        Unpausing the activity. If activity was not paused this will be a no-op.
-         If activity was waiting for retry - it will be scheduled immediately.
-    ManageActivityRequest_UpdateActivityOptionsRequest:
-      type: object
-      properties:
-        activityOptions:
-          allOf:
-            - $ref: '#/components/schemas/ActivityOptions'
-          description: Activity options. Partial updates are accepted and controlled by update_mask
-        updateMask:
-          type: string
-          description: Controls which fields from `activity_options` will be applied
-          format: field-mask
-    ManageActivityResponse:
-      type: object
-      properties: {}
     MarkerRecordedEventAttributes:
       type: object
       properties:
@@ -7696,9 +7528,6 @@ components:
         identity:
           type: string
           description: The identity of the client who initiated this request.
-        requestId:
-          type: string
-          description: Used to de-dupe requests.
     PauseActivityByIdResponse:
       type: object
       properties: {}
@@ -8316,19 +8145,20 @@ components:
         identity:
           type: string
           description: The identity of the client who initiated this request.
-        requestId:
-          type: string
-          description: Used to de-dupe requests.
-        noWait:
-          type: boolean
-          description: |-
-            Indicates that activity should be scheduled immediately.
-             If this flag doesn't set, and activity currently running - temporal will wait until activity is completed.
         resetHeartbeat:
           type: boolean
           description: |-
             Indicates that activity should reset heartbeat details.
              This flag will be applied only to the new instance of the activity.
+        keepPaused:
+          type: boolean
+          description: if activity is paused, it will remain paused after reset
+        jitter:
+          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+          type: string
+          description: |-
+            If set, and activity is in backoff, the activity will start at a random time within the specified jitter duration.
+             (unless it is paused and keep_paused is set)
     ResetActivityByIdResponse:
       type: object
       properties: {}
@@ -9993,30 +9823,16 @@ components:
         identity:
           type: string
           description: The identity of the client who initiated this request.
-        requestId:
-          type: string
-          description: Used to de-dupe requests.
-        resume:
-          $ref: '#/components/schemas/UnpauseActivityByIdRequest_ResumeOperation'
-        reset:
-          $ref: '#/components/schemas/UnpauseActivityByIdRequest_ResetOperation'
-    UnpauseActivityByIdRequest_ResetOperation:
-      type: object
-      properties:
-        noWait:
+        resetAttempts:
           type: boolean
-          description: |-
-            Indicates that the activity should be scheduled immediately.
-             Note that this may run simultaneously with any existing executions of the activity.
+          description: unpause can also reset the number of attempts
         resetHeartbeat:
           type: boolean
-          description: If set, the Heartbeat Details will be cleared out to make the Activity start over from the beginning
-    UnpauseActivityByIdRequest_ResumeOperation:
-      type: object
-      properties:
-        noWait:
-          type: boolean
-          description: Indicates that if the activity is waiting to retry, it will  be scheduled immediately.
+          description: unpause can also reset the heartbeat details
+        jitter:
+          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+          type: string
+          description: If set, the activity will start at a random time within the specified jitter duration.
     UnpauseActivityByIdResponse:
       type: object
       properties: {}

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -6294,7 +6294,6 @@ components:
              - The list of operations must not be empty.
              - The workflow ids must match across operations.
              - The only valid list of operations at this time is [StartWorkflow, UpdateWorkflow], in this order.
-             Only this order is supported:
 
              Note that additional operation-specific restrictions have to be considered.
     ExecuteMultiOperationRequest_Operation:
@@ -6307,7 +6306,7 @@ components:
             Additional restrictions:
              - setting `cron_schedule` is invalid
              - setting `request_eager_execution` is invalid
-             - setting `workflow_start_delay` is invalid, but only if UpdateWorkflowExecutionRequest present
+             - setting `workflow_start_delay` is invalid
         updateWorkflow:
           allOf:
             - $ref: '#/components/schemas/UpdateWorkflowExecutionRequest'

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1717,6 +1717,7 @@ message ExecuteMultiOperationRequest {
     // - The list of operations must not be empty.
     // - The workflow ids must match across operations.
     // - The only valid list of operations at this time is [StartWorkflow, UpdateWorkflow], in this order.
+    // Only this order is supported:
     //
     // Note that additional operation-specific restrictions have to be considered.
     repeated Operation operations = 2;
@@ -1726,7 +1727,7 @@ message ExecuteMultiOperationRequest {
             // Additional restrictions:
             // - setting `cron_schedule` is invalid
             // - setting `request_eager_execution` is invalid
-            // - setting `workflow_start_delay` is invalid
+            // - setting `workflow_start_delay` is invalid, but only if UpdateWorkflowExecutionRequest present
             StartWorkflowExecutionRequest start_workflow = 1;
 
             // Additional restrictions:
@@ -1791,27 +1792,14 @@ message PauseActivityByIdRequest {
     // The identity of the client who initiated this request.
     string identity = 5;
 
-    // Used to de-dupe requests.
-    string request_id = 6;
+    reserved 6;
+    reserved "request_id";
 }
 
 message PauseActivityByIdResponse {
 }
 
 message UnpauseActivityByIdRequest {
-    message ResumeOperation {
-        // Indicates that if the activity is waiting to retry, it will  be scheduled immediately.
-        bool no_wait = 1;
-    }
-
-    message ResetOperation {
-        // Indicates that the activity should be scheduled immediately.
-        // Note that this may run simultaneously with any existing executions of the activity.
-        bool no_wait = 1;
-        // If set, the Heartbeat Details will be cleared out to make the Activity start over from the beginning
-        bool reset_heartbeat = 2;
-    }
-
     // Namespace of the workflow which scheduled this activity.
     string namespace = 1;
     // ID of the workflow which scheduled this activity.
@@ -1825,14 +1813,21 @@ message UnpauseActivityByIdRequest {
     // The identity of the client who initiated this request.
     string identity = 5;
 
-    // Used to de-dupe requests.
-    string request_id = 6;
+    reserved 6;
+    reserved 7; // was resume/reset. Flatten this.
+    reserved 8; // was resume/reset. Flatten this.
+    reserved "request_id";
+    reserved "reset";
+    reserved "resume";
 
-    // There are two options to resume the activity - with 'resume' or with 'reset'.
-    oneof operation{
-        ResumeOperation resume = 7;
-        ResetOperation reset = 8;
-    }
+    // unpause can also reset the number of attempts
+    bool reset_attempts = 9;
+
+    // unpause can also reset the heartbeat details
+    bool reset_heartbeat = 10;
+
+    // If set, the activity will start at a random time within the specified jitter duration.
+    google.protobuf.Duration jitter = 11;
 }
 
 message UnpauseActivityByIdResponse {
@@ -1852,16 +1847,21 @@ message ResetActivityByIdRequest {
     // The identity of the client who initiated this request.
     string identity = 5;
 
-    // Used to de-dupe requests.
-    string request_id = 6;
-
-    // Indicates that activity should be scheduled immediately.
-    // If this flag doesn't set, and activity currently running - temporal will wait until activity is completed.
-    bool no_wait = 7;
+    reserved 6;
+    reserved 7;
+    reserved "request_id";
+    reserved "no_wait";
 
     // Indicates that activity should reset heartbeat details.
     // This flag will be applied only to the new instance of the activity.
     bool reset_heartbeat = 8;
+
+    // if activity is paused, it will remain paused after reset
+    bool keep_paused = 9;
+
+    // If set, and activity is in backoff, the activity will start at a random time within the specified jitter duration.
+    // (unless it is paused and keep_paused is set)
+    google.protobuf.Duration jitter = 11;
 }
 
 message ResetActivityByIdResponse {
@@ -1948,65 +1948,4 @@ message GetDeploymentReachabilityResponse {
     // Reachability level might come from server cache. This timestamp specifies when the value
     // was actually calculated.
     google.protobuf.Timestamp last_update_time = 3;
-}
-
-message ManageActivityRequest {
-    // Namespace of the workflow which scheduled this activity.
-    string namespace = 1;
-
-    // Execution info of the requesting workflow
-    temporal.api.common.v1.WorkflowExecution workflow_execution = 2;
-
-    oneof activity {
-        // Activity ID of the activity to manage.
-        string id = 4;
-        // Activity type of the activities to manage.
-        temporal.api.common.v1.ActivityType type = 5;
-    }
-
-    // Pausing the activity. Either id or type should be provided
-    // If type is provided, all activities of this type will be paused
-    message PauseActivityRequest {
-    }
-
-    // Unpausing the activity. If activity was not paused this will be a no-op.
-    // If activity was waiting for retry - it will be scheduled immediately.
-    message UnpauseActivityRequest {
-        // If set, the activity will start at a random time within the specified jitter
-        // duration, introducing variability to the start time.
-        google.protobuf.Duration jitter = 4;
-    }
-
-    // Resetting the activity. This operation will reset the number of attempts.
-    // If activity is paused - activity will be unpaused.
-    // If activity is currently waiting for retry - it will be scheduled immediately.
-    message ResetActivityRequest {
-        // If this flag is provided and activity is currently paused - it will stay paused.
-        bool keep_paused = 1;
-        // Indicates that activity should reset heartbeat details.
-        // This flag will be applied only to the new instance of the activity.
-        bool reset_heartbeat = 2;
-    }
-
-    message UpdateActivityOptionsRequest {
-        // Activity options. Partial updates are accepted and controlled by update_mask
-        temporal.api.activity.v1.ActivityOptions activity_options = 6;
-
-        // Controls which fields from `activity_options` will be applied
-        google.protobuf.FieldMask update_mask = 7;
-    }
-
-    message Operation {
-        oneof operation_type {
-            PauseActivityRequest pause = 9;
-            UnpauseActivityRequest unpause = 10;
-            ResetActivityRequest reset = 11;
-            UpdateActivityOptionsRequest update_options = 12;
-        }
-    }
-
-    repeated Operation operations = 8;
-}
-
-message ManageActivityResponse {
 }

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1717,7 +1717,6 @@ message ExecuteMultiOperationRequest {
     // - The list of operations must not be empty.
     // - The workflow ids must match across operations.
     // - The only valid list of operations at this time is [StartWorkflow, UpdateWorkflow], in this order.
-    // Only this order is supported:
     //
     // Note that additional operation-specific restrictions have to be considered.
     repeated Operation operations = 2;
@@ -1727,7 +1726,7 @@ message ExecuteMultiOperationRequest {
             // Additional restrictions:
             // - setting `cron_schedule` is invalid
             // - setting `request_eager_execution` is invalid
-            // - setting `workflow_start_delay` is invalid, but only if UpdateWorkflowExecutionRequest present
+            // - setting `workflow_start_delay` is invalid
             StartWorkflowExecutionRequest start_workflow = 1;
 
             // Additional restrictions:

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -951,7 +951,7 @@ service WorkflowService {
     //
     // Pausing an activity means:
     // - If the activity is currently waiting for a retry or is running and subsequently fails,
-    //   it will not be rescheduled until it is unpaused.
+    //   it will not be rescheduled until it is unpause.
     // - If the activity is already paused, calling this method will have no effect.
     // - If the activity is running and finishes successfully, the activity will be completed.
     // - If the activity is running and finishes with failure:
@@ -974,17 +974,17 @@ service WorkflowService {
     }
 
     // UnpauseActivityById unpauses the execution of an activity specified by its ID.
+    //
+    // If activity is not paused, this call will have no effect.
+    // If the activity is waiting for retry, it will be scheduled immediately (* see 'jitter' flag).
+    // Once the activity is unpause, all timeout timers will be regenerated.
+    //
+    // Flags:
+    // 'jitter': the activity will be scheduled at a random time within the jitter duration.
+    // 'reset_attempts': the number of attempts will be reset.
+    // 'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.
+    //
     // Returns a `NotFound` error if there is no pending activity with the provided ID.
-    // There are two 'modes' of unpausing an activity:
-    // 'resume' - If the activity is paused, it will be resumed and scheduled for execution.
-    //    * If the activity is currently running Unpause with 'resume' has no effect.
-    //    * if 'no_wait' flag is set and the activity is waiting, the activity will be scheduled immediately.
-    // 'reset' - If the activity is paused, it will be reset to its initial state and (depending on parameters) scheduled for execution.
-    //    * If the activity is currently running, Unpause with 'reset' will reset the number of attempts.
-    //    * if 'no_wait' flag is set, the activity will be scheduled immediately.
-    //    * if 'reset_heartbeats' flag is set, the activity heartbeat timer and heartbeats will be reset.
-    // If the activity is in waiting for retry and past it retry timeout, it will be scheduled immediately.
-    // Once the activity is unpaused, all timeout timers will be regenerated.
     // (-- api-linter: core::0136::prepositions=disabled
     //     aip.dev/not-precedent: "By" is used to indicate request type. --)
     rpc UnpauseActivityById (UnpauseActivityByIdRequest) returns (UnpauseActivityByIdResponse) {
@@ -998,15 +998,22 @@ service WorkflowService {
         };
     }
 
-    // ResetActivityById unpauses the execution of an activity specified by its ID.
-    // Returns a `NotFound` error if there is no pending activity with the provided ID.
+    // ResetActivityById resets the execution of an activity specified by its ID.
+    //
     // Resetting an activity means:
     // * number of attempts will be reset to 0.
-    // * activity timeouts will be resetted.
-    // If the activity currently running:
-    // *  if 'no_wait' flag is provided, a new instance of the activity will be scheduled immediately.
-    // *  if 'no_wait' flag is not provided, a new instance of the  activity will be scheduled after current instance completes if needed.
-    // If 'reset_heartbeats' flag is set, the activity heartbeat timer and heartbeats will be reset.
+    // * activity timeouts will be reset.
+    // * if the activity is waiting for retry, and it is not paused or 'keep_paused' is not provided:
+    //    it will be scheduled immediately (* see 'jitter' flag),
+    //
+    // Flags:
+    //
+    // 'jitter': the activity will be scheduled at a random time within the jitter duration.
+    // If the activity currently paused it will be unpause, unless 'keep_paused' flag is provided.
+    // 'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.
+    // 'keep_paused': if the activity is paused, it will remain paused.
+    //
+    // Returns a `NotFound` error if there is no pending activity with the provided ID.
     // (-- api-linter: core::0136::prepositions=disabled
     //     aip.dev/not-precedent: "By" is used to indicate request type. --)
     rpc ResetActivityById (ResetActivityByIdRequest) returns (ResetActivityByIdResponse) {
@@ -1019,37 +1026,5 @@ service WorkflowService {
             }
         };
     }
-
-    // ManageActivity apply reset/pause/unpause/update operations to an activity specified by its ID and/or type.
-    // Either activity id or activity type must be provided.
-    // Supported operations:
-    // 1. Reset operation. Resets the activity to its initial state.
-    // Resetting the activity. This operation will reset the number of attempts.
-    // If activity is paused - activity will be unpaused bt default (see 'keep_paused' flag).
-    // If activity is currently waiting for retry - it will be scheduled immediately.
-    // Flags:
-    // 'reset_heartbeats' indicates that activity should reset heartbeat details.
-    // 'keep_paused'- prevents activity from being unpaused.
-    // 2. Pause operation. Pauses the activity. If activity was already paused it is no-op.
-    // 3. Unpause operation. Unpauses the activity. If activity was not paused this will be a no-op.
-    // If activity was waiting for retry - it will be scheduled immediately.
-    // Unpause operation supports the following flags:
-    // * jitter - if set, the activity will start at a random time within the specified jitter duration.
-    // 4. Update operation - updates the activity options.
-    // for details see UnpauseActivityById.
-    // Returns a `NotFound` error if there is no pending activity with the provided ID or type.
-    // (-- api-linter: core::0136::prepositions=disabled
-    //     aip.dev/not-precedent: "By" is used to indicate request type. --)
-    rpc ManageActivity (ManageActivityRequest) returns (ManageActivityResponse) {
-        option (google.api.http) = {
-            post: "/namespaces/{namespace}/activities/manage"
-            body: "*"
-            additional_bindings {
-                post: "/api/v1/namespaces/{namespace}/activities/manage"
-                body: "*"
-            }
-        };
-    }
-
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
1. Removed added "ManageActivity"
2. Remove multiple fields from various activity related API, per feedback.
3. Add some other fields per feedback, in particular "jitter"
4. Add the ability to unpause to reset api.

<!-- Tell your future self why have you made these changes -->
**Why?**
1. Don't want to "win by technicality". I think separation of concerns is a deal breaker, and if I can't convince with it - I can't convince.

but more important
2. Removing pause/unpause/update/reset activity API completely will be bad user experience once we (finally) add http rest api support. The more I think about this the more I convinced that this is a price I'm not ready to pay. Now requests are a bit "bloated", but its better then not to have them at all.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
Nope.