### PR TITLE
pull api/cmd/protogen@master instead of @latest while latest is incompatible with latest protoc-gen packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ http-api-docs:
 ##### Plugins & tools #####
 grpc-install:
 	@printf $(COLOR) "Install/update protoc and plugins..."
-	@go install go.temporal.io/api/cmd/protogen@latest
+	@go install go.temporal.io/api/cmd/protogen@master
 	@go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 	@go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 	@go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@latest


### PR DESCRIPTION

_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
pull api/cmd/protogen@master instead of @latest while latest is incompatible with latest protoc-gen packages


<!-- Tell your future self why have you made these changes -->
To fix the panic error caused by installing @latest of all packages in `make grpc-install`
```
panic: interface conversion: ast.Expr is *ast.CallExpr, not *ast.CompositeLit

goroutine 1 [running]:
main.(*disableUtf8Validation).visit(0x0?, {0x1044665a8?, 0x1400039a480?})
        /Users/cdf/go/pkg/mod/go.temporal.io/api@v1.43.2/cmd/protogen/disable_utf8.go:90 +0x484
go/ast.inspector.Visit(0x140003a20b0, {0x1044665a8?, 0x1400039a480?})
```

Another option would be to figure out which of these other versions caused the problem and pin that package to an older version that is compatible with v1.43.2 of our api-go repo, but that requires a lot more work to narrow down the right combination of versions.

If we want to pin to an old version instead, it would need to be an older version of one of these packages:
```
Install/update protoc and plugins...
go: downloading google.golang.org/protobuf v1.36.4
go: downloading google.golang.org/grpc v1.70.0
go: downloading github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.0
go: downloading google.golang.org/grpc v1.69.4
go: downloading google.golang.org/protobuf v1.36.3
go: downloading google.golang.org/genproto/googleapis/api v0.0.0-20250115164207-1a7da9e5054f
go: downloading google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f
go: downloading github.com/mikefarah/yq/v4 v4.45.1
go: downloading github.com/goccy/go-json v0.10.4
go: downloading github.com/elliotchance/orderedmap v1.7.1
go: downloading github.com/goccy/go-yaml v1.13.3
go: downloading github.com/magiconair/properties v1.8.9
go: downloading golang.org/x/net v0.33.0
```


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
