### PR TITLE
Add activty type as an option for activity API

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -479,7 +479,7 @@
     },
     "/api/v1/namespaces/{namespace}/activities/pause-by-id": {
       "post": {
-        "summary": "PauseActivityById pauses the execution of an activity specified by its ID.\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
+        "summary": "PauseActivityById pauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be paused\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
         "description": "Pausing an activity means:\n- If the activity is currently waiting for a retry or is running and subsequently fails,\n  it will not be rescheduled until it is unpause.\n- If the activity is already paused, calling this method will have no effect.\n- If the activity is running and finishes successfully, the activity will be completed.\n- If the activity is running and finishes with failure:\n  * if there is no retry left - the activity will be completed.\n  * if there are more retries left - the activity will be paused.\nFor long-running activities:\n- activities in paused state will send a cancellation with \"activity_paused\" set to 'true' in response to 'RecordActivityTaskHeartbeat'.\n- The activity should respond to the cancellation accordingly.",
         "operationId": "PauseActivityById2",
         "responses": {
@@ -520,7 +520,7 @@
     },
     "/api/v1/namespaces/{namespace}/activities/reset-by-id": {
       "post": {
-        "summary": "ResetActivityById resets the execution of an activity specified by its ID.",
+        "summary": "ResetActivityById resets the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be reset.",
         "description": "Resetting an activity means:\n* number of attempts will be reset to 0.\n* activity timeouts will be reset.\n* if the activity is waiting for retry, and it is not paused or 'keep_paused' is not provided:\n   it will be scheduled immediately (* see 'jitter' flag),\n\nFlags:\n\n'jitter': the activity will be scheduled at a random time within the jitter duration.\nIf the activity currently paused it will be unpause, unless 'keep_paused' flag is provided.\n'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.\n'keep_paused': if the activity is paused, it will remain paused.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
         "operationId": "ResetActivityById2",
         "responses": {
@@ -561,7 +561,7 @@
     },
     "/api/v1/namespaces/{namespace}/activities/unpause-by-id": {
       "post": {
-        "summary": "UnpauseActivityById unpauses the execution of an activity specified by its ID.",
+        "summary": "UnpauseActivityById unpauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be unpause.",
         "description": "If activity is not paused, this call will have no effect.\nIf the activity is waiting for retry, it will be scheduled immediately (* see 'jitter' flag).\nOnce the activity is unpause, all timeout timers will be regenerated.\n\nFlags:\n'jitter': the activity will be scheduled at a random time within the jitter duration.\n'reset_attempts': the number of attempts will be reset.\n'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
         "operationId": "UnpauseActivityById2",
         "responses": {
@@ -602,7 +602,7 @@
     },
     "/api/v1/namespaces/{namespace}/activities/update-options-by-id": {
       "post": {
-        "summary": "UpdateActivityOptionsById is called by the client to update the options of an activity",
+        "summary": "UpdateActivityOptionsById is called by the client to update the options of an activity by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be updated.",
         "operationId": "UpdateActivityOptionsById2",
         "responses": {
           "200": {
@@ -3481,7 +3481,7 @@
     },
     "/namespaces/{namespace}/activities/pause-by-id": {
       "post": {
-        "summary": "PauseActivityById pauses the execution of an activity specified by its ID.\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
+        "summary": "PauseActivityById pauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be paused\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
         "description": "Pausing an activity means:\n- If the activity is currently waiting for a retry or is running and subsequently fails,\n  it will not be rescheduled until it is unpause.\n- If the activity is already paused, calling this method will have no effect.\n- If the activity is running and finishes successfully, the activity will be completed.\n- If the activity is running and finishes with failure:\n  * if there is no retry left - the activity will be completed.\n  * if there are more retries left - the activity will be paused.\nFor long-running activities:\n- activities in paused state will send a cancellation with \"activity_paused\" set to 'true' in response to 'RecordActivityTaskHeartbeat'.\n- The activity should respond to the cancellation accordingly.",
         "operationId": "PauseActivityById",
         "responses": {
@@ -3522,7 +3522,7 @@
     },
     "/namespaces/{namespace}/activities/reset-by-id": {
       "post": {
-        "summary": "ResetActivityById resets the execution of an activity specified by its ID.",
+        "summary": "ResetActivityById resets the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be reset.",
         "description": "Resetting an activity means:\n* number of attempts will be reset to 0.\n* activity timeouts will be reset.\n* if the activity is waiting for retry, and it is not paused or 'keep_paused' is not provided:\n   it will be scheduled immediately (* see 'jitter' flag),\n\nFlags:\n\n'jitter': the activity will be scheduled at a random time within the jitter duration.\nIf the activity currently paused it will be unpause, unless 'keep_paused' flag is provided.\n'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.\n'keep_paused': if the activity is paused, it will remain paused.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
         "operationId": "ResetActivityById",
         "responses": {
@@ -3563,7 +3563,7 @@
     },
     "/namespaces/{namespace}/activities/unpause-by-id": {
       "post": {
-        "summary": "UnpauseActivityById unpauses the execution of an activity specified by its ID.",
+        "summary": "UnpauseActivityById unpauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be unpause.",
         "description": "If activity is not paused, this call will have no effect.\nIf the activity is waiting for retry, it will be scheduled immediately (* see 'jitter' flag).\nOnce the activity is unpause, all timeout timers will be regenerated.\n\nFlags:\n'jitter': the activity will be scheduled at a random time within the jitter duration.\n'reset_attempts': the number of attempts will be reset.\n'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
         "operationId": "UnpauseActivityById",
         "responses": {
@@ -3604,7 +3604,7 @@
     },
     "/namespaces/{namespace}/activities/update-options-by-id": {
       "post": {
-        "summary": "UpdateActivityOptionsById is called by the client to update the options of an activity",
+        "summary": "UpdateActivityOptionsById is called by the client to update the options of an activity by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be updated.",
         "operationId": "UpdateActivityOptionsById",
         "responses": {
           "200": {
@@ -5881,13 +5881,17 @@
           "type": "string",
           "description": "Run ID of the workflow which scheduled this activity.\nIf empty - latest workflow is used."
         },
-        "activityId": {
-          "type": "string",
-          "description": "ID of the activity we're updating."
-        },
         "identity": {
           "type": "string",
           "description": "The identity of the client who initiated this request."
+        },
+        "id": {
+          "type": "string",
+          "description": "ID of the activity we're pausing."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the activity we're pausing."
         }
       }
     },
@@ -6015,10 +6019,6 @@
           "type": "string",
           "description": "Run ID of the workflow which scheduled this activity.\nIf empty - latest workflow is used."
         },
-        "activityId": {
-          "type": "string",
-          "description": "ID of the activity we're updating."
-        },
         "identity": {
           "type": "string",
           "description": "The identity of the client who initiated this request."
@@ -6034,6 +6034,14 @@
         "jitter": {
           "type": "string",
           "title": "If set, and activity is in backoff, the activity will start at a random time within the specified jitter duration.\n(unless it is paused and keep_paused is set)"
+        },
+        "id": {
+          "type": "string",
+          "description": "ID of the activity we're pausing."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the activity we're pausing."
         }
       }
     },
@@ -6597,13 +6605,17 @@
           "type": "string",
           "description": "Run ID of the workflow which scheduled this activity.\nIf empty - latest workflow is used."
         },
-        "activityId": {
-          "type": "string",
-          "description": "ID of the activity we're updating."
-        },
         "identity": {
           "type": "string",
           "description": "The identity of the client who initiated this request."
+        },
+        "id": {
+          "type": "string",
+          "description": "ID of the activity we're pausing."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the activity we're pausing."
         },
         "resetAttempts": {
           "type": "boolean",
@@ -6630,10 +6642,6 @@
           "type": "string",
           "title": "Run ID of the workflow which scheduled this activity\nif empty - latest workflow is used"
         },
-        "activityId": {
-          "type": "string",
-          "title": "ID of the activity we're updating"
-        },
         "identity": {
           "type": "string",
           "title": "The identity of the client who initiated this request"
@@ -6646,9 +6654,13 @@
           "type": "string",
           "title": "Controls which fields from `activity_options` will be applied"
         },
-        "requestId": {
+        "id": {
           "type": "string",
-          "title": "Used to de-dupe requests"
+          "description": "ID of the activity we're pausing."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the activity we're pausing."
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -421,7 +421,8 @@ paths:
       tags:
         - WorkflowService
       description: |-
-        PauseActivityById pauses the execution of an activity specified by its ID.
+        PauseActivityById pauses the execution of an activity specified by its ID or type.
+         If there are multiple pending activities of the provided type - all of them will be paused
          Returns a `NotFound` error if there is no pending activity with the provided ID.
 
          Pausing an activity means:
@@ -469,7 +470,8 @@ paths:
       tags:
         - WorkflowService
       description: |-
-        ResetActivityById resets the execution of an activity specified by its ID.
+        ResetActivityById resets the execution of an activity specified by its ID or type.
+         If there are multiple pending activities of the provided type - all of them will be reset.
 
          Resetting an activity means:
          * number of attempts will be reset to 0.
@@ -519,7 +521,8 @@ paths:
       tags:
         - WorkflowService
       description: |-
-        UnpauseActivityById unpauses the execution of an activity specified by its ID.
+        UnpauseActivityById unpauses the execution of an activity specified by its ID or type.
+         If there are multiple pending activities of the provided type - all of them will be unpause.
 
          If activity is not paused, this call will have no effect.
          If the activity is waiting for retry, it will be scheduled immediately (* see 'jitter' flag).
@@ -565,7 +568,8 @@ paths:
       tags:
         - WorkflowService
       description: |-
-        UpdateActivityOptionsById is called by the client to update the options of an activity
+        UpdateActivityOptionsById is called by the client to update the options of an activity by its ID or type.
+         If there are multiple pending activities of the provided type - all of them will be updated.
          (-- api-linter: core::0136::prepositions=disabled
              aip.dev/not-precedent: "By" is used to indicate request type. --)
       operationId: UpdateActivityOptionsById
@@ -3091,7 +3095,8 @@ paths:
       tags:
         - WorkflowService
       description: |-
-        PauseActivityById pauses the execution of an activity specified by its ID.
+        PauseActivityById pauses the execution of an activity specified by its ID or type.
+         If there are multiple pending activities of the provided type - all of them will be paused
          Returns a `NotFound` error if there is no pending activity with the provided ID.
 
          Pausing an activity means:
@@ -3139,7 +3144,8 @@ paths:
       tags:
         - WorkflowService
       description: |-
-        ResetActivityById resets the execution of an activity specified by its ID.
+        ResetActivityById resets the execution of an activity specified by its ID or type.
+         If there are multiple pending activities of the provided type - all of them will be reset.
 
          Resetting an activity means:
          * number of attempts will be reset to 0.
@@ -3189,7 +3195,8 @@ paths:
       tags:
         - WorkflowService
       description: |-
-        UnpauseActivityById unpauses the execution of an activity specified by its ID.
+        UnpauseActivityById unpauses the execution of an activity specified by its ID or type.
+         If there are multiple pending activities of the provided type - all of them will be unpause.
 
          If activity is not paused, this call will have no effect.
          If the activity is waiting for retry, it will be scheduled immediately (* see 'jitter' flag).
@@ -3235,7 +3242,8 @@ paths:
       tags:
         - WorkflowService
       description: |-
-        UpdateActivityOptionsById is called by the client to update the options of an activity
+        UpdateActivityOptionsById is called by the client to update the options of an activity by its ID or type.
+         If there are multiple pending activities of the provided type - all of them will be updated.
          (-- api-linter: core::0136::prepositions=disabled
              aip.dev/not-precedent: "By" is used to indicate request type. --)
       operationId: UpdateActivityOptionsById
@@ -7521,12 +7529,15 @@ components:
           description: |-
             Run ID of the workflow which scheduled this activity.
              If empty - latest workflow is used.
-        activityId:
-          type: string
-          description: ID of the activity we're updating.
         identity:
           type: string
           description: The identity of the client who initiated this request.
+        id:
+          type: string
+          description: ID of the activity we're pausing.
+        type:
+          type: string
+          description: Type of the activity we're pausing.
     PauseActivityByIdResponse:
       type: object
       properties: {}
@@ -8138,9 +8149,6 @@ components:
           description: |-
             Run ID of the workflow which scheduled this activity.
              If empty - latest workflow is used.
-        activityId:
-          type: string
-          description: ID of the activity we're updating.
         identity:
           type: string
           description: The identity of the client who initiated this request.
@@ -8158,6 +8166,12 @@ components:
           description: |-
             If set, and activity is in backoff, the activity will start at a random time within the specified jitter duration.
              (unless it is paused and keep_paused is set)
+        id:
+          type: string
+          description: ID of the activity we're pausing.
+        type:
+          type: string
+          description: Type of the activity we're pausing.
     ResetActivityByIdResponse:
       type: object
       properties: {}
@@ -9816,12 +9830,15 @@ components:
           description: |-
             Run ID of the workflow which scheduled this activity.
              If empty - latest workflow is used.
-        activityId:
-          type: string
-          description: ID of the activity we're updating.
         identity:
           type: string
           description: The identity of the client who initiated this request.
+        id:
+          type: string
+          description: ID of the activity we're pausing.
+        type:
+          type: string
+          description: Type of the activity we're pausing.
         resetAttempts:
           type: boolean
           description: unpause can also reset the number of attempts
@@ -9849,9 +9866,6 @@ components:
           description: |-
             Run ID of the workflow which scheduled this activity
              if empty - latest workflow is used
-        activityId:
-          type: string
-          description: ID of the activity we're updating
         identity:
           type: string
           description: The identity of the client who initiated this request
@@ -9863,9 +9877,12 @@ components:
           type: string
           description: Controls which fields from `activity_options` will be applied
           format: field-mask
-        requestId:
+        id:
           type: string
-          description: Used to de-dupe requests
+          description: ID of the activity we're pausing.
+        type:
+          type: string
+          description: Type of the activity we're pausing.
     UpdateActivityOptionsByIdResponse:
       type: object
       properties:

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1756,8 +1756,6 @@ message UpdateActivityOptionsByIdRequest {
     // Run ID of the workflow which scheduled this activity
     // if empty - latest workflow is used
     string run_id = 3;
-    // ID of the activity we're updating
-    string activity_id = 4;
 
     // The identity of the client who initiated this request
     string identity = 5;
@@ -1768,8 +1766,18 @@ message UpdateActivityOptionsByIdRequest {
     // Controls which fields from `activity_options` will be applied
     google.protobuf.FieldMask update_mask = 7;
 
-    // Used to de-dupe requests
-    string request_id = 8;
+    // either activity id or activity type must be provided
+    oneof activity {
+        // ID of the activity we're pausing.
+        string id = 9;
+        // Type of the activity we're pausing.
+        string type = 10;
+    }
+
+    reserved 4;
+    reserved 8;
+    reserved "activity_id";
+    reserved "request_id";
 }
 
 message UpdateActivityOptionsByIdResponse {
@@ -1785,13 +1793,22 @@ message PauseActivityByIdRequest {
     // Run ID of the workflow which scheduled this activity.
     // If empty - latest workflow is used.
     string run_id = 3;
-    // ID of the activity we're updating.
-    string activity_id = 4;
+
 
     // The identity of the client who initiated this request.
     string identity = 5;
 
+    // either activity id or activity type must be provided
+    oneof activity {
+        // ID of the activity we're pausing.
+        string id = 7;
+        // Type of the activity we're pausing.
+        string type = 8;
+    }
+
+    reserved 4;
     reserved 6;
+    reserved "activity_id";
     reserved "request_id";
 }
 
@@ -1806,18 +1823,17 @@ message UnpauseActivityByIdRequest {
     // Run ID of the workflow which scheduled this activity.
     // If empty - latest workflow is used.
     string run_id = 3;
-    // ID of the activity we're updating.
-    string activity_id = 4;
 
     // The identity of the client who initiated this request.
     string identity = 5;
 
-    reserved 6;
-    reserved 7; // was resume/reset. Flatten this.
-    reserved 8; // was resume/reset. Flatten this.
-    reserved "request_id";
-    reserved "reset";
-    reserved "resume";
+    // either activity id or activity type must be provided
+    oneof activity {
+        // ID of the activity we're pausing.
+        string id = 12;
+        // Type of the activity we're pausing.
+        string type = 13;
+    }
 
     // unpause can also reset the number of attempts
     bool reset_attempts = 9;
@@ -1827,6 +1843,16 @@ message UnpauseActivityByIdRequest {
 
     // If set, the activity will start at a random time within the specified jitter duration.
     google.protobuf.Duration jitter = 11;
+
+    reserved 4;
+    reserved 6;
+    reserved 7;
+    reserved 8;
+    reserved "activity_id";
+    reserved "request_id";
+    reserved "reset";
+    reserved "resume";
+
 }
 
 message UnpauseActivityByIdResponse {
@@ -1840,16 +1866,10 @@ message ResetActivityByIdRequest {
     // Run ID of the workflow which scheduled this activity.
     // If empty - latest workflow is used.
     string run_id = 3;
-    // ID of the activity we're updating.
-    string activity_id = 4;
 
     // The identity of the client who initiated this request.
     string identity = 5;
 
-    reserved 6;
-    reserved 7;
-    reserved "request_id";
-    reserved "no_wait";
 
     // Indicates that activity should reset heartbeat details.
     // This flag will be applied only to the new instance of the activity.
@@ -1861,6 +1881,21 @@ message ResetActivityByIdRequest {
     // If set, and activity is in backoff, the activity will start at a random time within the specified jitter duration.
     // (unless it is paused and keep_paused is set)
     google.protobuf.Duration jitter = 11;
+
+    // either activity id or activity type must be provided
+    oneof activity {
+        // ID of the activity we're pausing.
+        string id = 12;
+        // Type of the activity we're pausing.
+        string type = 13;
+    }
+
+    reserved 4;
+    reserved 6;
+    reserved 7;
+    reserved "activity_id";
+    reserved "request_id";
+    reserved "no_wait";
 }
 
 message ResetActivityByIdResponse {

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -920,7 +920,8 @@ service WorkflowService {
     rpc RespondNexusTaskFailed(RespondNexusTaskFailedRequest) returns (RespondNexusTaskFailedResponse) {
     }
 
-    // UpdateActivityOptionsById is called by the client to update the options of an activity
+    // UpdateActivityOptionsById is called by the client to update the options of an activity by its ID or type.
+    // If there are multiple pending activities of the provided type - all of them will be updated.
     // (-- api-linter: core::0136::prepositions=disabled
     //     aip.dev/not-precedent: "By" is used to indicate request type. --)
     rpc UpdateActivityOptionsById (UpdateActivityOptionsByIdRequest) returns (UpdateActivityOptionsByIdResponse) {
@@ -946,7 +947,8 @@ service WorkflowService {
         };
     }
 
-    // PauseActivityById pauses the execution of an activity specified by its ID.
+    // PauseActivityById pauses the execution of an activity specified by its ID or type.
+    // If there are multiple pending activities of the provided type - all of them will be paused
     // Returns a `NotFound` error if there is no pending activity with the provided ID.
     //
     // Pausing an activity means:
@@ -973,7 +975,8 @@ service WorkflowService {
         };
     }
 
-    // UnpauseActivityById unpauses the execution of an activity specified by its ID.
+    // UnpauseActivityById unpauses the execution of an activity specified by its ID or type.
+    // If there are multiple pending activities of the provided type - all of them will be unpause.
     //
     // If activity is not paused, this call will have no effect.
     // If the activity is waiting for retry, it will be scheduled immediately (* see 'jitter' flag).
@@ -998,7 +1001,8 @@ service WorkflowService {
         };
     }
 
-    // ResetActivityById resets the execution of an activity specified by its ID.
+    // ResetActivityById resets the execution of an activity specified by its ID or type.
+    // If there are multiple pending activities of the provided type - all of them will be reset.
     //
     // Resetting an activity means:
     // * number of attempts will be reset to 0.
@@ -1027,4 +1031,3 @@ service WorkflowService {
         };
     }
 }
-


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
remove acitvity_id as a single option for Activity API.
Now callers can chose to pause/undate/unpause/reset all the pending activities of a certain type.

<!-- Tell your future self why have you made these changes -->
**Why?**
Design review feedback.
If multiple activities are running in parallel they are usually of the same type, and experience the same problem.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
No with current implementation.