### PR TITLE
Add completion callbacks to SignalWithStart request

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -6367,6 +6367,14 @@
         "versioningOverride": {
           "$ref": "#/definitions/v1VersioningOverride",
           "description": "If set, takes precedence over the Versioning Behavior sent by the SDK on Workflow Task completion.\nTo unset the override after the workflow is running, use UpdateWorkflowExecutionOptions."
+        },
+        "completionCallbacks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1Callback"
+          },
+          "description": "Callbacks to be called by the server when this workflow reaches a terminal state.\nIf the workflow continues-as-new, these callbacks will be carried over to the new execution.\nCallbacks will not be deduplicated if the workflow is already started with callbacks.\nCallback addresses must be whitelisted in the server's dynamic configuration."
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9063,6 +9063,15 @@ components:
           description: |-
             If set, takes precedence over the Versioning Behavior sent by the SDK on Workflow Task completion.
              To unset the override after the workflow is running, use UpdateWorkflowExecutionOptions.
+        completionCallbacks:
+          type: array
+          items:
+            $ref: '#/components/schemas/Callback'
+          description: |-
+            Callbacks to be called by the server when this workflow reaches a terminal state.
+             If the workflow continues-as-new, these callbacks will be carried over to the new execution.
+             Callbacks will not be deduplicated if the workflow is already started with callbacks.
+             Callback addresses must be whitelisted in the server's dynamic configuration.
     SignalWithStartWorkflowExecutionResponse:
       type: object
       properties:

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -754,6 +754,11 @@ message SignalWithStartWorkflowExecutionRequest {
     // If set, takes precedence over the Versioning Behavior sent by the SDK on Workflow Task completion.
     // To unset the override after the workflow is running, use UpdateWorkflowExecutionOptions.
     temporal.api.workflow.v1.VersioningOverride versioning_override = 25;
+    // Callbacks to be called by the server when this workflow reaches a terminal state.
+    // If the workflow continues-as-new, these callbacks will be carried over to the new execution.
+    // Callbacks will not be deduplicated if the workflow is already started with callbacks.
+    // Callback addresses must be whitelisted in the server's dynamic configuration.
+    repeated temporal.api.common.v1.Callback completion_callbacks = 26;
 }
 
 message SignalWithStartWorkflowExecutionResponse {


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
Adding a new field for completion callbacks to `SignalWithStartWorkflowExecutionRequest`

<!-- Tell your future self why have you made these changes -->
**Why?**
So that Nexus operations which use SignalWithStart can be informed of the workflow's completion.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
