### PR TITLE
Single Activity API changes

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -479,8 +479,8 @@
     },
     "/api/v1/namespaces/{namespace}/activities/pause-by-id": {
       "post": {
-        "summary": "PauseActivityById pauses the execution of an activity specified by its ID.\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
-        "description": "Pausing an activity means:\n- If the activity is currently waiting for a retry or is running and subsequently fails,\n  it will not be rescheduled until it is unpaused.\n- If the activity is already paused, calling this method will have no effect.\n- If the activity is running and finishes successfully, the activity will be completed.\n- If the activity is running and finishes with failure:\n  * if there is no retry left - the activity will be completed.\n  * if there are more retries left - the activity will be paused.\nFor long-running activities:\n- activities in paused state will send a cancellation with \"activity_paused\" set to 'true' in response to 'RecordActivityTaskHeartbeat'.\n- The activity should respond to the cancellation accordingly.",
+        "summary": "PauseActivityById pauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be paused\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
+        "description": "Pausing an activity means:\n- If the activity is currently waiting for a retry or is running and subsequently fails,\n  it will not be rescheduled until it is unpause.\n- If the activity is already paused, calling this method will have no effect.\n- If the activity is running and finishes successfully, the activity will be completed.\n- If the activity is running and finishes with failure:\n  * if there is no retry left - the activity will be completed.\n  * if there are more retries left - the activity will be paused.\nFor long-running activities:\n- activities in paused state will send a cancellation with \"activity_paused\" set to 'true' in response to 'RecordActivityTaskHeartbeat'.\n- The activity should respond to the cancellation accordingly.",
         "operationId": "PauseActivityById2",
         "responses": {
           "200": {
@@ -520,7 +520,8 @@
     },
     "/api/v1/namespaces/{namespace}/activities/reset-by-id": {
       "post": {
-        "summary": "ResetActivityById unpauses the execution of an activity specified by its ID.\nReturns a `NotFound` error if there is no pending activity with the provided ID.\nResetting an activity means:\n* number of attempts will be reset to 0.\n* activity timeouts will be resetted.\nIf the activity currently running:\n*  if 'no_wait' flag is provided, a new instance of the activity will be scheduled immediately.\n*  if 'no_wait' flag is not provided, a new instance of the  activity will be scheduled after current instance completes if needed.\nIf 'reset_heartbeats' flag is set, the activity heartbeat timer and heartbeats will be reset.",
+        "summary": "ResetActivityById resets the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be reset.",
+        "description": "Resetting an activity means:\n* number of attempts will be reset to 0.\n* activity timeouts will be reset.\n* if the activity is waiting for retry, and it is not paused or 'keep_paused' is not provided:\n   it will be scheduled immediately (* see 'jitter' flag),\n\nFlags:\n\n'jitter': the activity will be scheduled at a random time within the jitter duration.\nIf the activity currently paused it will be unpause, unless 'keep_paused' flag is provided.\n'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.\n'keep_paused': if the activity is paused, it will remain paused.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
         "operationId": "ResetActivityById2",
         "responses": {
           "200": {
@@ -560,7 +561,8 @@
     },
     "/api/v1/namespaces/{namespace}/activities/unpause-by-id": {
       "post": {
-        "summary": "UnpauseActivityById unpauses the execution of an activity specified by its ID.\nReturns a `NotFound` error if there is no pending activity with the provided ID.\nThere are two 'modes' of unpausing an activity:\n'resume' - If the activity is paused, it will be resumed and scheduled for execution.\n   * If the activity is currently running Unpause with 'resume' has no effect.\n   * if 'no_wait' flag is set and the activity is waiting, the activity will be scheduled immediately.\n'reset' - If the activity is paused, it will be reset to its initial state and (depending on parameters) scheduled for execution.\n   * If the activity is currently running, Unpause with 'reset' will reset the number of attempts.\n   * if 'no_wait' flag is set, the activity will be scheduled immediately.\n   * if 'reset_heartbeats' flag is set, the activity heartbeat timer and heartbeats will be reset.\nIf the activity is in waiting for retry and past it retry timeout, it will be scheduled immediately.\nOnce the activity is unpaused, all timeout timers will be regenerated.",
+        "summary": "UnpauseActivityById unpauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be unpause.",
+        "description": "If activity is not paused, this call will have no effect.\nIf the activity is waiting for retry, it will be scheduled immediately (* see 'jitter' flag).\nOnce the activity is unpause, all timeout timers will be regenerated.\n\nFlags:\n'jitter': the activity will be scheduled at a random time within the jitter duration.\n'reset_attempts': the number of attempts will be reset.\n'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
         "operationId": "UnpauseActivityById2",
         "responses": {
           "200": {
@@ -600,7 +602,7 @@
     },
     "/api/v1/namespaces/{namespace}/activities/update-options-by-id": {
       "post": {
-        "summary": "UpdateActivityOptionsById is called by the client to update the options of an activity",
+        "summary": "UpdateActivityOptionsById is called by the client to update the options of an activity by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be updated.",
         "operationId": "UpdateActivityOptionsById2",
         "responses": {
           "200": {
@@ -3479,8 +3481,8 @@
     },
     "/namespaces/{namespace}/activities/pause-by-id": {
       "post": {
-        "summary": "PauseActivityById pauses the execution of an activity specified by its ID.\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
-        "description": "Pausing an activity means:\n- If the activity is currently waiting for a retry or is running and subsequently fails,\n  it will not be rescheduled until it is unpaused.\n- If the activity is already paused, calling this method will have no effect.\n- If the activity is running and finishes successfully, the activity will be completed.\n- If the activity is running and finishes with failure:\n  * if there is no retry left - the activity will be completed.\n  * if there are more retries left - the activity will be paused.\nFor long-running activities:\n- activities in paused state will send a cancellation with \"activity_paused\" set to 'true' in response to 'RecordActivityTaskHeartbeat'.\n- The activity should respond to the cancellation accordingly.",
+        "summary": "PauseActivityById pauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be paused\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
+        "description": "Pausing an activity means:\n- If the activity is currently waiting for a retry or is running and subsequently fails,\n  it will not be rescheduled until it is unpause.\n- If the activity is already paused, calling this method will have no effect.\n- If the activity is running and finishes successfully, the activity will be completed.\n- If the activity is running and finishes with failure:\n  * if there is no retry left - the activity will be completed.\n  * if there are more retries left - the activity will be paused.\nFor long-running activities:\n- activities in paused state will send a cancellation with \"activity_paused\" set to 'true' in response to 'RecordActivityTaskHeartbeat'.\n- The activity should respond to the cancellation accordingly.",
         "operationId": "PauseActivityById",
         "responses": {
           "200": {
@@ -3520,7 +3522,8 @@
     },
     "/namespaces/{namespace}/activities/reset-by-id": {
       "post": {
-        "summary": "ResetActivityById unpauses the execution of an activity specified by its ID.\nReturns a `NotFound` error if there is no pending activity with the provided ID.\nResetting an activity means:\n* number of attempts will be reset to 0.\n* activity timeouts will be resetted.\nIf the activity currently running:\n*  if 'no_wait' flag is provided, a new instance of the activity will be scheduled immediately.\n*  if 'no_wait' flag is not provided, a new instance of the  activity will be scheduled after current instance completes if needed.\nIf 'reset_heartbeats' flag is set, the activity heartbeat timer and heartbeats will be reset.",
+        "summary": "ResetActivityById resets the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be reset.",
+        "description": "Resetting an activity means:\n* number of attempts will be reset to 0.\n* activity timeouts will be reset.\n* if the activity is waiting for retry, and it is not paused or 'keep_paused' is not provided:\n   it will be scheduled immediately (* see 'jitter' flag),\n\nFlags:\n\n'jitter': the activity will be scheduled at a random time within the jitter duration.\nIf the activity currently paused it will be unpause, unless 'keep_paused' flag is provided.\n'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.\n'keep_paused': if the activity is paused, it will remain paused.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
         "operationId": "ResetActivityById",
         "responses": {
           "200": {
@@ -3560,7 +3563,8 @@
     },
     "/namespaces/{namespace}/activities/unpause-by-id": {
       "post": {
-        "summary": "UnpauseActivityById unpauses the execution of an activity specified by its ID.\nReturns a `NotFound` error if there is no pending activity with the provided ID.\nThere are two 'modes' of unpausing an activity:\n'resume' - If the activity is paused, it will be resumed and scheduled for execution.\n   * If the activity is currently running Unpause with 'resume' has no effect.\n   * if 'no_wait' flag is set and the activity is waiting, the activity will be scheduled immediately.\n'reset' - If the activity is paused, it will be reset to its initial state and (depending on parameters) scheduled for execution.\n   * If the activity is currently running, Unpause with 'reset' will reset the number of attempts.\n   * if 'no_wait' flag is set, the activity will be scheduled immediately.\n   * if 'reset_heartbeats' flag is set, the activity heartbeat timer and heartbeats will be reset.\nIf the activity is in waiting for retry and past it retry timeout, it will be scheduled immediately.\nOnce the activity is unpaused, all timeout timers will be regenerated.",
+        "summary": "UnpauseActivityById unpauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be unpause.",
+        "description": "If activity is not paused, this call will have no effect.\nIf the activity is waiting for retry, it will be scheduled immediately (* see 'jitter' flag).\nOnce the activity is unpause, all timeout timers will be regenerated.\n\nFlags:\n'jitter': the activity will be scheduled at a random time within the jitter duration.\n'reset_attempts': the number of attempts will be reset.\n'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
         "operationId": "UnpauseActivityById",
         "responses": {
           "200": {
@@ -3600,7 +3604,7 @@
     },
     "/namespaces/{namespace}/activities/update-options-by-id": {
       "post": {
-        "summary": "UpdateActivityOptionsById is called by the client to update the options of an activity",
+        "summary": "UpdateActivityOptionsById is called by the client to update the options of an activity by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be updated.",
         "operationId": "UpdateActivityOptionsById",
         "responses": {
           "200": {
@@ -5684,28 +5688,6 @@
       },
       "description": "An operation completed successfully."
     },
-    "UnpauseActivityByIdRequestResetOperation": {
-      "type": "object",
-      "properties": {
-        "noWait": {
-          "type": "boolean",
-          "description": "Indicates that the activity should be scheduled immediately.\nNote that this may run simultaneously with any existing executions of the activity."
-        },
-        "resetHeartbeat": {
-          "type": "boolean",
-          "title": "If set, the Heartbeat Details will be cleared out to make the Activity start over from the beginning"
-        }
-      }
-    },
-    "UnpauseActivityByIdRequestResumeOperation": {
-      "type": "object",
-      "properties": {
-        "noWait": {
-          "type": "boolean",
-          "description": "Indicates that if the activity is waiting to retry, it will  be scheduled immediately."
-        }
-      }
-    },
     "UpdateWorkerBuildIdCompatibilityRequestAddNewCompatibleVersion": {
       "type": "object",
       "properties": {
@@ -5899,17 +5881,17 @@
           "type": "string",
           "description": "Run ID of the workflow which scheduled this activity.\nIf empty - latest workflow is used."
         },
-        "activityId": {
-          "type": "string",
-          "description": "ID of the activity we're updating."
-        },
         "identity": {
           "type": "string",
           "description": "The identity of the client who initiated this request."
         },
-        "requestId": {
+        "id": {
           "type": "string",
-          "description": "Used to de-dupe requests."
+          "description": "ID of the activity we're pausing."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the activity we're pausing."
         }
       }
     },
@@ -6037,25 +6019,29 @@
           "type": "string",
           "description": "Run ID of the workflow which scheduled this activity.\nIf empty - latest workflow is used."
         },
-        "activityId": {
-          "type": "string",
-          "description": "ID of the activity we're updating."
-        },
         "identity": {
           "type": "string",
           "description": "The identity of the client who initiated this request."
         },
-        "requestId": {
-          "type": "string",
-          "description": "Used to de-dupe requests."
-        },
-        "noWait": {
-          "type": "boolean",
-          "description": "Indicates that activity should be scheduled immediately.\nIf this flag doesn't set, and activity currently running - temporal will wait until activity is completed."
-        },
         "resetHeartbeat": {
           "type": "boolean",
           "description": "Indicates that activity should reset heartbeat details.\nThis flag will be applied only to the new instance of the activity."
+        },
+        "keepPaused": {
+          "type": "boolean",
+          "title": "if activity is paused, it will remain paused after reset"
+        },
+        "jitter": {
+          "type": "string",
+          "title": "If set, and activity is in backoff, the activity will start at a random time within the specified jitter duration.\n(unless it is paused and keep_paused is set)"
+        },
+        "id": {
+          "type": "string",
+          "description": "ID of the activity we're pausing."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the activity we're pausing."
         }
       }
     },
@@ -6619,23 +6605,29 @@
           "type": "string",
           "description": "Run ID of the workflow which scheduled this activity.\nIf empty - latest workflow is used."
         },
-        "activityId": {
-          "type": "string",
-          "description": "ID of the activity we're updating."
-        },
         "identity": {
           "type": "string",
           "description": "The identity of the client who initiated this request."
         },
-        "requestId": {
+        "id": {
           "type": "string",
-          "description": "Used to de-dupe requests."
+          "description": "ID of the activity we're pausing."
         },
-        "resume": {
-          "$ref": "#/definitions/UnpauseActivityByIdRequestResumeOperation"
+        "type": {
+          "type": "string",
+          "description": "Type of the activity we're pausing."
         },
-        "reset": {
-          "$ref": "#/definitions/UnpauseActivityByIdRequestResetOperation"
+        "resetAttempts": {
+          "type": "boolean",
+          "title": "unpause can also reset the number of attempts"
+        },
+        "resetHeartbeat": {
+          "type": "boolean",
+          "title": "unpause can also reset the heartbeat details"
+        },
+        "jitter": {
+          "type": "string",
+          "description": "If set, the activity will start at a random time within the specified jitter duration."
         }
       }
     },
@@ -6650,10 +6642,6 @@
           "type": "string",
           "title": "Run ID of the workflow which scheduled this activity\nif empty - latest workflow is used"
         },
-        "activityId": {
-          "type": "string",
-          "title": "ID of the activity we're updating"
-        },
         "identity": {
           "type": "string",
           "title": "The identity of the client who initiated this request"
@@ -6666,9 +6654,13 @@
           "type": "string",
           "title": "Controls which fields from `activity_options` will be applied"
         },
-        "requestId": {
+        "id": {
           "type": "string",
-          "title": "Used to de-dupe requests"
+          "description": "ID of the activity we're pausing."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the activity we're pausing."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -6605,6 +6605,10 @@
           "type": "string",
           "description": "Unpause all running activities with of this type."
         },
+        "unpauseAll": {
+          "type": "boolean",
+          "description": "Unpause all running activities."
+        },
         "resetAttempts": {
           "type": "boolean",
           "description": "Providing this flag will also reset the number of attempts."

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -480,7 +480,7 @@
     "/api/v1/namespaces/{namespace}/activities/pause": {
       "post": {
         "summary": "PauseActivity pauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be paused",
-        "description": "Pausing an activity means:\n- If the activity is currently waiting for a retry or is running and subsequently fails,\n  it will not be rescheduled until it is unpause.\n- If the activity is already paused, calling this method will have no effect.\n- If the activity is running and finishes successfully, the activity will be completed.\n- If the activity is running and finishes with failure:\n  * if there is no retry left - the activity will be completed.\n  * if there are more retries left - the activity will be paused.\nFor long-running activities:\n- activities in paused state will send a cancellation with \"activity_paused\" set to 'true' in response to 'RecordActivityTaskHeartbeat'.\n- The activity should respond to the cancellation accordingly.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type",
+        "description": "Pausing an activity means:\n- If the activity is currently waiting for a retry or is running and subsequently fails,\n  it will not be rescheduled until it is unpaused.\n- If the activity is already paused, calling this method will have no effect.\n- If the activity is running and finishes successfully, the activity will be completed.\n- If the activity is running and finishes with failure:\n  * if there is no retry left - the activity will be completed.\n  * if there are more retries left - the activity will be paused.\nFor long-running activities:\n- activities in paused state will send a cancellation with \"activity_paused\" set to 'true' in response to 'RecordActivityTaskHeartbeat'.\n- The activity should respond to the cancellation accordingly.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type",
         "operationId": "PauseActivity2",
         "responses": {
           "200": {
@@ -521,7 +521,7 @@
     "/api/v1/namespaces/{namespace}/activities/reset": {
       "post": {
         "summary": "ResetActivity resets the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be reset.",
-        "description": "Resetting an activity means:\n* number of attempts will be reset to 0.\n* activity timeouts will be reset.\n* if the activity is waiting for retry, and it is not paused or 'keep_paused' is not provided:\n   it will be scheduled immediately (* see 'jitter' flag),\n\nFlags:\n\n'jitter': the activity will be scheduled at a random time within the jitter duration.\nIf the activity currently paused it will be unpause, unless 'keep_paused' flag is provided.\n'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.\n'keep_paused': if the activity is paused, it will remain paused.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type.",
+        "description": "Resetting an activity means:\n* number of attempts will be reset to 0.\n* activity timeouts will be reset.\n* if the activity is waiting for retry, and it is not paused or 'keep_paused' is not provided:\n   it will be scheduled immediately (* see 'jitter' flag),\n\nFlags:\n\n'jitter': the activity will be scheduled at a random time within the jitter duration.\nIf the activity currently paused it will be unpaused, unless 'keep_paused' flag is provided.\n'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.\n'keep_paused': if the activity is paused, it will remain paused.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type.",
         "operationId": "ResetActivity2",
         "responses": {
           "200": {
@@ -562,7 +562,7 @@
     "/api/v1/namespaces/{namespace}/activities/unpause": {
       "post": {
         "summary": "UnpauseActivity unpauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be unpaused.",
-        "description": "If activity is not paused, this call will have no effect.\nIf the activity was paused while waiting for retry, it will be scheduled immediately (* see 'jitter' flag).\nOnce the activity is unpause, all timeout timers will be regenerated.\n\nFlags:\n'jitter': the activity will be scheduled at a random time within the jitter duration.\n'reset_attempts': the number of attempts will be reset.\n'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type",
+        "description": "If activity is not paused, this call will have no effect.\nIf the activity was paused while waiting for retry, it will be scheduled immediately (* see 'jitter' flag).\nOnce the activity is unpaused, all timeout timers will be regenerated.\n\nFlags:\n'jitter': the activity will be scheduled at a random time within the jitter duration.\n'reset_attempts': the number of attempts will be reset.\n'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type",
         "operationId": "UnpauseActivity2",
         "responses": {
           "200": {
@@ -3482,7 +3482,7 @@
     "/namespaces/{namespace}/activities/pause": {
       "post": {
         "summary": "PauseActivity pauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be paused",
-        "description": "Pausing an activity means:\n- If the activity is currently waiting for a retry or is running and subsequently fails,\n  it will not be rescheduled until it is unpause.\n- If the activity is already paused, calling this method will have no effect.\n- If the activity is running and finishes successfully, the activity will be completed.\n- If the activity is running and finishes with failure:\n  * if there is no retry left - the activity will be completed.\n  * if there are more retries left - the activity will be paused.\nFor long-running activities:\n- activities in paused state will send a cancellation with \"activity_paused\" set to 'true' in response to 'RecordActivityTaskHeartbeat'.\n- The activity should respond to the cancellation accordingly.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type",
+        "description": "Pausing an activity means:\n- If the activity is currently waiting for a retry or is running and subsequently fails,\n  it will not be rescheduled until it is unpaused.\n- If the activity is already paused, calling this method will have no effect.\n- If the activity is running and finishes successfully, the activity will be completed.\n- If the activity is running and finishes with failure:\n  * if there is no retry left - the activity will be completed.\n  * if there are more retries left - the activity will be paused.\nFor long-running activities:\n- activities in paused state will send a cancellation with \"activity_paused\" set to 'true' in response to 'RecordActivityTaskHeartbeat'.\n- The activity should respond to the cancellation accordingly.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type",
         "operationId": "PauseActivity",
         "responses": {
           "200": {
@@ -3523,7 +3523,7 @@
     "/namespaces/{namespace}/activities/reset": {
       "post": {
         "summary": "ResetActivity resets the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be reset.",
-        "description": "Resetting an activity means:\n* number of attempts will be reset to 0.\n* activity timeouts will be reset.\n* if the activity is waiting for retry, and it is not paused or 'keep_paused' is not provided:\n   it will be scheduled immediately (* see 'jitter' flag),\n\nFlags:\n\n'jitter': the activity will be scheduled at a random time within the jitter duration.\nIf the activity currently paused it will be unpause, unless 'keep_paused' flag is provided.\n'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.\n'keep_paused': if the activity is paused, it will remain paused.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type.",
+        "description": "Resetting an activity means:\n* number of attempts will be reset to 0.\n* activity timeouts will be reset.\n* if the activity is waiting for retry, and it is not paused or 'keep_paused' is not provided:\n   it will be scheduled immediately (* see 'jitter' flag),\n\nFlags:\n\n'jitter': the activity will be scheduled at a random time within the jitter duration.\nIf the activity currently paused it will be unpaused, unless 'keep_paused' flag is provided.\n'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.\n'keep_paused': if the activity is paused, it will remain paused.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type.",
         "operationId": "ResetActivity",
         "responses": {
           "200": {
@@ -3564,7 +3564,7 @@
     "/namespaces/{namespace}/activities/unpause": {
       "post": {
         "summary": "UnpauseActivity unpauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be unpaused.",
-        "description": "If activity is not paused, this call will have no effect.\nIf the activity was paused while waiting for retry, it will be scheduled immediately (* see 'jitter' flag).\nOnce the activity is unpause, all timeout timers will be regenerated.\n\nFlags:\n'jitter': the activity will be scheduled at a random time within the jitter duration.\n'reset_attempts': the number of attempts will be reset.\n'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type",
+        "description": "If activity is not paused, this call will have no effect.\nIf the activity was paused while waiting for retry, it will be scheduled immediately (* see 'jitter' flag).\nOnce the activity is unpaused, all timeout timers will be regenerated.\n\nFlags:\n'jitter': the activity will be scheduled at a random time within the jitter duration.\n'reset_attempts': the number of attempts will be reset.\n'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type",
         "operationId": "UnpauseActivity",
         "responses": {
           "200": {
@@ -5883,7 +5883,7 @@
         },
         "id": {
           "type": "string",
-          "description": "Only activity with this ID will be paused."
+          "description": "Only the activity with this ID will be paused."
         },
         "type": {
           "type": "string",
@@ -6599,7 +6599,7 @@
         },
         "id": {
           "type": "string",
-          "description": "Only activity with this ID will be unpause."
+          "description": "Only the activity with this ID will be unpaused."
         },
         "type": {
           "type": "string",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -561,8 +561,8 @@
     },
     "/api/v1/namespaces/{namespace}/activities/unpause": {
       "post": {
-        "summary": "UnpauseActivity unpauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be unpause.",
-        "description": "If activity is not paused, this call will have no effect.\nIf the activity is waiting for retry, it will be scheduled immediately (* see 'jitter' flag).\nOnce the activity is unpause, all timeout timers will be regenerated.\n\nFlags:\n'jitter': the activity will be scheduled at a random time within the jitter duration.\n'reset_attempts': the number of attempts will be reset.\n'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type",
+        "summary": "UnpauseActivity unpauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be unpaused.",
+        "description": "If activity is not paused, this call will have no effect.\nIf the activity was paused while waiting for retry, it will be scheduled immediately (* see 'jitter' flag).\nOnce the activity is unpause, all timeout timers will be regenerated.\n\nFlags:\n'jitter': the activity will be scheduled at a random time within the jitter duration.\n'reset_attempts': the number of attempts will be reset.\n'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type",
         "operationId": "UnpauseActivity2",
         "responses": {
           "200": {
@@ -3563,8 +3563,8 @@
     },
     "/namespaces/{namespace}/activities/unpause": {
       "post": {
-        "summary": "UnpauseActivity unpauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be unpause.",
-        "description": "If activity is not paused, this call will have no effect.\nIf the activity is waiting for retry, it will be scheduled immediately (* see 'jitter' flag).\nOnce the activity is unpause, all timeout timers will be regenerated.\n\nFlags:\n'jitter': the activity will be scheduled at a random time within the jitter duration.\n'reset_attempts': the number of attempts will be reset.\n'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type",
+        "summary": "UnpauseActivity unpauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be unpaused.",
+        "description": "If activity is not paused, this call will have no effect.\nIf the activity was paused while waiting for retry, it will be scheduled immediately (* see 'jitter' flag).\nOnce the activity is unpause, all timeout timers will be regenerated.\n\nFlags:\n'jitter': the activity will be scheduled at a random time within the jitter duration.\n'reset_attempts': the number of attempts will be reset.\n'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type",
         "operationId": "UnpauseActivity",
         "responses": {
           "200": {
@@ -5883,11 +5883,11 @@
         },
         "id": {
           "type": "string",
-          "description": "ID of the activity we're pausing."
+          "description": "Only activity with this ID will be paused."
         },
         "type": {
           "type": "string",
-          "description": "Type of the activity we're pausing."
+          "description": "Pause all running activities of this type."
         }
       }
     },
@@ -6017,11 +6017,11 @@
         },
         "id": {
           "type": "string",
-          "description": "ID of the activity we're pausing."
+          "description": "Only activity with this ID will be reset."
         },
         "type": {
           "type": "string",
-          "description": "Type of the activity we're pausing."
+          "description": "Reset all running activities with of this type."
         },
         "resetHeartbeat": {
           "type": "boolean",
@@ -6599,19 +6599,19 @@
         },
         "id": {
           "type": "string",
-          "description": "ID of the activity we're pausing."
+          "description": "Only activity with this ID will be unpause."
         },
         "type": {
           "type": "string",
-          "description": "Type of the activity we're pausing."
+          "description": "Unpause all running activities with of this type."
         },
         "resetAttempts": {
           "type": "boolean",
-          "title": "unpause can also reset the number of attempts"
+          "description": "Providing this flag will also reset the number of attempts."
         },
         "resetHeartbeat": {
           "type": "boolean",
-          "title": "unpause can also reset the heartbeat details"
+          "description": "Providing this flag will also reset the heartbeat details."
         },
         "jitter": {
           "type": "string",
@@ -6640,11 +6640,11 @@
         },
         "id": {
           "type": "string",
-          "description": "ID of the activity we're pausing."
+          "description": "Only activity with this ID will be updated."
         },
         "type": {
           "type": "string",
-          "description": "Type of the activity we're pausing."
+          "description": "Update all running activities of this type."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -477,16 +477,16 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/activities/pause-by-id": {
+    "/api/v1/namespaces/{namespace}/activities/pause": {
       "post": {
-        "summary": "PauseActivityById pauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be paused\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
-        "description": "Pausing an activity means:\n- If the activity is currently waiting for a retry or is running and subsequently fails,\n  it will not be rescheduled until it is unpause.\n- If the activity is already paused, calling this method will have no effect.\n- If the activity is running and finishes successfully, the activity will be completed.\n- If the activity is running and finishes with failure:\n  * if there is no retry left - the activity will be completed.\n  * if there are more retries left - the activity will be paused.\nFor long-running activities:\n- activities in paused state will send a cancellation with \"activity_paused\" set to 'true' in response to 'RecordActivityTaskHeartbeat'.\n- The activity should respond to the cancellation accordingly.",
-        "operationId": "PauseActivityById2",
+        "summary": "PauseActivity pauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be paused",
+        "description": "Pausing an activity means:\n- If the activity is currently waiting for a retry or is running and subsequently fails,\n  it will not be rescheduled until it is unpause.\n- If the activity is already paused, calling this method will have no effect.\n- If the activity is running and finishes successfully, the activity will be completed.\n- If the activity is running and finishes with failure:\n  * if there is no retry left - the activity will be completed.\n  * if there are more retries left - the activity will be paused.\nFor long-running activities:\n- activities in paused state will send a cancellation with \"activity_paused\" set to 'true' in response to 'RecordActivityTaskHeartbeat'.\n- The activity should respond to the cancellation accordingly.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type",
+        "operationId": "PauseActivity2",
         "responses": {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1PauseActivityByIdResponse"
+              "$ref": "#/definitions/v1PauseActivityResponse"
             }
           },
           "default": {
@@ -509,7 +509,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/WorkflowServicePauseActivityByIdBody"
+              "$ref": "#/definitions/WorkflowServicePauseActivityBody"
             }
           }
         ],
@@ -518,16 +518,16 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/activities/reset-by-id": {
+    "/api/v1/namespaces/{namespace}/activities/reset": {
       "post": {
-        "summary": "ResetActivityById resets the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be reset.",
-        "description": "Resetting an activity means:\n* number of attempts will be reset to 0.\n* activity timeouts will be reset.\n* if the activity is waiting for retry, and it is not paused or 'keep_paused' is not provided:\n   it will be scheduled immediately (* see 'jitter' flag),\n\nFlags:\n\n'jitter': the activity will be scheduled at a random time within the jitter duration.\nIf the activity currently paused it will be unpause, unless 'keep_paused' flag is provided.\n'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.\n'keep_paused': if the activity is paused, it will remain paused.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
-        "operationId": "ResetActivityById2",
+        "summary": "ResetActivity resets the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be reset.",
+        "description": "Resetting an activity means:\n* number of attempts will be reset to 0.\n* activity timeouts will be reset.\n* if the activity is waiting for retry, and it is not paused or 'keep_paused' is not provided:\n   it will be scheduled immediately (* see 'jitter' flag),\n\nFlags:\n\n'jitter': the activity will be scheduled at a random time within the jitter duration.\nIf the activity currently paused it will be unpause, unless 'keep_paused' flag is provided.\n'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.\n'keep_paused': if the activity is paused, it will remain paused.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type.",
+        "operationId": "ResetActivity2",
         "responses": {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1ResetActivityByIdResponse"
+              "$ref": "#/definitions/v1ResetActivityResponse"
             }
           },
           "default": {
@@ -550,7 +550,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/WorkflowServiceResetActivityByIdBody"
+              "$ref": "#/definitions/WorkflowServiceResetActivityBody"
             }
           }
         ],
@@ -559,16 +559,16 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/activities/unpause-by-id": {
+    "/api/v1/namespaces/{namespace}/activities/unpause": {
       "post": {
-        "summary": "UnpauseActivityById unpauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be unpause.",
-        "description": "If activity is not paused, this call will have no effect.\nIf the activity is waiting for retry, it will be scheduled immediately (* see 'jitter' flag).\nOnce the activity is unpause, all timeout timers will be regenerated.\n\nFlags:\n'jitter': the activity will be scheduled at a random time within the jitter duration.\n'reset_attempts': the number of attempts will be reset.\n'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
-        "operationId": "UnpauseActivityById2",
+        "summary": "UnpauseActivity unpauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be unpause.",
+        "description": "If activity is not paused, this call will have no effect.\nIf the activity is waiting for retry, it will be scheduled immediately (* see 'jitter' flag).\nOnce the activity is unpause, all timeout timers will be regenerated.\n\nFlags:\n'jitter': the activity will be scheduled at a random time within the jitter duration.\n'reset_attempts': the number of attempts will be reset.\n'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type",
+        "operationId": "UnpauseActivity2",
         "responses": {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1UnpauseActivityByIdResponse"
+              "$ref": "#/definitions/v1UnpauseActivityResponse"
             }
           },
           "default": {
@@ -591,7 +591,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/WorkflowServiceUnpauseActivityByIdBody"
+              "$ref": "#/definitions/WorkflowServiceUnpauseActivityBody"
             }
           }
         ],
@@ -600,15 +600,15 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/activities/update-options-by-id": {
+    "/api/v1/namespaces/{namespace}/activities/update-options": {
       "post": {
-        "summary": "UpdateActivityOptionsById is called by the client to update the options of an activity by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be updated.",
-        "operationId": "UpdateActivityOptionsById2",
+        "summary": "UpdateActivityOptions is called by the client to update the options of an activity by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be updated.",
+        "operationId": "UpdateActivityOptions2",
         "responses": {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1UpdateActivityOptionsByIdResponse"
+              "$ref": "#/definitions/v1UpdateActivityOptionsResponse"
             }
           },
           "default": {
@@ -631,7 +631,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/WorkflowServiceUpdateActivityOptionsByIdBody"
+              "$ref": "#/definitions/WorkflowServiceUpdateActivityOptionsBody"
             }
           }
         ],
@@ -3479,16 +3479,16 @@
         ]
       }
     },
-    "/namespaces/{namespace}/activities/pause-by-id": {
+    "/namespaces/{namespace}/activities/pause": {
       "post": {
-        "summary": "PauseActivityById pauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be paused\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
-        "description": "Pausing an activity means:\n- If the activity is currently waiting for a retry or is running and subsequently fails,\n  it will not be rescheduled until it is unpause.\n- If the activity is already paused, calling this method will have no effect.\n- If the activity is running and finishes successfully, the activity will be completed.\n- If the activity is running and finishes with failure:\n  * if there is no retry left - the activity will be completed.\n  * if there are more retries left - the activity will be paused.\nFor long-running activities:\n- activities in paused state will send a cancellation with \"activity_paused\" set to 'true' in response to 'RecordActivityTaskHeartbeat'.\n- The activity should respond to the cancellation accordingly.",
-        "operationId": "PauseActivityById",
+        "summary": "PauseActivity pauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be paused",
+        "description": "Pausing an activity means:\n- If the activity is currently waiting for a retry or is running and subsequently fails,\n  it will not be rescheduled until it is unpause.\n- If the activity is already paused, calling this method will have no effect.\n- If the activity is running and finishes successfully, the activity will be completed.\n- If the activity is running and finishes with failure:\n  * if there is no retry left - the activity will be completed.\n  * if there are more retries left - the activity will be paused.\nFor long-running activities:\n- activities in paused state will send a cancellation with \"activity_paused\" set to 'true' in response to 'RecordActivityTaskHeartbeat'.\n- The activity should respond to the cancellation accordingly.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type",
+        "operationId": "PauseActivity",
         "responses": {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1PauseActivityByIdResponse"
+              "$ref": "#/definitions/v1PauseActivityResponse"
             }
           },
           "default": {
@@ -3511,7 +3511,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/WorkflowServicePauseActivityByIdBody"
+              "$ref": "#/definitions/WorkflowServicePauseActivityBody"
             }
           }
         ],
@@ -3520,16 +3520,16 @@
         ]
       }
     },
-    "/namespaces/{namespace}/activities/reset-by-id": {
+    "/namespaces/{namespace}/activities/reset": {
       "post": {
-        "summary": "ResetActivityById resets the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be reset.",
-        "description": "Resetting an activity means:\n* number of attempts will be reset to 0.\n* activity timeouts will be reset.\n* if the activity is waiting for retry, and it is not paused or 'keep_paused' is not provided:\n   it will be scheduled immediately (* see 'jitter' flag),\n\nFlags:\n\n'jitter': the activity will be scheduled at a random time within the jitter duration.\nIf the activity currently paused it will be unpause, unless 'keep_paused' flag is provided.\n'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.\n'keep_paused': if the activity is paused, it will remain paused.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
-        "operationId": "ResetActivityById",
+        "summary": "ResetActivity resets the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be reset.",
+        "description": "Resetting an activity means:\n* number of attempts will be reset to 0.\n* activity timeouts will be reset.\n* if the activity is waiting for retry, and it is not paused or 'keep_paused' is not provided:\n   it will be scheduled immediately (* see 'jitter' flag),\n\nFlags:\n\n'jitter': the activity will be scheduled at a random time within the jitter duration.\nIf the activity currently paused it will be unpause, unless 'keep_paused' flag is provided.\n'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.\n'keep_paused': if the activity is paused, it will remain paused.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type.",
+        "operationId": "ResetActivity",
         "responses": {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1ResetActivityByIdResponse"
+              "$ref": "#/definitions/v1ResetActivityResponse"
             }
           },
           "default": {
@@ -3552,7 +3552,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/WorkflowServiceResetActivityByIdBody"
+              "$ref": "#/definitions/WorkflowServiceResetActivityBody"
             }
           }
         ],
@@ -3561,16 +3561,16 @@
         ]
       }
     },
-    "/namespaces/{namespace}/activities/unpause-by-id": {
+    "/namespaces/{namespace}/activities/unpause": {
       "post": {
-        "summary": "UnpauseActivityById unpauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be unpause.",
-        "description": "If activity is not paused, this call will have no effect.\nIf the activity is waiting for retry, it will be scheduled immediately (* see 'jitter' flag).\nOnce the activity is unpause, all timeout timers will be regenerated.\n\nFlags:\n'jitter': the activity will be scheduled at a random time within the jitter duration.\n'reset_attempts': the number of attempts will be reset.\n'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID.",
-        "operationId": "UnpauseActivityById",
+        "summary": "UnpauseActivity unpauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be unpause.",
+        "description": "If activity is not paused, this call will have no effect.\nIf the activity is waiting for retry, it will be scheduled immediately (* see 'jitter' flag).\nOnce the activity is unpause, all timeout timers will be regenerated.\n\nFlags:\n'jitter': the activity will be scheduled at a random time within the jitter duration.\n'reset_attempts': the number of attempts will be reset.\n'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type",
+        "operationId": "UnpauseActivity",
         "responses": {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1UnpauseActivityByIdResponse"
+              "$ref": "#/definitions/v1UnpauseActivityResponse"
             }
           },
           "default": {
@@ -3593,7 +3593,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/WorkflowServiceUnpauseActivityByIdBody"
+              "$ref": "#/definitions/WorkflowServiceUnpauseActivityBody"
             }
           }
         ],
@@ -3602,15 +3602,15 @@
         ]
       }
     },
-    "/namespaces/{namespace}/activities/update-options-by-id": {
+    "/namespaces/{namespace}/activities/update-options": {
       "post": {
-        "summary": "UpdateActivityOptionsById is called by the client to update the options of an activity by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be updated.",
-        "operationId": "UpdateActivityOptionsById",
+        "summary": "UpdateActivityOptions is called by the client to update the options of an activity by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be updated.",
+        "operationId": "UpdateActivityOptions",
         "responses": {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1UpdateActivityOptionsByIdResponse"
+              "$ref": "#/definitions/v1UpdateActivityOptionsResponse"
             }
           },
           "default": {
@@ -3633,7 +3633,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/WorkflowServiceUpdateActivityOptionsByIdBody"
+              "$ref": "#/definitions/WorkflowServiceUpdateActivityOptionsBody"
             }
           }
         ],
@@ -5870,16 +5870,12 @@
         }
       }
     },
-    "WorkflowServicePauseActivityByIdBody": {
+    "WorkflowServicePauseActivityBody": {
       "type": "object",
       "properties": {
-        "workflowId": {
-          "type": "string",
-          "description": "ID of the workflow which scheduled this activity."
-        },
-        "runId": {
-          "type": "string",
-          "description": "Run ID of the workflow which scheduled this activity.\nIf empty - latest workflow is used."
+        "execution": {
+          "$ref": "#/definitions/v1WorkflowExecution",
+          "title": "Execution info of the workflow which scheduled this activity"
         },
         "identity": {
           "type": "string",
@@ -6008,20 +6004,24 @@
         }
       }
     },
-    "WorkflowServiceResetActivityByIdBody": {
+    "WorkflowServiceResetActivityBody": {
       "type": "object",
       "properties": {
-        "workflowId": {
-          "type": "string",
-          "description": "ID of the workflow which scheduled this activity."
-        },
-        "runId": {
-          "type": "string",
-          "description": "Run ID of the workflow which scheduled this activity.\nIf empty - latest workflow is used."
+        "execution": {
+          "$ref": "#/definitions/v1WorkflowExecution",
+          "title": "Execution info of the workflow which scheduled this activity"
         },
         "identity": {
           "type": "string",
           "description": "The identity of the client who initiated this request."
+        },
+        "id": {
+          "type": "string",
+          "description": "ID of the activity we're pausing."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the activity we're pausing."
         },
         "resetHeartbeat": {
           "type": "boolean",
@@ -6034,14 +6034,6 @@
         "jitter": {
           "type": "string",
           "title": "If set, and activity is in backoff, the activity will start at a random time within the specified jitter duration.\n(unless it is paused and keep_paused is set)"
-        },
-        "id": {
-          "type": "string",
-          "description": "ID of the activity we're pausing."
-        },
-        "type": {
-          "type": "string",
-          "description": "Type of the activity we're pausing."
         }
       }
     },
@@ -6594,16 +6586,12 @@
         }
       }
     },
-    "WorkflowServiceUnpauseActivityByIdBody": {
+    "WorkflowServiceUnpauseActivityBody": {
       "type": "object",
       "properties": {
-        "workflowId": {
-          "type": "string",
-          "description": "ID of the workflow which scheduled this activity."
-        },
-        "runId": {
-          "type": "string",
-          "description": "Run ID of the workflow which scheduled this activity.\nIf empty - latest workflow is used."
+        "execution": {
+          "$ref": "#/definitions/v1WorkflowExecution",
+          "title": "Execution info of the workflow which scheduled this activity"
         },
         "identity": {
           "type": "string",
@@ -6631,16 +6619,12 @@
         }
       }
     },
-    "WorkflowServiceUpdateActivityOptionsByIdBody": {
+    "WorkflowServiceUpdateActivityOptionsBody": {
       "type": "object",
       "properties": {
-        "workflowId": {
-          "type": "string",
-          "title": "ID of the workflow which scheduled this activity"
-        },
-        "runId": {
-          "type": "string",
-          "title": "Run ID of the workflow which scheduled this activity\nif empty - latest workflow is used"
+        "execution": {
+          "$ref": "#/definitions/v1WorkflowExecution",
+          "title": "Execution info of the workflow which scheduled this activity"
         },
         "identity": {
           "type": "string",
@@ -10025,7 +10009,7 @@
     "v1PatchScheduleResponse": {
       "type": "object"
     },
-    "v1PauseActivityByIdResponse": {
+    "v1PauseActivityResponse": {
       "type": "object"
     },
     "v1Payload": {
@@ -10801,7 +10785,7 @@
     "v1RequestCancelWorkflowExecutionResponse": {
       "type": "object"
     },
-    "v1ResetActivityByIdResponse": {
+    "v1ResetActivityResponse": {
       "type": "object"
     },
     "v1ResetOptions": {
@@ -12460,7 +12444,7 @@
         }
       }
     },
-    "v1UnpauseActivityByIdResponse": {
+    "v1UnpauseActivityResponse": {
       "type": "object"
     },
     "v1UnsuccessfulOperationError": {
@@ -12475,7 +12459,7 @@
         }
       }
     },
-    "v1UpdateActivityOptionsByIdResponse": {
+    "v1UpdateActivityOptionsResponse": {
       "type": "object",
       "properties": {
         "activityOptions": {

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -416,14 +416,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/activities/pause-by-id:
+  /api/v1/namespaces/{namespace}/activities/pause:
     post:
       tags:
         - WorkflowService
       description: |-
-        PauseActivityById pauses the execution of an activity specified by its ID or type.
+        PauseActivity pauses the execution of an activity specified by its ID or type.
          If there are multiple pending activities of the provided type - all of them will be paused
-         Returns a `NotFound` error if there is no pending activity with the provided ID.
 
          Pausing an activity means:
          - If the activity is currently waiting for a retry or is running and subsequently fails,
@@ -436,9 +435,9 @@ paths:
          For long-running activities:
          - activities in paused state will send a cancellation with "activity_paused" set to 'true' in response to 'RecordActivityTaskHeartbeat'.
          - The activity should respond to the cancellation accordingly.
-         (-- api-linter: core::0136::prepositions=disabled
-             aip.dev/not-precedent: "By" is used to indicate request type. --)
-      operationId: PauseActivityById
+
+         Returns a `NotFound` error if there is no pending activity with the provided ID or type
+      operationId: PauseActivity
       parameters:
         - name: namespace
           in: path
@@ -450,7 +449,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PauseActivityByIdRequest'
+              $ref: '#/components/schemas/PauseActivityRequest'
         required: true
       responses:
         "200":
@@ -458,19 +457,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PauseActivityByIdResponse'
+                $ref: '#/components/schemas/PauseActivityResponse'
         default:
           description: Default error response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/activities/reset-by-id:
+  /api/v1/namespaces/{namespace}/activities/reset:
     post:
       tags:
         - WorkflowService
       description: |-
-        ResetActivityById resets the execution of an activity specified by its ID or type.
+        ResetActivity resets the execution of an activity specified by its ID or type.
          If there are multiple pending activities of the provided type - all of them will be reset.
 
          Resetting an activity means:
@@ -486,10 +485,8 @@ paths:
          'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.
          'keep_paused': if the activity is paused, it will remain paused.
 
-         Returns a `NotFound` error if there is no pending activity with the provided ID.
-         (-- api-linter: core::0136::prepositions=disabled
-             aip.dev/not-precedent: "By" is used to indicate request type. --)
-      operationId: ResetActivityById
+         Returns a `NotFound` error if there is no pending activity with the provided ID or type.
+      operationId: ResetActivity
       parameters:
         - name: namespace
           in: path
@@ -501,7 +498,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ResetActivityByIdRequest'
+              $ref: '#/components/schemas/ResetActivityRequest'
         required: true
       responses:
         "200":
@@ -509,19 +506,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ResetActivityByIdResponse'
+                $ref: '#/components/schemas/ResetActivityResponse'
         default:
           description: Default error response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/activities/unpause-by-id:
+  /api/v1/namespaces/{namespace}/activities/unpause:
     post:
       tags:
         - WorkflowService
       description: |-
-        UnpauseActivityById unpauses the execution of an activity specified by its ID or type.
+        UnpauseActivity unpauses the execution of an activity specified by its ID or type.
          If there are multiple pending activities of the provided type - all of them will be unpause.
 
          If activity is not paused, this call will have no effect.
@@ -533,10 +530,8 @@ paths:
          'reset_attempts': the number of attempts will be reset.
          'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.
 
-         Returns a `NotFound` error if there is no pending activity with the provided ID.
-         (-- api-linter: core::0136::prepositions=disabled
-             aip.dev/not-precedent: "By" is used to indicate request type. --)
-      operationId: UnpauseActivityById
+         Returns a `NotFound` error if there is no pending activity with the provided ID or type
+      operationId: UnpauseActivity
       parameters:
         - name: namespace
           in: path
@@ -548,7 +543,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UnpauseActivityByIdRequest'
+              $ref: '#/components/schemas/UnpauseActivityRequest'
         required: true
       responses:
         "200":
@@ -556,23 +551,21 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UnpauseActivityByIdResponse'
+                $ref: '#/components/schemas/UnpauseActivityResponse'
         default:
           description: Default error response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/activities/update-options-by-id:
+  /api/v1/namespaces/{namespace}/activities/update-options:
     post:
       tags:
         - WorkflowService
       description: |-
-        UpdateActivityOptionsById is called by the client to update the options of an activity by its ID or type.
+        UpdateActivityOptions is called by the client to update the options of an activity by its ID or type.
          If there are multiple pending activities of the provided type - all of them will be updated.
-         (-- api-linter: core::0136::prepositions=disabled
-             aip.dev/not-precedent: "By" is used to indicate request type. --)
-      operationId: UpdateActivityOptionsById
+      operationId: UpdateActivityOptions
       parameters:
         - name: namespace
           in: path
@@ -584,7 +577,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdateActivityOptionsByIdRequest'
+              $ref: '#/components/schemas/UpdateActivityOptionsRequest'
         required: true
       responses:
         "200":
@@ -592,7 +585,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpdateActivityOptionsByIdResponse'
+                $ref: '#/components/schemas/UpdateActivityOptionsResponse'
         default:
           description: Default error response
           content:
@@ -3090,14 +3083,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/activities/pause-by-id:
+  /namespaces/{namespace}/activities/pause:
     post:
       tags:
         - WorkflowService
       description: |-
-        PauseActivityById pauses the execution of an activity specified by its ID or type.
+        PauseActivity pauses the execution of an activity specified by its ID or type.
          If there are multiple pending activities of the provided type - all of them will be paused
-         Returns a `NotFound` error if there is no pending activity with the provided ID.
 
          Pausing an activity means:
          - If the activity is currently waiting for a retry or is running and subsequently fails,
@@ -3110,9 +3102,9 @@ paths:
          For long-running activities:
          - activities in paused state will send a cancellation with "activity_paused" set to 'true' in response to 'RecordActivityTaskHeartbeat'.
          - The activity should respond to the cancellation accordingly.
-         (-- api-linter: core::0136::prepositions=disabled
-             aip.dev/not-precedent: "By" is used to indicate request type. --)
-      operationId: PauseActivityById
+
+         Returns a `NotFound` error if there is no pending activity with the provided ID or type
+      operationId: PauseActivity
       parameters:
         - name: namespace
           in: path
@@ -3124,7 +3116,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PauseActivityByIdRequest'
+              $ref: '#/components/schemas/PauseActivityRequest'
         required: true
       responses:
         "200":
@@ -3132,19 +3124,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PauseActivityByIdResponse'
+                $ref: '#/components/schemas/PauseActivityResponse'
         default:
           description: Default error response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/activities/reset-by-id:
+  /namespaces/{namespace}/activities/reset:
     post:
       tags:
         - WorkflowService
       description: |-
-        ResetActivityById resets the execution of an activity specified by its ID or type.
+        ResetActivity resets the execution of an activity specified by its ID or type.
          If there are multiple pending activities of the provided type - all of them will be reset.
 
          Resetting an activity means:
@@ -3160,10 +3152,8 @@ paths:
          'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.
          'keep_paused': if the activity is paused, it will remain paused.
 
-         Returns a `NotFound` error if there is no pending activity with the provided ID.
-         (-- api-linter: core::0136::prepositions=disabled
-             aip.dev/not-precedent: "By" is used to indicate request type. --)
-      operationId: ResetActivityById
+         Returns a `NotFound` error if there is no pending activity with the provided ID or type.
+      operationId: ResetActivity
       parameters:
         - name: namespace
           in: path
@@ -3175,7 +3165,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ResetActivityByIdRequest'
+              $ref: '#/components/schemas/ResetActivityRequest'
         required: true
       responses:
         "200":
@@ -3183,19 +3173,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ResetActivityByIdResponse'
+                $ref: '#/components/schemas/ResetActivityResponse'
         default:
           description: Default error response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/activities/unpause-by-id:
+  /namespaces/{namespace}/activities/unpause:
     post:
       tags:
         - WorkflowService
       description: |-
-        UnpauseActivityById unpauses the execution of an activity specified by its ID or type.
+        UnpauseActivity unpauses the execution of an activity specified by its ID or type.
          If there are multiple pending activities of the provided type - all of them will be unpause.
 
          If activity is not paused, this call will have no effect.
@@ -3207,10 +3197,8 @@ paths:
          'reset_attempts': the number of attempts will be reset.
          'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.
 
-         Returns a `NotFound` error if there is no pending activity with the provided ID.
-         (-- api-linter: core::0136::prepositions=disabled
-             aip.dev/not-precedent: "By" is used to indicate request type. --)
-      operationId: UnpauseActivityById
+         Returns a `NotFound` error if there is no pending activity with the provided ID or type
+      operationId: UnpauseActivity
       parameters:
         - name: namespace
           in: path
@@ -3222,7 +3210,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UnpauseActivityByIdRequest'
+              $ref: '#/components/schemas/UnpauseActivityRequest'
         required: true
       responses:
         "200":
@@ -3230,23 +3218,21 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UnpauseActivityByIdResponse'
+                $ref: '#/components/schemas/UnpauseActivityResponse'
         default:
           description: Default error response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/activities/update-options-by-id:
+  /namespaces/{namespace}/activities/update-options:
     post:
       tags:
         - WorkflowService
       description: |-
-        UpdateActivityOptionsById is called by the client to update the options of an activity by its ID or type.
+        UpdateActivityOptions is called by the client to update the options of an activity by its ID or type.
          If there are multiple pending activities of the provided type - all of them will be updated.
-         (-- api-linter: core::0136::prepositions=disabled
-             aip.dev/not-precedent: "By" is used to indicate request type. --)
-      operationId: UpdateActivityOptionsById
+      operationId: UpdateActivityOptions
       parameters:
         - name: namespace
           in: path
@@ -3258,7 +3244,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdateActivityOptionsByIdRequest'
+              $ref: '#/components/schemas/UpdateActivityOptionsRequest'
         required: true
       responses:
         "200":
@@ -3266,7 +3252,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpdateActivityOptionsByIdResponse'
+                $ref: '#/components/schemas/UpdateActivityOptionsResponse'
         default:
           description: Default error response
           content:
@@ -7516,20 +7502,16 @@ components:
     PatchScheduleResponse:
       type: object
       properties: {}
-    PauseActivityByIdRequest:
+    PauseActivityRequest:
       type: object
       properties:
         namespace:
           type: string
           description: Namespace of the workflow which scheduled this activity.
-        workflowId:
-          type: string
-          description: ID of the workflow which scheduled this activity.
-        runId:
-          type: string
-          description: |-
-            Run ID of the workflow which scheduled this activity.
-             If empty - latest workflow is used.
+        execution:
+          allOf:
+            - $ref: '#/components/schemas/WorkflowExecution'
+          description: Execution info of the workflow which scheduled this activity
         identity:
           type: string
           description: The identity of the client who initiated this request.
@@ -7539,7 +7521,7 @@ components:
         type:
           type: string
           description: Type of the activity we're pausing.
-    PauseActivityByIdResponse:
+    PauseActivityResponse:
       type: object
       properties: {}
     Payload:
@@ -8136,23 +8118,25 @@ components:
     RequestCancelWorkflowExecutionResponse:
       type: object
       properties: {}
-    ResetActivityByIdRequest:
+    ResetActivityRequest:
       type: object
       properties:
         namespace:
           type: string
           description: Namespace of the workflow which scheduled this activity.
-        workflowId:
-          type: string
-          description: ID of the workflow which scheduled this activity.
-        runId:
-          type: string
-          description: |-
-            Run ID of the workflow which scheduled this activity.
-             If empty - latest workflow is used.
+        execution:
+          allOf:
+            - $ref: '#/components/schemas/WorkflowExecution'
+          description: Execution info of the workflow which scheduled this activity
         identity:
           type: string
           description: The identity of the client who initiated this request.
+        id:
+          type: string
+          description: ID of the activity we're pausing.
+        type:
+          type: string
+          description: Type of the activity we're pausing.
         resetHeartbeat:
           type: boolean
           description: |-
@@ -8167,13 +8151,7 @@ components:
           description: |-
             If set, and activity is in backoff, the activity will start at a random time within the specified jitter duration.
              (unless it is paused and keep_paused is set)
-        id:
-          type: string
-          description: ID of the activity we're pausing.
-        type:
-          type: string
-          description: Type of the activity we're pausing.
-    ResetActivityByIdResponse:
+    ResetActivityResponse:
       type: object
       properties: {}
     ResetOptions:
@@ -9817,20 +9795,16 @@ components:
           type: string
           description: If set, override overlap policy for this one request.
           format: enum
-    UnpauseActivityByIdRequest:
+    UnpauseActivityRequest:
       type: object
       properties:
         namespace:
           type: string
           description: Namespace of the workflow which scheduled this activity.
-        workflowId:
-          type: string
-          description: ID of the workflow which scheduled this activity.
-        runId:
-          type: string
-          description: |-
-            Run ID of the workflow which scheduled this activity.
-             If empty - latest workflow is used.
+        execution:
+          allOf:
+            - $ref: '#/components/schemas/WorkflowExecution'
+          description: Execution info of the workflow which scheduled this activity
         identity:
           type: string
           description: The identity of the client who initiated this request.
@@ -9850,23 +9824,19 @@ components:
           pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
           type: string
           description: If set, the activity will start at a random time within the specified jitter duration.
-    UnpauseActivityByIdResponse:
+    UnpauseActivityResponse:
       type: object
       properties: {}
-    UpdateActivityOptionsByIdRequest:
+    UpdateActivityOptionsRequest:
       type: object
       properties:
         namespace:
           type: string
           description: Namespace of the workflow which scheduled this activity
-        workflowId:
-          type: string
-          description: ID of the workflow which scheduled this activity
-        runId:
-          type: string
-          description: |-
-            Run ID of the workflow which scheduled this activity
-             if empty - latest workflow is used
+        execution:
+          allOf:
+            - $ref: '#/components/schemas/WorkflowExecution'
+          description: Execution info of the workflow which scheduled this activity
         identity:
           type: string
           description: The identity of the client who initiated this request
@@ -9884,7 +9854,7 @@ components:
         type:
           type: string
           description: Type of the activity we're pausing.
-    UpdateActivityOptionsByIdResponse:
+    UpdateActivityOptionsResponse:
       type: object
       properties:
         activityOptions:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -421,12 +421,13 @@ paths:
       tags:
         - WorkflowService
       description: |-
-        PauseActivityById pauses the execution of an activity specified by its ID.
+        PauseActivityById pauses the execution of an activity specified by its ID or type.
+         If there are multiple pending activities of the provided type - all of them will be paused
          Returns a `NotFound` error if there is no pending activity with the provided ID.
 
          Pausing an activity means:
          - If the activity is currently waiting for a retry or is running and subsequently fails,
-           it will not be rescheduled until it is unpaused.
+           it will not be rescheduled until it is unpause.
          - If the activity is already paused, calling this method will have no effect.
          - If the activity is running and finishes successfully, the activity will be completed.
          - If the activity is running and finishes with failure:
@@ -469,15 +470,23 @@ paths:
       tags:
         - WorkflowService
       description: |-
-        ResetActivityById unpauses the execution of an activity specified by its ID.
-         Returns a `NotFound` error if there is no pending activity with the provided ID.
+        ResetActivityById resets the execution of an activity specified by its ID or type.
+         If there are multiple pending activities of the provided type - all of them will be reset.
+
          Resetting an activity means:
          * number of attempts will be reset to 0.
-         * activity timeouts will be resetted.
-         If the activity currently running:
-         *  if 'no_wait' flag is provided, a new instance of the activity will be scheduled immediately.
-         *  if 'no_wait' flag is not provided, a new instance of the  activity will be scheduled after current instance completes if needed.
-         If 'reset_heartbeats' flag is set, the activity heartbeat timer and heartbeats will be reset.
+         * activity timeouts will be reset.
+         * if the activity is waiting for retry, and it is not paused or 'keep_paused' is not provided:
+            it will be scheduled immediately (* see 'jitter' flag),
+
+         Flags:
+
+         'jitter': the activity will be scheduled at a random time within the jitter duration.
+         If the activity currently paused it will be unpause, unless 'keep_paused' flag is provided.
+         'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.
+         'keep_paused': if the activity is paused, it will remain paused.
+
+         Returns a `NotFound` error if there is no pending activity with the provided ID.
          (-- api-linter: core::0136::prepositions=disabled
              aip.dev/not-precedent: "By" is used to indicate request type. --)
       operationId: ResetActivityById
@@ -512,18 +521,19 @@ paths:
       tags:
         - WorkflowService
       description: |-
-        UnpauseActivityById unpauses the execution of an activity specified by its ID.
+        UnpauseActivityById unpauses the execution of an activity specified by its ID or type.
+         If there are multiple pending activities of the provided type - all of them will be unpause.
+
+         If activity is not paused, this call will have no effect.
+         If the activity is waiting for retry, it will be scheduled immediately (* see 'jitter' flag).
+         Once the activity is unpause, all timeout timers will be regenerated.
+
+         Flags:
+         'jitter': the activity will be scheduled at a random time within the jitter duration.
+         'reset_attempts': the number of attempts will be reset.
+         'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.
+
          Returns a `NotFound` error if there is no pending activity with the provided ID.
-         There are two 'modes' of unpausing an activity:
-         'resume' - If the activity is paused, it will be resumed and scheduled for execution.
-            * If the activity is currently running Unpause with 'resume' has no effect.
-            * if 'no_wait' flag is set and the activity is waiting, the activity will be scheduled immediately.
-         'reset' - If the activity is paused, it will be reset to its initial state and (depending on parameters) scheduled for execution.
-            * If the activity is currently running, Unpause with 'reset' will reset the number of attempts.
-            * if 'no_wait' flag is set, the activity will be scheduled immediately.
-            * if 'reset_heartbeats' flag is set, the activity heartbeat timer and heartbeats will be reset.
-         If the activity is in waiting for retry and past it retry timeout, it will be scheduled immediately.
-         Once the activity is unpaused, all timeout timers will be regenerated.
          (-- api-linter: core::0136::prepositions=disabled
              aip.dev/not-precedent: "By" is used to indicate request type. --)
       operationId: UnpauseActivityById
@@ -558,7 +568,8 @@ paths:
       tags:
         - WorkflowService
       description: |-
-        UpdateActivityOptionsById is called by the client to update the options of an activity
+        UpdateActivityOptionsById is called by the client to update the options of an activity by its ID or type.
+         If there are multiple pending activities of the provided type - all of them will be updated.
          (-- api-linter: core::0136::prepositions=disabled
              aip.dev/not-precedent: "By" is used to indicate request type. --)
       operationId: UpdateActivityOptionsById
@@ -3084,12 +3095,13 @@ paths:
       tags:
         - WorkflowService
       description: |-
-        PauseActivityById pauses the execution of an activity specified by its ID.
+        PauseActivityById pauses the execution of an activity specified by its ID or type.
+         If there are multiple pending activities of the provided type - all of them will be paused
          Returns a `NotFound` error if there is no pending activity with the provided ID.
 
          Pausing an activity means:
          - If the activity is currently waiting for a retry or is running and subsequently fails,
-           it will not be rescheduled until it is unpaused.
+           it will not be rescheduled until it is unpause.
          - If the activity is already paused, calling this method will have no effect.
          - If the activity is running and finishes successfully, the activity will be completed.
          - If the activity is running and finishes with failure:
@@ -3132,15 +3144,23 @@ paths:
       tags:
         - WorkflowService
       description: |-
-        ResetActivityById unpauses the execution of an activity specified by its ID.
-         Returns a `NotFound` error if there is no pending activity with the provided ID.
+        ResetActivityById resets the execution of an activity specified by its ID or type.
+         If there are multiple pending activities of the provided type - all of them will be reset.
+
          Resetting an activity means:
          * number of attempts will be reset to 0.
-         * activity timeouts will be resetted.
-         If the activity currently running:
-         *  if 'no_wait' flag is provided, a new instance of the activity will be scheduled immediately.
-         *  if 'no_wait' flag is not provided, a new instance of the  activity will be scheduled after current instance completes if needed.
-         If 'reset_heartbeats' flag is set, the activity heartbeat timer and heartbeats will be reset.
+         * activity timeouts will be reset.
+         * if the activity is waiting for retry, and it is not paused or 'keep_paused' is not provided:
+            it will be scheduled immediately (* see 'jitter' flag),
+
+         Flags:
+
+         'jitter': the activity will be scheduled at a random time within the jitter duration.
+         If the activity currently paused it will be unpause, unless 'keep_paused' flag is provided.
+         'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.
+         'keep_paused': if the activity is paused, it will remain paused.
+
+         Returns a `NotFound` error if there is no pending activity with the provided ID.
          (-- api-linter: core::0136::prepositions=disabled
              aip.dev/not-precedent: "By" is used to indicate request type. --)
       operationId: ResetActivityById
@@ -3175,18 +3195,19 @@ paths:
       tags:
         - WorkflowService
       description: |-
-        UnpauseActivityById unpauses the execution of an activity specified by its ID.
+        UnpauseActivityById unpauses the execution of an activity specified by its ID or type.
+         If there are multiple pending activities of the provided type - all of them will be unpause.
+
+         If activity is not paused, this call will have no effect.
+         If the activity is waiting for retry, it will be scheduled immediately (* see 'jitter' flag).
+         Once the activity is unpause, all timeout timers will be regenerated.
+
+         Flags:
+         'jitter': the activity will be scheduled at a random time within the jitter duration.
+         'reset_attempts': the number of attempts will be reset.
+         'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.
+
          Returns a `NotFound` error if there is no pending activity with the provided ID.
-         There are two 'modes' of unpausing an activity:
-         'resume' - If the activity is paused, it will be resumed and scheduled for execution.
-            * If the activity is currently running Unpause with 'resume' has no effect.
-            * if 'no_wait' flag is set and the activity is waiting, the activity will be scheduled immediately.
-         'reset' - If the activity is paused, it will be reset to its initial state and (depending on parameters) scheduled for execution.
-            * If the activity is currently running, Unpause with 'reset' will reset the number of attempts.
-            * if 'no_wait' flag is set, the activity will be scheduled immediately.
-            * if 'reset_heartbeats' flag is set, the activity heartbeat timer and heartbeats will be reset.
-         If the activity is in waiting for retry and past it retry timeout, it will be scheduled immediately.
-         Once the activity is unpaused, all timeout timers will be regenerated.
          (-- api-linter: core::0136::prepositions=disabled
              aip.dev/not-precedent: "By" is used to indicate request type. --)
       operationId: UnpauseActivityById
@@ -3221,7 +3242,8 @@ paths:
       tags:
         - WorkflowService
       description: |-
-        UpdateActivityOptionsById is called by the client to update the options of an activity
+        UpdateActivityOptionsById is called by the client to update the options of an activity by its ID or type.
+         If there are multiple pending activities of the provided type - all of them will be updated.
          (-- api-linter: core::0136::prepositions=disabled
              aip.dev/not-precedent: "By" is used to indicate request type. --)
       operationId: UpdateActivityOptionsById
@@ -7508,15 +7530,15 @@ components:
           description: |-
             Run ID of the workflow which scheduled this activity.
              If empty - latest workflow is used.
-        activityId:
-          type: string
-          description: ID of the activity we're updating.
         identity:
           type: string
           description: The identity of the client who initiated this request.
-        requestId:
+        id:
           type: string
-          description: Used to de-dupe requests.
+          description: ID of the activity we're pausing.
+        type:
+          type: string
+          description: Type of the activity we're pausing.
     PauseActivityByIdResponse:
       type: object
       properties: {}
@@ -8128,25 +8150,29 @@ components:
           description: |-
             Run ID of the workflow which scheduled this activity.
              If empty - latest workflow is used.
-        activityId:
-          type: string
-          description: ID of the activity we're updating.
         identity:
           type: string
           description: The identity of the client who initiated this request.
-        requestId:
-          type: string
-          description: Used to de-dupe requests.
-        noWait:
-          type: boolean
-          description: |-
-            Indicates that activity should be scheduled immediately.
-             If this flag doesn't set, and activity currently running - temporal will wait until activity is completed.
         resetHeartbeat:
           type: boolean
           description: |-
             Indicates that activity should reset heartbeat details.
              This flag will be applied only to the new instance of the activity.
+        keepPaused:
+          type: boolean
+          description: if activity is paused, it will remain paused after reset
+        jitter:
+          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+          type: string
+          description: |-
+            If set, and activity is in backoff, the activity will start at a random time within the specified jitter duration.
+             (unless it is paused and keep_paused is set)
+        id:
+          type: string
+          description: ID of the activity we're pausing.
+        type:
+          type: string
+          description: Type of the activity we're pausing.
     ResetActivityByIdResponse:
       type: object
       properties: {}
@@ -9805,36 +9831,25 @@ components:
           description: |-
             Run ID of the workflow which scheduled this activity.
              If empty - latest workflow is used.
-        activityId:
-          type: string
-          description: ID of the activity we're updating.
         identity:
           type: string
           description: The identity of the client who initiated this request.
-        requestId:
+        id:
           type: string
-          description: Used to de-dupe requests.
-        resume:
-          $ref: '#/components/schemas/UnpauseActivityByIdRequest_ResumeOperation'
-        reset:
-          $ref: '#/components/schemas/UnpauseActivityByIdRequest_ResetOperation'
-    UnpauseActivityByIdRequest_ResetOperation:
-      type: object
-      properties:
-        noWait:
+          description: ID of the activity we're pausing.
+        type:
+          type: string
+          description: Type of the activity we're pausing.
+        resetAttempts:
           type: boolean
-          description: |-
-            Indicates that the activity should be scheduled immediately.
-             Note that this may run simultaneously with any existing executions of the activity.
+          description: unpause can also reset the number of attempts
         resetHeartbeat:
           type: boolean
-          description: If set, the Heartbeat Details will be cleared out to make the Activity start over from the beginning
-    UnpauseActivityByIdRequest_ResumeOperation:
-      type: object
-      properties:
-        noWait:
-          type: boolean
-          description: Indicates that if the activity is waiting to retry, it will  be scheduled immediately.
+          description: unpause can also reset the heartbeat details
+        jitter:
+          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+          type: string
+          description: If set, the activity will start at a random time within the specified jitter duration.
     UnpauseActivityByIdResponse:
       type: object
       properties: {}
@@ -9852,9 +9867,6 @@ components:
           description: |-
             Run ID of the workflow which scheduled this activity
              if empty - latest workflow is used
-        activityId:
-          type: string
-          description: ID of the activity we're updating
         identity:
           type: string
           description: The identity of the client who initiated this request
@@ -9866,9 +9878,12 @@ components:
           type: string
           description: Controls which fields from `activity_options` will be applied
           format: field-mask
-        requestId:
+        id:
           type: string
-          description: Used to de-dupe requests
+          description: ID of the activity we're pausing.
+        type:
+          type: string
+          description: Type of the activity we're pausing.
     UpdateActivityOptionsByIdResponse:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9814,6 +9814,9 @@ components:
         type:
           type: string
           description: Unpause all running activities with of this type.
+        unpauseAll:
+          type: boolean
+          description: Unpause all running activities.
         resetAttempts:
           type: boolean
           description: Providing this flag will also reset the number of attempts.

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -519,10 +519,10 @@ paths:
         - WorkflowService
       description: |-
         UnpauseActivity unpauses the execution of an activity specified by its ID or type.
-         If there are multiple pending activities of the provided type - all of them will be unpause.
+         If there are multiple pending activities of the provided type - all of them will be unpaused.
 
          If activity is not paused, this call will have no effect.
-         If the activity is waiting for retry, it will be scheduled immediately (* see 'jitter' flag).
+         If the activity was paused while waiting for retry, it will be scheduled immediately (* see 'jitter' flag).
          Once the activity is unpause, all timeout timers will be regenerated.
 
          Flags:
@@ -3186,10 +3186,10 @@ paths:
         - WorkflowService
       description: |-
         UnpauseActivity unpauses the execution of an activity specified by its ID or type.
-         If there are multiple pending activities of the provided type - all of them will be unpause.
+         If there are multiple pending activities of the provided type - all of them will be unpaused.
 
          If activity is not paused, this call will have no effect.
-         If the activity is waiting for retry, it will be scheduled immediately (* see 'jitter' flag).
+         If the activity was paused while waiting for retry, it will be scheduled immediately (* see 'jitter' flag).
          Once the activity is unpause, all timeout timers will be regenerated.
 
          Flags:
@@ -7517,10 +7517,10 @@ components:
           description: The identity of the client who initiated this request.
         id:
           type: string
-          description: ID of the activity we're pausing.
+          description: Only activity with this ID will be paused.
         type:
           type: string
-          description: Type of the activity we're pausing.
+          description: Pause all running activities of this type.
     PauseActivityResponse:
       type: object
       properties: {}
@@ -8133,10 +8133,10 @@ components:
           description: The identity of the client who initiated this request.
         id:
           type: string
-          description: ID of the activity we're pausing.
+          description: Only activity with this ID will be reset.
         type:
           type: string
-          description: Type of the activity we're pausing.
+          description: Reset all running activities with of this type.
         resetHeartbeat:
           type: boolean
           description: |-
@@ -9810,16 +9810,16 @@ components:
           description: The identity of the client who initiated this request.
         id:
           type: string
-          description: ID of the activity we're pausing.
+          description: Only activity with this ID will be unpause.
         type:
           type: string
-          description: Type of the activity we're pausing.
+          description: Unpause all running activities with of this type.
         resetAttempts:
           type: boolean
-          description: unpause can also reset the number of attempts
+          description: Providing this flag will also reset the number of attempts.
         resetHeartbeat:
           type: boolean
-          description: unpause can also reset the heartbeat details
+          description: Providing this flag will also reset the heartbeat details.
         jitter:
           pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
           type: string
@@ -9850,10 +9850,10 @@ components:
           format: field-mask
         id:
           type: string
-          description: ID of the activity we're pausing.
+          description: Only activity with this ID will be updated.
         type:
           type: string
-          description: Type of the activity we're pausing.
+          description: Update all running activities of this type.
     UpdateActivityOptionsResponse:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -426,7 +426,7 @@ paths:
 
          Pausing an activity means:
          - If the activity is currently waiting for a retry or is running and subsequently fails,
-           it will not be rescheduled until it is unpause.
+           it will not be rescheduled until it is unpaused.
          - If the activity is already paused, calling this method will have no effect.
          - If the activity is running and finishes successfully, the activity will be completed.
          - If the activity is running and finishes with failure:
@@ -481,7 +481,7 @@ paths:
          Flags:
 
          'jitter': the activity will be scheduled at a random time within the jitter duration.
-         If the activity currently paused it will be unpause, unless 'keep_paused' flag is provided.
+         If the activity currently paused it will be unpaused, unless 'keep_paused' flag is provided.
          'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.
          'keep_paused': if the activity is paused, it will remain paused.
 
@@ -523,7 +523,7 @@ paths:
 
          If activity is not paused, this call will have no effect.
          If the activity was paused while waiting for retry, it will be scheduled immediately (* see 'jitter' flag).
-         Once the activity is unpause, all timeout timers will be regenerated.
+         Once the activity is unpaused, all timeout timers will be regenerated.
 
          Flags:
          'jitter': the activity will be scheduled at a random time within the jitter duration.
@@ -3093,7 +3093,7 @@ paths:
 
          Pausing an activity means:
          - If the activity is currently waiting for a retry or is running and subsequently fails,
-           it will not be rescheduled until it is unpause.
+           it will not be rescheduled until it is unpaused.
          - If the activity is already paused, calling this method will have no effect.
          - If the activity is running and finishes successfully, the activity will be completed.
          - If the activity is running and finishes with failure:
@@ -3148,7 +3148,7 @@ paths:
          Flags:
 
          'jitter': the activity will be scheduled at a random time within the jitter duration.
-         If the activity currently paused it will be unpause, unless 'keep_paused' flag is provided.
+         If the activity currently paused it will be unpaused, unless 'keep_paused' flag is provided.
          'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.
          'keep_paused': if the activity is paused, it will remain paused.
 
@@ -3190,7 +3190,7 @@ paths:
 
          If activity is not paused, this call will have no effect.
          If the activity was paused while waiting for retry, it will be scheduled immediately (* see 'jitter' flag).
-         Once the activity is unpause, all timeout timers will be regenerated.
+         Once the activity is unpaused, all timeout timers will be regenerated.
 
          Flags:
          'jitter': the activity will be scheduled at a random time within the jitter duration.
@@ -7517,7 +7517,7 @@ components:
           description: The identity of the client who initiated this request.
         id:
           type: string
-          description: Only activity with this ID will be paused.
+          description: Only the activity with this ID will be paused.
         type:
           type: string
           description: Pause all running activities of this type.
@@ -9810,7 +9810,7 @@ components:
           description: The identity of the client who initiated this request.
         id:
           type: string
-          description: Only activity with this ID will be unpause.
+          description: Only the activity with this ID will be unpaused.
         type:
           type: string
           description: Unpause all running activities with of this type.

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1814,16 +1814,18 @@ message UnpauseActivityRequest {
         string id = 4;
         // Unpause all running activities with of this type.
         string type = 5;
+        // Unpause all running activities.
+        bool unpause_all = 6;
     }
 
     // Providing this flag will also reset the number of attempts.
-    bool reset_attempts = 6;
+    bool reset_attempts = 7;
 
     // Providing this flag will also reset the heartbeat details.
-    bool reset_heartbeat = 7;
+    bool reset_heartbeat = 8;
 
     // If set, the activity will start at a random time within the specified jitter duration.
-    google.protobuf.Duration jitter = 8;
+    google.protobuf.Duration jitter = 9;
 }
 
 message UnpauseActivityResponse {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1765,9 +1765,9 @@ message UpdateActivityOptionsRequest {
 
     // either activity id or activity type must be provided
     oneof activity {
-        // ID of the activity we're pausing.
+        // Only activity with this ID will be updated.
         string id = 6;
-        // Type of the activity we're pausing.
+        // Update all running activities of this type.
         string type = 7;
     }
 }
@@ -1788,9 +1788,9 @@ message PauseActivityRequest {
 
     // either activity id or activity type must be provided
     oneof activity {
-        // ID of the activity we're pausing.
+        // Only activity with this ID will be paused.
         string id = 4;
-        // Type of the activity we're pausing.
+        // Pause all running activities of this type.
         string type = 5;
     }
 
@@ -1810,16 +1810,16 @@ message UnpauseActivityRequest {
 
     // either activity id or activity type must be provided
     oneof activity {
-        // ID of the activity we're pausing.
+        // Only activity with this ID will be unpause.
         string id = 4;
-        // Type of the activity we're pausing.
+        // Unpause all running activities with of this type.
         string type = 5;
     }
 
-    // unpause can also reset the number of attempts
+    // Providing this flag will also reset the number of attempts.
     bool reset_attempts = 6;
 
-    // unpause can also reset the heartbeat details
+    // Providing this flag will also reset the heartbeat details.
     bool reset_heartbeat = 7;
 
     // If set, the activity will start at a random time within the specified jitter duration.
@@ -1840,9 +1840,9 @@ message ResetActivityRequest {
 
     // either activity id or activity type must be provided
     oneof activity {
-        // ID of the activity we're pausing.
+        // Only activity with this ID will be reset.
         string id = 4;
-        // Type of the activity we're pausing.
+        // Reset all running activities with of this type.
         string type = 5;
     }
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1756,8 +1756,6 @@ message UpdateActivityOptionsByIdRequest {
     // Run ID of the workflow which scheduled this activity
     // if empty - latest workflow is used
     string run_id = 3;
-    // ID of the activity we're updating
-    string activity_id = 4;
 
     // The identity of the client who initiated this request
     string identity = 5;
@@ -1768,8 +1766,18 @@ message UpdateActivityOptionsByIdRequest {
     // Controls which fields from `activity_options` will be applied
     google.protobuf.FieldMask update_mask = 7;
 
-    // Used to de-dupe requests
-    string request_id = 8;
+    // either activity id or activity type must be provided
+    oneof activity {
+        // ID of the activity we're pausing.
+        string id = 9;
+        // Type of the activity we're pausing.
+        string type = 10;
+    }
+
+    reserved 4;
+    reserved 8;
+    reserved "activity_id";
+    reserved "request_id";
 }
 
 message UpdateActivityOptionsByIdResponse {
@@ -1785,33 +1793,29 @@ message PauseActivityByIdRequest {
     // Run ID of the workflow which scheduled this activity.
     // If empty - latest workflow is used.
     string run_id = 3;
-    // ID of the activity we're updating.
-    string activity_id = 4;
+
 
     // The identity of the client who initiated this request.
     string identity = 5;
 
-    // Used to de-dupe requests.
-    string request_id = 6;
+    // either activity id or activity type must be provided
+    oneof activity {
+        // ID of the activity we're pausing.
+        string id = 7;
+        // Type of the activity we're pausing.
+        string type = 8;
+    }
+
+    reserved 4;
+    reserved 6;
+    reserved "activity_id";
+    reserved "request_id";
 }
 
 message PauseActivityByIdResponse {
 }
 
 message UnpauseActivityByIdRequest {
-    message ResumeOperation {
-        // Indicates that if the activity is waiting to retry, it will  be scheduled immediately.
-        bool no_wait = 1;
-    }
-
-    message ResetOperation {
-        // Indicates that the activity should be scheduled immediately.
-        // Note that this may run simultaneously with any existing executions of the activity.
-        bool no_wait = 1;
-        // If set, the Heartbeat Details will be cleared out to make the Activity start over from the beginning
-        bool reset_heartbeat = 2;
-    }
-
     // Namespace of the workflow which scheduled this activity.
     string namespace = 1;
     // ID of the workflow which scheduled this activity.
@@ -1819,20 +1823,36 @@ message UnpauseActivityByIdRequest {
     // Run ID of the workflow which scheduled this activity.
     // If empty - latest workflow is used.
     string run_id = 3;
-    // ID of the activity we're updating.
-    string activity_id = 4;
 
     // The identity of the client who initiated this request.
     string identity = 5;
 
-    // Used to de-dupe requests.
-    string request_id = 6;
-
-    // There are two options to resume the activity - with 'resume' or with 'reset'.
-    oneof operation{
-        ResumeOperation resume = 7;
-        ResetOperation reset = 8;
+    // either activity id or activity type must be provided
+    oneof activity {
+        // ID of the activity we're pausing.
+        string id = 12;
+        // Type of the activity we're pausing.
+        string type = 13;
     }
+
+    // unpause can also reset the number of attempts
+    bool reset_attempts = 9;
+
+    // unpause can also reset the heartbeat details
+    bool reset_heartbeat = 10;
+
+    // If set, the activity will start at a random time within the specified jitter duration.
+    google.protobuf.Duration jitter = 11;
+
+    reserved 4;
+    reserved 6;
+    reserved 7;
+    reserved 8;
+    reserved "activity_id";
+    reserved "request_id";
+    reserved "reset";
+    reserved "resume";
+
 }
 
 message UnpauseActivityByIdResponse {
@@ -1846,22 +1866,36 @@ message ResetActivityByIdRequest {
     // Run ID of the workflow which scheduled this activity.
     // If empty - latest workflow is used.
     string run_id = 3;
-    // ID of the activity we're updating.
-    string activity_id = 4;
 
     // The identity of the client who initiated this request.
     string identity = 5;
 
-    // Used to de-dupe requests.
-    string request_id = 6;
-
-    // Indicates that activity should be scheduled immediately.
-    // If this flag doesn't set, and activity currently running - temporal will wait until activity is completed.
-    bool no_wait = 7;
 
     // Indicates that activity should reset heartbeat details.
     // This flag will be applied only to the new instance of the activity.
     bool reset_heartbeat = 8;
+
+    // if activity is paused, it will remain paused after reset
+    bool keep_paused = 9;
+
+    // If set, and activity is in backoff, the activity will start at a random time within the specified jitter duration.
+    // (unless it is paused and keep_paused is set)
+    google.protobuf.Duration jitter = 11;
+
+    // either activity id or activity type must be provided
+    oneof activity {
+        // ID of the activity we're pausing.
+        string id = 12;
+        // Type of the activity we're pausing.
+        string type = 13;
+    }
+
+    reserved 4;
+    reserved 6;
+    reserved 7;
+    reserved "activity_id";
+    reserved "request_id";
+    reserved "no_wait";
 }
 
 message ResetActivityByIdResponse {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1748,157 +1748,117 @@ message ExecuteMultiOperationResponse {
     }
 }
 
-message UpdateActivityOptionsByIdRequest {
+message UpdateActivityOptionsRequest {
     // Namespace of the workflow which scheduled this activity
     string namespace = 1;
-    // ID of the workflow which scheduled this activity
-    string workflow_id = 2;
-    // Run ID of the workflow which scheduled this activity
-    // if empty - latest workflow is used
-    string run_id = 3;
+    // Execution info of the workflow which scheduled this activity
+    temporal.api.common.v1.WorkflowExecution execution = 2;
 
     // The identity of the client who initiated this request
-    string identity = 5;
+    string identity = 3;
 
     // Activity options. Partial updates are accepted and controlled by update_mask
-    temporal.api.activity.v1.ActivityOptions activity_options = 6;
+    temporal.api.activity.v1.ActivityOptions activity_options = 4;
 
     // Controls which fields from `activity_options` will be applied
-    google.protobuf.FieldMask update_mask = 7;
+    google.protobuf.FieldMask update_mask = 5;
 
     // either activity id or activity type must be provided
     oneof activity {
         // ID of the activity we're pausing.
-        string id = 9;
+        string id = 6;
         // Type of the activity we're pausing.
-        string type = 10;
+        string type = 7;
     }
-
-    reserved 4;
-    reserved 8;
-    reserved "activity_id";
-    reserved "request_id";
 }
 
-message UpdateActivityOptionsByIdResponse {
+message UpdateActivityOptionsResponse {
     // Activity options after an update
     temporal.api.activity.v1.ActivityOptions activity_options = 1;
 }
 
-message PauseActivityByIdRequest {
+message PauseActivityRequest {
     // Namespace of the workflow which scheduled this activity.
     string namespace = 1;
-    // ID of the workflow which scheduled this activity.
-    string workflow_id = 2;
-    // Run ID of the workflow which scheduled this activity.
-    // If empty - latest workflow is used.
-    string run_id = 3;
-
+    // Execution info of the workflow which scheduled this activity
+    temporal.api.common.v1.WorkflowExecution execution = 2;
 
     // The identity of the client who initiated this request.
-    string identity = 5;
+    string identity = 3;
 
     // either activity id or activity type must be provided
     oneof activity {
         // ID of the activity we're pausing.
-        string id = 7;
+        string id = 4;
         // Type of the activity we're pausing.
-        string type = 8;
+        string type = 5;
     }
 
-    reserved 4;
-    reserved 6;
-    reserved "activity_id";
-    reserved "request_id";
 }
 
-message PauseActivityByIdResponse {
+message PauseActivityResponse {
 }
 
-message UnpauseActivityByIdRequest {
+message UnpauseActivityRequest {
     // Namespace of the workflow which scheduled this activity.
     string namespace = 1;
-    // ID of the workflow which scheduled this activity.
-    string workflow_id = 2;
-    // Run ID of the workflow which scheduled this activity.
-    // If empty - latest workflow is used.
-    string run_id = 3;
+    // Execution info of the workflow which scheduled this activity
+    temporal.api.common.v1.WorkflowExecution execution = 2;
 
     // The identity of the client who initiated this request.
-    string identity = 5;
+    string identity = 3;
 
     // either activity id or activity type must be provided
     oneof activity {
         // ID of the activity we're pausing.
-        string id = 12;
+        string id = 4;
         // Type of the activity we're pausing.
-        string type = 13;
+        string type = 5;
     }
 
     // unpause can also reset the number of attempts
-    bool reset_attempts = 9;
+    bool reset_attempts = 6;
 
     // unpause can also reset the heartbeat details
-    bool reset_heartbeat = 10;
+    bool reset_heartbeat = 7;
 
     // If set, the activity will start at a random time within the specified jitter duration.
-    google.protobuf.Duration jitter = 11;
-
-    reserved 4;
-    reserved 6;
-    reserved 7;
-    reserved 8;
-    reserved "activity_id";
-    reserved "request_id";
-    reserved "reset";
-    reserved "resume";
-
+    google.protobuf.Duration jitter = 8;
 }
 
-message UnpauseActivityByIdResponse {
+message UnpauseActivityResponse {
 }
 
-message ResetActivityByIdRequest {
+message ResetActivityRequest {
     // Namespace of the workflow which scheduled this activity.
     string namespace = 1;
-    // ID of the workflow which scheduled this activity.
-    string workflow_id = 2;
-    // Run ID of the workflow which scheduled this activity.
-    // If empty - latest workflow is used.
-    string run_id = 3;
+    // Execution info of the workflow which scheduled this activity
+    temporal.api.common.v1.WorkflowExecution execution = 2;
 
     // The identity of the client who initiated this request.
-    string identity = 5;
-
-
-    // Indicates that activity should reset heartbeat details.
-    // This flag will be applied only to the new instance of the activity.
-    bool reset_heartbeat = 8;
-
-    // if activity is paused, it will remain paused after reset
-    bool keep_paused = 9;
-
-    // If set, and activity is in backoff, the activity will start at a random time within the specified jitter duration.
-    // (unless it is paused and keep_paused is set)
-    google.protobuf.Duration jitter = 11;
+    string identity = 3;
 
     // either activity id or activity type must be provided
     oneof activity {
         // ID of the activity we're pausing.
-        string id = 12;
+        string id = 4;
         // Type of the activity we're pausing.
-        string type = 13;
+        string type = 5;
     }
 
-    reserved 4;
-    reserved 6;
-    reserved 7;
-    reserved "activity_id";
-    reserved "request_id";
-    reserved "no_wait";
+    // Indicates that activity should reset heartbeat details.
+    // This flag will be applied only to the new instance of the activity.
+    bool reset_heartbeat = 6;
+
+    // if activity is paused, it will remain paused after reset
+    bool keep_paused = 7;
+
+    // If set, and activity is in backoff, the activity will start at a random time within the specified jitter duration.
+    // (unless it is paused and keep_paused is set)
+    google.protobuf.Duration jitter = 8;
 }
 
-message ResetActivityByIdResponse {
+message ResetActivityResponse {
 }
 
 message UpdateWorkflowExecutionOptionsRequest {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1788,7 +1788,7 @@ message PauseActivityRequest {
 
     // either activity id or activity type must be provided
     oneof activity {
-        // Only activity with this ID will be paused.
+        // Only the activity with this ID will be paused.
         string id = 4;
         // Pause all running activities of this type.
         string type = 5;
@@ -1810,7 +1810,7 @@ message UnpauseActivityRequest {
 
     // either activity id or activity type must be provided
     oneof activity {
-        // Only activity with this ID will be unpause.
+        // Only the activity with this ID will be unpaused.
         string id = 4;
         // Unpause all running activities with of this type.
         string type = 5;

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -920,16 +920,14 @@ service WorkflowService {
     rpc RespondNexusTaskFailed(RespondNexusTaskFailedRequest) returns (RespondNexusTaskFailedResponse) {
     }
 
-    // UpdateActivityOptionsById is called by the client to update the options of an activity by its ID or type.
+    // UpdateActivityOptions is called by the client to update the options of an activity by its ID or type.
     // If there are multiple pending activities of the provided type - all of them will be updated.
-    // (-- api-linter: core::0136::prepositions=disabled
-    //     aip.dev/not-precedent: "By" is used to indicate request type. --)
-    rpc UpdateActivityOptionsById (UpdateActivityOptionsByIdRequest) returns (UpdateActivityOptionsByIdResponse) {
+    rpc UpdateActivityOptions (UpdateActivityOptionsRequest) returns (UpdateActivityOptionsResponse) {
         option (google.api.http) = {
-            post: "/namespaces/{namespace}/activities/update-options-by-id"
+            post: "/namespaces/{namespace}/activities/update-options"
             body: "*"
             additional_bindings {
-                post: "/api/v1/namespaces/{namespace}/activities/update-options-by-id"
+                post: "/api/v1/namespaces/{namespace}/activities/update-options"
                 body: "*"
             }
         };
@@ -947,9 +945,8 @@ service WorkflowService {
         };
     }
 
-    // PauseActivityById pauses the execution of an activity specified by its ID or type.
+    // PauseActivity pauses the execution of an activity specified by its ID or type.
     // If there are multiple pending activities of the provided type - all of them will be paused
-    // Returns a `NotFound` error if there is no pending activity with the provided ID.
     //
     // Pausing an activity means:
     // - If the activity is currently waiting for a retry or is running and subsequently fails,
@@ -962,20 +959,20 @@ service WorkflowService {
     // For long-running activities:
     // - activities in paused state will send a cancellation with "activity_paused" set to 'true' in response to 'RecordActivityTaskHeartbeat'.
     // - The activity should respond to the cancellation accordingly.
-    // (-- api-linter: core::0136::prepositions=disabled
-    //     aip.dev/not-precedent: "By" is used to indicate request type. --)
-    rpc PauseActivityById (PauseActivityByIdRequest) returns (PauseActivityByIdResponse) {
+    //
+    // Returns a `NotFound` error if there is no pending activity with the provided ID or type
+    rpc PauseActivity (PauseActivityRequest) returns (PauseActivityResponse) {
         option (google.api.http) = {
-            post: "/namespaces/{namespace}/activities/pause-by-id"
+            post: "/namespaces/{namespace}/activities/pause"
             body: "*"
             additional_bindings {
-                post: "/api/v1/namespaces/{namespace}/activities/pause-by-id"
+                post: "/api/v1/namespaces/{namespace}/activities/pause"
                 body: "*"
             }
         };
     }
 
-    // UnpauseActivityById unpauses the execution of an activity specified by its ID or type.
+    // UnpauseActivity unpauses the execution of an activity specified by its ID or type.
     // If there are multiple pending activities of the provided type - all of them will be unpause.
     //
     // If activity is not paused, this call will have no effect.
@@ -987,21 +984,19 @@ service WorkflowService {
     // 'reset_attempts': the number of attempts will be reset.
     // 'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.
     //
-    // Returns a `NotFound` error if there is no pending activity with the provided ID.
-    // (-- api-linter: core::0136::prepositions=disabled
-    //     aip.dev/not-precedent: "By" is used to indicate request type. --)
-    rpc UnpauseActivityById (UnpauseActivityByIdRequest) returns (UnpauseActivityByIdResponse) {
+    // Returns a `NotFound` error if there is no pending activity with the provided ID or type
+    rpc UnpauseActivity (UnpauseActivityRequest) returns (UnpauseActivityResponse) {
         option (google.api.http) = {
-            post: "/namespaces/{namespace}/activities/unpause-by-id"
+            post: "/namespaces/{namespace}/activities/unpause"
             body: "*"
             additional_bindings {
-                post: "/api/v1/namespaces/{namespace}/activities/unpause-by-id"
+                post: "/api/v1/namespaces/{namespace}/activities/unpause"
                 body: "*"
             }
         };
     }
 
-    // ResetActivityById resets the execution of an activity specified by its ID or type.
+    // ResetActivity resets the execution of an activity specified by its ID or type.
     // If there are multiple pending activities of the provided type - all of them will be reset.
     //
     // Resetting an activity means:
@@ -1017,15 +1012,13 @@ service WorkflowService {
     // 'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.
     // 'keep_paused': if the activity is paused, it will remain paused.
     //
-    // Returns a `NotFound` error if there is no pending activity with the provided ID.
-    // (-- api-linter: core::0136::prepositions=disabled
-    //     aip.dev/not-precedent: "By" is used to indicate request type. --)
-    rpc ResetActivityById (ResetActivityByIdRequest) returns (ResetActivityByIdResponse) {
+    // Returns a `NotFound` error if there is no pending activity with the provided ID or type.
+    rpc ResetActivity (ResetActivityRequest) returns (ResetActivityResponse) {
         option (google.api.http) = {
-            post: "/namespaces/{namespace}/activities/reset-by-id"
+            post: "/namespaces/{namespace}/activities/reset"
             body: "*"
             additional_bindings {
-                post: "/api/v1/namespaces/{namespace}/activities/reset-by-id"
+                post: "/api/v1/namespaces/{namespace}/activities/reset"
                 body: "*"
             }
         };

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -950,7 +950,7 @@ service WorkflowService {
     //
     // Pausing an activity means:
     // - If the activity is currently waiting for a retry or is running and subsequently fails,
-    //   it will not be rescheduled until it is unpause.
+    //   it will not be rescheduled until it is unpaused.
     // - If the activity is already paused, calling this method will have no effect.
     // - If the activity is running and finishes successfully, the activity will be completed.
     // - If the activity is running and finishes with failure:
@@ -977,7 +977,7 @@ service WorkflowService {
     //
     // If activity is not paused, this call will have no effect.
     // If the activity was paused while waiting for retry, it will be scheduled immediately (* see 'jitter' flag).
-    // Once the activity is unpause, all timeout timers will be regenerated.
+    // Once the activity is unpaused, all timeout timers will be regenerated.
     //
     // Flags:
     // 'jitter': the activity will be scheduled at a random time within the jitter duration.
@@ -1008,7 +1008,7 @@ service WorkflowService {
     // Flags:
     //
     // 'jitter': the activity will be scheduled at a random time within the jitter duration.
-    // If the activity currently paused it will be unpause, unless 'keep_paused' flag is provided.
+    // If the activity currently paused it will be unpaused, unless 'keep_paused' flag is provided.
     // 'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.
     // 'keep_paused': if the activity is paused, it will remain paused.
     //

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -973,10 +973,10 @@ service WorkflowService {
     }
 
     // UnpauseActivity unpauses the execution of an activity specified by its ID or type.
-    // If there are multiple pending activities of the provided type - all of them will be unpause.
+    // If there are multiple pending activities of the provided type - all of them will be unpaused.
     //
     // If activity is not paused, this call will have no effect.
-    // If the activity is waiting for retry, it will be scheduled immediately (* see 'jitter' flag).
+    // If the activity was paused while waiting for retry, it will be scheduled immediately (* see 'jitter' flag).
     // Once the activity is unpause, all timeout timers will be regenerated.
     //
     // Flags:

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -920,7 +920,8 @@ service WorkflowService {
     rpc RespondNexusTaskFailed(RespondNexusTaskFailedRequest) returns (RespondNexusTaskFailedResponse) {
     }
 
-    // UpdateActivityOptionsById is called by the client to update the options of an activity
+    // UpdateActivityOptionsById is called by the client to update the options of an activity by its ID or type.
+    // If there are multiple pending activities of the provided type - all of them will be updated.
     // (-- api-linter: core::0136::prepositions=disabled
     //     aip.dev/not-precedent: "By" is used to indicate request type. --)
     rpc UpdateActivityOptionsById (UpdateActivityOptionsByIdRequest) returns (UpdateActivityOptionsByIdResponse) {
@@ -946,12 +947,13 @@ service WorkflowService {
         };
     }
 
-    // PauseActivityById pauses the execution of an activity specified by its ID.
+    // PauseActivityById pauses the execution of an activity specified by its ID or type.
+    // If there are multiple pending activities of the provided type - all of them will be paused
     // Returns a `NotFound` error if there is no pending activity with the provided ID.
     //
     // Pausing an activity means:
     // - If the activity is currently waiting for a retry or is running and subsequently fails,
-    //   it will not be rescheduled until it is unpaused.
+    //   it will not be rescheduled until it is unpause.
     // - If the activity is already paused, calling this method will have no effect.
     // - If the activity is running and finishes successfully, the activity will be completed.
     // - If the activity is running and finishes with failure:
@@ -973,18 +975,19 @@ service WorkflowService {
         };
     }
 
-    // UnpauseActivityById unpauses the execution of an activity specified by its ID.
+    // UnpauseActivityById unpauses the execution of an activity specified by its ID or type.
+    // If there are multiple pending activities of the provided type - all of them will be unpause.
+    //
+    // If activity is not paused, this call will have no effect.
+    // If the activity is waiting for retry, it will be scheduled immediately (* see 'jitter' flag).
+    // Once the activity is unpause, all timeout timers will be regenerated.
+    //
+    // Flags:
+    // 'jitter': the activity will be scheduled at a random time within the jitter duration.
+    // 'reset_attempts': the number of attempts will be reset.
+    // 'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.
+    //
     // Returns a `NotFound` error if there is no pending activity with the provided ID.
-    // There are two 'modes' of unpausing an activity:
-    // 'resume' - If the activity is paused, it will be resumed and scheduled for execution.
-    //    * If the activity is currently running Unpause with 'resume' has no effect.
-    //    * if 'no_wait' flag is set and the activity is waiting, the activity will be scheduled immediately.
-    // 'reset' - If the activity is paused, it will be reset to its initial state and (depending on parameters) scheduled for execution.
-    //    * If the activity is currently running, Unpause with 'reset' will reset the number of attempts.
-    //    * if 'no_wait' flag is set, the activity will be scheduled immediately.
-    //    * if 'reset_heartbeats' flag is set, the activity heartbeat timer and heartbeats will be reset.
-    // If the activity is in waiting for retry and past it retry timeout, it will be scheduled immediately.
-    // Once the activity is unpaused, all timeout timers will be regenerated.
     // (-- api-linter: core::0136::prepositions=disabled
     //     aip.dev/not-precedent: "By" is used to indicate request type. --)
     rpc UnpauseActivityById (UnpauseActivityByIdRequest) returns (UnpauseActivityByIdResponse) {
@@ -998,15 +1001,23 @@ service WorkflowService {
         };
     }
 
-    // ResetActivityById unpauses the execution of an activity specified by its ID.
-    // Returns a `NotFound` error if there is no pending activity with the provided ID.
+    // ResetActivityById resets the execution of an activity specified by its ID or type.
+    // If there are multiple pending activities of the provided type - all of them will be reset.
+    //
     // Resetting an activity means:
     // * number of attempts will be reset to 0.
-    // * activity timeouts will be resetted.
-    // If the activity currently running:
-    // *  if 'no_wait' flag is provided, a new instance of the activity will be scheduled immediately.
-    // *  if 'no_wait' flag is not provided, a new instance of the  activity will be scheduled after current instance completes if needed.
-    // If 'reset_heartbeats' flag is set, the activity heartbeat timer and heartbeats will be reset.
+    // * activity timeouts will be reset.
+    // * if the activity is waiting for retry, and it is not paused or 'keep_paused' is not provided:
+    //    it will be scheduled immediately (* see 'jitter' flag),
+    //
+    // Flags:
+    //
+    // 'jitter': the activity will be scheduled at a random time within the jitter duration.
+    // If the activity currently paused it will be unpause, unless 'keep_paused' flag is provided.
+    // 'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.
+    // 'keep_paused': if the activity is paused, it will remain paused.
+    //
+    // Returns a `NotFound` error if there is no pending activity with the provided ID.
     // (-- api-linter: core::0136::prepositions=disabled
     //     aip.dev/not-precedent: "By" is used to indicate request type. --)
     rpc ResetActivityById (ResetActivityByIdRequest) returns (ResetActivityByIdResponse) {
@@ -1020,4 +1031,3 @@ service WorkflowService {
         };
     }
 }
-


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This PR  contains  a commutative feedback for single activity API:
* add 'jitter' fields to Reset and Unpause
* 'Flatten' unpause. Previous approach was marked as overcomplicated
* Add 'keep_unpause' flag to Reset. By default reset will also unpause the activity.
* Remove no-wait flag. By default, if activity is in retry, they will be scheduled immediately (*jitter)
* Add "activity type" as a routing parameter to every activity operation. If activity type is provided - every pending activity of this type will be paused/reset/updated/unpaused
* Update API descriptions to reflect those changes.

<!-- Tell your future self why have you made these changes -->
**Why?**
Working on single activity API feedback from the design review.


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
Yes

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
[Add batch activity unpause. Single activity commulative changes](https://github.com/temporalio/temporal/pull/7169)