### PR TITLE
Versioning 3 API refinements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ http-api-docs:
 ##### Plugins & tools #####
 grpc-install:
 	@printf $(COLOR) "Install/update protoc and plugins..."
-	@go install go.temporal.io/api/cmd/protogen@latest
+	@go install go.temporal.io/api/cmd/protogen@a53ea3f999f6c52d7ff0b317f75a289f600cc7d3
 	@go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 	@go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 	@go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@latest

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ http-api-docs:
 ##### Plugins & tools #####
 grpc-install:
 	@printf $(COLOR) "Install/update protoc and plugins..."
-	@go install go.temporal.io/api/cmd/protogen@a53ea3f999f6c52d7ff0b317f75a289f600cc7d3
+	@go install go.temporal.io/api/cmd/protogen@master
 	@go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 	@go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 	@go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@latest

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -1812,6 +1812,42 @@
         ]
       }
     },
+    "/api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}": {
+      "get": {
+        "operationId": "DescribeWorkerDeployment2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1DescribeWorkerDeploymentResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
     "/api/v1/namespaces/{namespace}/worker-task-reachability": {
       "get": {
         "summary": "Deprecated. Use `DescribeTaskQueue`.",
@@ -4824,6 +4860,42 @@
         ]
       }
     },
+    "/namespaces/{namespace}/worker-deployments/{deploymentName}": {
+      "get": {
+        "operationId": "DescribeWorkerDeployment",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1DescribeWorkerDeploymentResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
     "/namespaces/{namespace}/worker-task-reachability": {
       "get": {
         "summary": "Deprecated. Use `DescribeTaskQueue`.",
@@ -5982,6 +6054,24 @@
         }
       },
       "description": "Replaces the routing rule with the given source Build ID."
+    },
+    "WorkerDeploymentInfoWorkerDeploymentVersionSummary": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "workflowVersioningMode": {
+          "$ref": "#/definitions/v1WorkflowVersioningMode"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "acceptsNewExecutions": {
+          "type": "boolean"
+        }
+      }
     },
     "WorkerDeploymentVersionInfoDeploymentVersionTaskQueueInfo": {
       "type": "object",
@@ -8644,6 +8734,14 @@
             "$ref": "#/definitions/v1TaskQueueVersionInfo"
           },
           "description": "This map contains Task Queue information for each Build ID. Empty string as key value means unversioned.\nOnly set in `ENHANCED` mode."
+        }
+      }
+    },
+    "v1DescribeWorkerDeploymentResponse": {
+      "type": "object",
+      "properties": {
+        "workerDeploymentInfo": {
+          "$ref": "#/definitions/v1WorkerDeploymentInfo"
         }
       }
     },
@@ -12980,6 +13078,28 @@
         }
       },
       "description": "Specifies client's intent to wait for Update results."
+    },
+    "v1WorkerDeploymentInfo": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Identifies a Worker Deployment. Must be unique within the namespace."
+        },
+        "versionSummaries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/WorkerDeploymentInfoWorkerDeploymentVersionSummary"
+          },
+          "title": "Deployment Versions that are currently tracked in this Deployment. A DeploymentVersion will be\ncleaned up automatically if all the following conditions meet:\n- It does not receive new executions (see WorkerDeploymentVersionInfo.accepts_new_executions) \n- It has no active pollers (see WorkerDeploymentVersionInfo.pollers_status) \n- It is drained (see WorkerDeploymentVersionInfo.drainage_status)"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "description": "A Worker Deployment (Deployment, for short) represents all workers serving \na shared set of Task Queues. Typically, a Deployment represents one service or \napplication.\nA Deployment contains multiple Deployment Versions, each representing a different \nversion of workers. (see documentation of WorkerDeploymentVersionInfo)\nDeployment records are created in Temporal server automatically when their \nfirst poller arrives to the server."
     },
     "v1WorkerDeploymentOptions": {
       "type": "object",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -1730,6 +1730,50 @@
         ]
       }
     },
+    "/api/v1/namespaces/{namespace}/worker-deployments": {
+      "get": {
+        "operationId": "ListWorkerDeployments2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListWorkerDeploymentsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "nextPageToken",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "format": "byte"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
     "/api/v1/namespaces/{namespace}/worker-deployments-version/{version}": {
       "get": {
         "summary": "Describes a worker deployment version.",
@@ -4823,6 +4867,50 @@
         ]
       }
     },
+    "/namespaces/{namespace}/worker-deployments": {
+      "get": {
+        "operationId": "ListWorkerDeployments",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListWorkerDeploymentsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "nextPageToken",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "format": "byte"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
     "/namespaces/{namespace}/worker-deployments-version/{version}": {
       "get": {
         "summary": "Describes a worker deployment version.",
@@ -5964,6 +6052,22 @@
           "$ref": "#/definitions/WorkflowEventEventReference"
         }
       }
+    },
+    "ListWorkerDeploymentsResponseWorkerDeploymentSummary": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "routingInfo": {
+          "$ref": "#/definitions/v1RoutingInfo"
+        }
+      },
+      "title": "A subset of WorkerDeploymentInfo"
     },
     "OperatorServiceUpdateNexusEndpointBody": {
       "type": "object",
@@ -9868,6 +9972,23 @@
             "type": "object",
             "$ref": "#/definitions/v1TaskQueuePartitionMetadata"
           }
+        }
+      }
+    },
+    "v1ListWorkerDeploymentsResponse": {
+      "type": "object",
+      "properties": {
+        "nextPageToken": {
+          "type": "string",
+          "format": "byte"
+        },
+        "workerDeployments": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/ListWorkerDeploymentsResponseWorkerDeploymentSummary"
+          },
+          "description": "The list of worker deployments."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -5983,7 +5983,7 @@
       },
       "description": "Replaces the routing rule with the given source Build ID."
     },
-    "WorkerDeploymentVersionInfoWorkerBuildTaskQueueInfo": {
+    "WorkerDeploymentVersionInfoDeploymentVersionTaskQueueInfo": {
       "type": "object",
       "properties": {
         "name": {
@@ -13031,7 +13031,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/WorkerDeploymentVersionInfoWorkerBuildTaskQueueInfo"
+            "$ref": "#/definitions/WorkerDeploymentVersionInfoDeploymentVersionTaskQueueInfo"
           },
           "description": "All the Task Queues that have ever polled from this Deployment version."
         }

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -1730,51 +1730,6 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/worker-deployment/{deploymentName}/set-current-version": {
-      "post": {
-        "summary": "Sets a deployment version as the current version for its deployment.",
-        "operationId": "SetCurrentDeploymentVersion2",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1SetCurrentDeploymentVersionResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "deploymentName",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceSetCurrentDeploymentVersionBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
     "/api/v1/namespaces/{namespace}/worker-deployments-version/{version}": {
       "get": {
         "summary": "Describes a worker deployment version.",
@@ -1841,6 +1796,96 @@
             "in": "path",
             "required": true,
             "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}/set-current-version": {
+      "post": {
+        "summary": "Set/unset the Current Version of a Worker Deployment. Automatically unsets the Ramping\nVersion if it is the Version being set as Current.",
+        "operationId": "SetWorkerDeploymentCurrentVersion2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1SetWorkerDeploymentCurrentVersionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceSetWorkerDeploymentCurrentVersionBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}/set-ramping-version": {
+      "post": {
+        "summary": "Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for\ngradual ramp to unversioned workers too.",
+        "operationId": "SetWorkerDeploymentRampingVersion2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1SetWorkerDeploymentRampingVersionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceSetWorkerDeploymentRampingVersionBody"
+            }
           }
         ],
         "tags": [
@@ -4778,51 +4823,6 @@
         ]
       }
     },
-    "/namespaces/{namespace}/worker-deployment/{deploymentName}/set-current-version": {
-      "post": {
-        "summary": "Sets a deployment version as the current version for its deployment.",
-        "operationId": "SetCurrentDeploymentVersion",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1SetCurrentDeploymentVersionResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "deploymentName",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceSetCurrentDeploymentVersionBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
     "/namespaces/{namespace}/worker-deployments-version/{version}": {
       "get": {
         "summary": "Describes a worker deployment version.",
@@ -4889,6 +4889,96 @@
             "in": "path",
             "required": true,
             "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/namespaces/{namespace}/worker-deployments/{deploymentName}/set-current-version": {
+      "post": {
+        "summary": "Set/unset the Current Version of a Worker Deployment. Automatically unsets the Ramping\nVersion if it is the Version being set as Current.",
+        "operationId": "SetWorkerDeploymentCurrentVersion",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1SetWorkerDeploymentCurrentVersionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceSetWorkerDeploymentCurrentVersionBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/namespaces/{namespace}/worker-deployments/{deploymentName}/set-ramping-version": {
+      "post": {
+        "summary": "Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for\ngradual ramp to unversioned workers too.",
+        "operationId": "SetWorkerDeploymentRampingVersion",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1SetWorkerDeploymentRampingVersionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceSetWorkerDeploymentRampingVersionBody"
+            }
           }
         ],
         "tags": [
@@ -6559,7 +6649,7 @@
       },
       "title": "[cleanup-wv-pre-release] Pre-release deployment APIs, clean up later"
     },
-    "WorkflowServiceSetCurrentDeploymentVersionBody": {
+    "WorkflowServiceSetWorkerDeploymentCurrentVersionBody": {
       "type": "object",
       "properties": {
         "version": {
@@ -6570,7 +6660,27 @@
           "type": "string",
           "description": "Optional. The identity of the client who initiated this request."
         }
-      }
+      },
+      "description": "Set/unset the Current Version of a Worker Deployment."
+    },
+    "WorkflowServiceSetWorkerDeploymentRampingVersionBody": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string",
+          "title": "The Version to be set as the Ramping Version of the Deployment. Optional when `percentage` is\nzero (unset case), but if given, it must match the current Ramping Version to be unset.\nCan be an empty string and paired with a non-zero `percentage`, in which case it will set the ramp\npercentage without a Ramping Version which means unversioned workers are being ramped.\n(Useful for migrating to unversioned workers from Deployment's Current Version.)"
+        },
+        "percentage": {
+          "type": "number",
+          "format": "float",
+          "description": "Valid range: [0,100]. Zero value will unset the Ramping Version."
+        },
+        "identity": {
+          "type": "string",
+          "description": "Optional. The identity of the client who initiated this request."
+        }
+      },
+      "description": "Set/unset the Ramping Version of a Worker Deployment and its ramp percentage.\nTo unset, pass zero `percentage`.\nTo ramp to unversioned workers (from Deployment's Current Version), pass `version=\"\"` with\nnon-zero `percentage`."
     },
     "WorkflowServiceSignalWithStartWorkflowExecutionBody": {
       "type": "object",
@@ -8734,6 +8844,10 @@
             "$ref": "#/definitions/v1TaskQueueVersionInfo"
           },
           "description": "This map contains Task Queue information for each Build ID. Empty string as key value means unversioned.\nOnly set in `ENHANCED` mode."
+        },
+        "versioningInfo": {
+          "$ref": "#/definitions/v1TaskQueueVersioningInfo",
+          "description": "Specifies which Worker Deployment Version(s) Server routes this Task Queue's tasks to.\nWhen not present, it means the tasks are routed to \"unversioned\" workers. Unversioned workers\nare those with UNVERSIONED (or unspecified) WorkflowVersioningMode.\nTask Queue Versioning info is updated indirectly by calling SetWorkerDeploymentCurrentVersion\nand SetWorkerDeploymentRampingVersion on Worker Deployments.\nNote: This information is not relevant to Pinned workflow executions and their activities as\nthey are always routed to their Pinned Deployment Version. However, new workflow executions\nare typically not Pinned until they complete their first task (unless they are started with\na Pinned VersioningOverride or are Child Workflows of a Pinned parent)."
         }
       }
     },
@@ -11825,12 +11939,26 @@
       },
       "title": "[cleanup-wv-pre-release] Pre-release deployment APIs, clean up later"
     },
-    "v1SetCurrentDeploymentVersionResponse": {
+    "v1SetWorkerDeploymentCurrentVersionResponse": {
       "type": "object",
       "properties": {
         "previousVersion": {
           "type": "string",
-          "description": "Info of the version that was current before executing this operation."
+          "description": "The version that was current before executing this operation."
+        }
+      }
+    },
+    "v1SetWorkerDeploymentRampingVersionResponse": {
+      "type": "object",
+      "properties": {
+        "previousVersion": {
+          "type": "string",
+          "description": "The ramping version before executing this operation."
+        },
+        "previousPercentage": {
+          "type": "number",
+          "format": "float",
+          "description": "The ramping version percentage before executing this operation."
         }
       }
     },
@@ -12643,6 +12771,29 @@
         }
       },
       "description": "Used for specifying versions the caller is interested in."
+    },
+    "v1TaskQueueVersioningInfo": {
+      "type": "object",
+      "properties": {
+        "currentVersion": {
+          "$ref": "#/definitions/v1WorkerDeploymentVersion",
+          "title": "Current Version receives all the tasks except the portion that is routed to the Ramping\nVersion according to `ramping_version_percentage`.\nIt is possible that Current Version is not present when user is ramping from unversioned to\nversioned workers. In that case, remaining tasks after `ramping_version_percentage` go to\nunversioned workers. (Unversioned workers are those with UNVERSIONED (or unspecified)\nWorkflowVersioningMode.)"
+        },
+        "rampingVersion": {
+          "$ref": "#/definitions/v1WorkerDeploymentVersion",
+          "description": "Ramping Version is set during gradual rollout of a new Version. It takes a share of tasks\naccording to `ramping_version_percentage`."
+        },
+        "rampingVersionPercentage": {
+          "type": "number",
+          "format": "float",
+          "description": "Percentage of tasks that are routed to the Ramping Version instead of the Current Version.\nSpecial case: it is possible that `ramping_version_percentage` is non-zero while\n`ramping_version` is absent. That case represents gradual migration out of the Current\nVersion to unversioned workers."
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last time versioning information of this Task Queue changed."
+        }
+      }
     },
     "v1TaskReachability": {
       "type": "string",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -6292,8 +6292,7 @@
         "type": {
           "$ref": "#/definitions/v1TaskQueueType"
         }
-      },
-      "title": "TODO (Shivam): + Poller_status + WorkerDeploymentVersionMetadata"
+      }
     },
     "WorkflowEventEventReference": {
       "type": "object",
@@ -6775,7 +6774,7 @@
       "properties": {
         "buildId": {
           "type": "string",
-          "title": "Required. Can be one of the following:\n- The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has\n`WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\nwith `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)"
+          "title": "Required. Can be one of the following:\n- The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has\n  `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\n  with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)"
         },
         "conflictToken": {
           "type": "string",
@@ -6794,7 +6793,7 @@
       "properties": {
         "buildId": {
           "type": "string",
-          "title": "Can be one of the following:\n- Absent/empty value to unset the Ramping Version. Must be paired with `percentage=0`.\n- The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has\n`WorkflowVersioningMode==VERSIONING_BEHAVIORS`) to set it as the Ramping Version.\n- Or, the \"__unversioned__\" special value, to ramp unversioned workers (those with\n`UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)"
+          "title": "Can be one of the following:\n- Absent/empty value to unset the Ramping Version. Must be paired with `percentage=0`.\n- The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has\n  `WorkflowVersioningMode==VERSIONING_BEHAVIORS`) to set it as the Ramping Version.\n- Or, the \"__unversioned__\" special value, to ramp unversioned workers (those with\n  `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)"
         },
         "percentage": {
           "type": "number",
@@ -11644,11 +11643,11 @@
       "properties": {
         "currentVersion": {
           "type": "string",
-          "title": "Always present. Specifies which Deployment Version should should receive new workflow\nexecutions and tasks of existing unversioned or AutoUpgrade workflows.\nCan be one of the following:\n- The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has\n`WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\nwith `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)\nNote: Current Version is overridden by the Ramping Version for a portion of traffic when a ramp\nis set (see `ramping_version`.)"
+          "title": "Always present. Specifies which Deployment Version should should receive new workflow\nexecutions and tasks of existing unversioned or AutoUpgrade workflows.\nCan be one of the following:\n- The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has\n  `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\n  with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)\nNote: Current Version is overridden by the Ramping Version for a portion of traffic when a ramp\nis set (see `ramping_version`.)"
         },
         "rampingVersion": {
           "type": "string",
-          "description": "When present, it means the traffic is being shifted from the Current Version to the Ramping\nVersion.\nMust always be different from Current Version. Can be one of the following:\n- The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has\n`WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\nwith `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)\nNote that it is possible to ramp from one Version to another Version, or from unversioned\nworkers to a particular Version, or from a particular Version to unversioned workers."
+          "description": "When present, it means the traffic is being shifted from the Current Version to the Ramping\nVersion.\nMust always be different from Current Version. Can be one of the following:\n- The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has\n  `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\n  with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)\nNote that it is possible to ramp from one Version to another Version, or from unversioned\nworkers to a particular Version, or from a particular Version to unversioned workers."
         },
         "rampingVersionPercentage": {
           "type": "number",
@@ -12965,16 +12964,16 @@
       "properties": {
         "currentVersion": {
           "$ref": "#/definitions/v1WorkerDeploymentVersion",
-          "title": "Current Version receives all the tasks except the portion that is routed to the Ramping\nVersion according to `ramping_version_percentage`.\nIt is possible that Current Version is not present when user is ramping from unversioned to\nversioned workers. In that case, remaining tasks after `ramping_version_percentage` go to\nunversioned workers. (Unversioned workers are those with UNVERSIONED (or unspecified)\nWorkflowVersioningMode.)"
+          "title": "Always present. Specifies which Deployment Version should should receive new workflow\nexecutions and tasks of existing unversioned or AutoUpgrade workflows.\nCan be one of the following:\n- The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has\n  `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\n  with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)\nNote: Current Version is overridden by the Ramping Version for a portion of traffic when a ramp\nis set (see `ramping_version`.)"
         },
         "rampingVersion": {
           "$ref": "#/definitions/v1WorkerDeploymentVersion",
-          "description": "Ramping Version is set during gradual rollout of a new Version. It takes a share of tasks\naccording to `ramping_version_percentage`.\nIt is possible that Ramping Version belong to a Deployment other than that of the Current\nVersion. This happens when a Task Queue is being moved from one Deployment to another."
+          "description": "When present, it means the traffic is being shifted from the Current Version to the Ramping\nVersion.\nMust always be different from Current Version. Can be one of the following:\n- The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has\n  `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\n  with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)\nNote that it is possible to ramp from one Version to another Version, or from unversioned\nworkers to a particular Version, or from a particular Version to unversioned workers."
         },
         "rampingVersionPercentage": {
           "type": "number",
           "format": "float",
-          "description": "Percentage of tasks that are routed to the Ramping Version instead of the Current Version.\nValid range: [0, 100]. A 100% value means the Ramping Version is receiving full traffic but\nnot yet \"promoted\" to be the Current Version, likely due to pending validations.\nSpecial case: it is possible that `ramping_version_percentage` is non-zero while\n`ramping_version` is absent. That case represents gradual migration out of the Current\nVersion to unversioned workers."
+          "description": "Percentage of tasks that are routed to the Ramping Version instead of the Current Version.\nValid range: [0, 100]. A 100% value means the Ramping Version is receiving full traffic but\nnot yet \"promoted\" to be the Current Version, likely due to pending validations."
         },
         "updateTime": {
           "type": "string",
@@ -13359,7 +13358,7 @@
       "properties": {
         "status": {
           "$ref": "#/definitions/v1VersionDrainageStatus",
-          "description": "Set to DRAINING when the version stops accepting new executions (is no longer current or ramping).\nSet to DRAINED when no more open pinned workflows exist on this version."
+          "description": "Set to DRAINING when the version first stops accepting new executions (is no longer current or ramping).\nSet to DRAINED when no more open pinned workflows exist on this version."
         },
         "lastChangedTime": {
           "type": "string",
@@ -13372,7 +13371,7 @@
           "description": "Last time the system checked for drainage of this version."
         }
       },
-      "description": "Information about workflow drainage to help the user determine when it is safe\nto decommission a Version. Not present while the version is current or ramping."
+      "description": "Information about workflow drainage to help the user determine when it is safe\nto decommission a Version. Not present while version is current or ramping."
     },
     "v1VersionDrainageStatus": {
       "type": "string",
@@ -13564,7 +13563,7 @@
         },
         "drainageInfo": {
           "$ref": "#/definitions/v1VersionDrainageInfo",
-          "description": "Helps user determine when it is safe to decommission the workers of this\nVersion. Not present when the workflow is accepting new workflow executions because it's current or ramping.\nCurrent limitations:\n- Not supported for Unversioned mode.\n- Periodically refreshed, may have delays up to few minutes (consult the\n  last_checked_time value).\n- Refreshed only when the version is neither current nor ramping AND \nthe status is not \"drained\" yet.\n- Once the status is changed to \"drained\", it is not changed until the Version\n  becomes Current or Ramping again, at which time the drainage info is cleared.\n  This means if the Version is \"drained\" but new workflows are sent to it via\n  Pinned Versioning Override, the status does not account for those Pinned-override\n  executions and remains \"drained\"."
+          "description": "Helps user determine when it is safe to decommission the workers of this\nVersion. Not present when version is current or ramping.\nCurrent limitations:\n- Not supported for Unversioned mode.\n- Periodically refreshed, may have delays up to few minutes (consult the\n  last_checked_time value).\n- Refreshed only when version is not current or ramping AND the status is not\n  \"drained\" yet.\n- Once the status is changed to \"drained\", it is not changed until the Version\n  becomes Current or Ramping again, at which time the drainage info is cleared.\n  This means if the Version is \"drained\" but new workflows are sent to it via\n  Pinned Versioning Override, the status does not account for those Pinned-override\n  executions and remains \"drained\"."
         },
         "metadata": {
           "$ref": "#/definitions/v1VersionMetadata",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -12125,7 +12125,7 @@
           "type": "string",
           "format": "byte"
         },
-        "previousVersion": {
+        "previousBuildId": {
           "type": "string",
           "description": "The Build ID of the version that was current before executing this operation. Can also be the\n`__unversioned__` special value."
         }
@@ -12138,7 +12138,7 @@
           "type": "string",
           "format": "byte"
         },
-        "previousVersion": {
+        "previousBuildId": {
           "type": "string",
           "description": "The Build ID of the version that was ramping before executing this operation. Can also be\nempty or the `__unversioned__` special value."
         },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -1774,43 +1774,6 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/worker-deployments-version/{version}": {
-      "get": {
-        "summary": "Describes a worker deployment version.",
-        "operationId": "DescribeWorkerDeploymentVersion2",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1DescribeWorkerDeploymentVersionResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "version",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
     "/api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}": {
       "get": {
         "operationId": "DescribeWorkerDeployment2",
@@ -1930,6 +1893,51 @@
             "schema": {
               "$ref": "#/definitions/WorkflowServiceSetWorkerDeploymentRampingVersionBody"
             }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/api/v1/namespaces/{namespace}/worker-deployments/{version.deploymentName}/version/{version.buildId}": {
+      "get": {
+        "summary": "Describes a worker deployment version.",
+        "operationId": "DescribeWorkerDeploymentVersion2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1DescribeWorkerDeploymentVersionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "version.deploymentName",
+            "description": "The name of the Deployment this version belongs too.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "version.buildId",
+            "description": "Build ID uniquely identifies the Deployment Version within a Deployment, but the same Build\nID can be used in multiple Deployments.",
+            "in": "path",
+            "required": true,
+            "type": "string"
           }
         ],
         "tags": [
@@ -4911,43 +4919,6 @@
         ]
       }
     },
-    "/namespaces/{namespace}/worker-deployments-version/{version}": {
-      "get": {
-        "summary": "Describes a worker deployment version.",
-        "operationId": "DescribeWorkerDeploymentVersion",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1DescribeWorkerDeploymentVersionResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "version",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
     "/namespaces/{namespace}/worker-deployments/{deploymentName}": {
       "get": {
         "operationId": "DescribeWorkerDeployment",
@@ -5067,6 +5038,51 @@
             "schema": {
               "$ref": "#/definitions/WorkflowServiceSetWorkerDeploymentRampingVersionBody"
             }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/namespaces/{namespace}/worker-deployments/{version.deploymentName}/version/{version.buildId}": {
+      "get": {
+        "summary": "Describes a worker deployment version.",
+        "operationId": "DescribeWorkerDeploymentVersion",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1DescribeWorkerDeploymentVersionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "version.deploymentName",
+            "description": "The name of the Deployment this version belongs too.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "version.buildId",
+            "description": "Build ID uniquely identifies the Deployment Version within a Deployment, but the same Build\nID can be used in multiple Deployments.",
+            "in": "path",
+            "required": true,
+            "type": "string"
           }
         ],
         "tags": [
@@ -6262,12 +6278,12 @@
           "type": "string",
           "format": "date-time"
         },
-        "acceptsNewExecutions": {
-          "type": "boolean"
+        "drainageStatus": {
+          "$ref": "#/definitions/v1VersionDrainageStatus"
         }
       }
     },
-    "WorkerDeploymentVersionInfoDeploymentVersionTaskQueueInfo": {
+    "WorkerDeploymentVersionInfoVersionTaskQueueInfo": {
       "type": "object",
       "properties": {
         "name": {
@@ -6758,7 +6774,12 @@
       "properties": {
         "version": {
           "type": "string",
-          "description": "Must be a Versioned Build. Pass empty string to unset."
+          "title": "Required. Can be one of the following:\n- The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has\n`WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\nwith `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)"
+        },
+        "conflictToken": {
+          "type": "string",
+          "format": "byte",
+          "description": "Optional. This can be the value of conflict_token from a Describe, or another Worker\nDeployment API. Passing conflict token which will cause this request to fail if the\nDeployment's configuration has been modified between the previous API call and\nthis one."
         },
         "identity": {
           "type": "string",
@@ -6772,19 +6793,24 @@
       "properties": {
         "version": {
           "type": "string",
-          "title": "The Version to be set as the Ramping Version of the Deployment. Optional when `percentage` is\nzero (unset case), but if given, it must match the current Ramping Version to be unset.\nCan be an empty string and paired with a non-zero `percentage`, in which case it will set the ramp\npercentage without a Ramping Version which means unversioned workers are being ramped.\n(Useful for migrating to unversioned workers from Deployment's Current Version.)"
+          "title": "Can be one of the following:\n- Absent/empty value to unset the Ramping Version. Must be paired with `percentage=0`.\n- The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has\n`WorkflowVersioningMode==VERSIONING_BEHAVIORS`) to set it as the Ramping Version.\n- Or, the \"__unversioned__\" special value, to ramp unversioned workers (those with\n`UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)"
         },
         "percentage": {
           "type": "number",
           "format": "float",
-          "description": "Valid range: [0,100]. Zero value will unset the Ramping Version."
+          "description": "Ramp percentage to set. Valid range: [0,100]."
+        },
+        "conflictToken": {
+          "type": "string",
+          "format": "byte",
+          "description": "Optional. This can be the value of conflict_token from a Describe, or another Worker\nDeployment API. Passing conflict token which will cause this request to fail if the\nDeployment's configuration has been modified between the previous API call and\nthis one."
         },
         "identity": {
           "type": "string",
           "description": "Optional. The identity of the client who initiated this request."
         }
       },
-      "description": "Set/unset the Ramping Version of a Worker Deployment and its ramp percentage.\nTo unset, pass zero `percentage`.\nTo ramp to unversioned workers (from Deployment's Current Version), pass `version=\"\"` with\nnon-zero `percentage`."
+      "description": "Set/unset the Ramping Version of a Worker Deployment and its ramp percentage."
     },
     "WorkflowServiceSignalWithStartWorkflowExecutionBody": {
       "type": "object",
@@ -8958,6 +8984,10 @@
     "v1DescribeWorkerDeploymentResponse": {
       "type": "object",
       "properties": {
+        "conflictToken": {
+          "type": "string",
+          "format": "byte"
+        },
         "workerDeploymentInfo": {
           "$ref": "#/definitions/v1WorkerDeploymentInfo"
         }
@@ -11613,16 +11643,16 @@
       "properties": {
         "currentVersion": {
           "type": "string",
-          "title": "Current Version receives all the tasks except the portion that is routed to the Ramping\nVersion according to `ramping_version_percentage`.\nIt is possible that Current Version is not present when user is ramping from unversioned to\nversioned workers. In that case, remaining tasks after `ramping_version_percentage` go to\nunversioned workers. (Unversioned workers are those with UNVERSIONED (or unspecified)\nWorkflowVersioningMode.)"
+          "title": "Always present. Specifies what Deployment Version should should receive new workflow\nexecutions and tasks of existing unversioned or AutoUpgrade workflows.\nCan be one of the following:\n- The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has\n`WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\nwith `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)\nNote: Current Version is overridden by the Ramping Version for a portion of traffic when a ramp\nis set (see `ramping_version`.)"
         },
         "rampingVersion": {
           "type": "string",
-          "description": "Ramping Version is set during gradual rollout of a new Version. It takes a share of tasks\naccording to `ramping_version_percentage`."
+          "description": "When present, it means the traffic is being shifted from the Current Version to the Ramping\nVersion.\nMust always be different from Current Version. Can be one of the following:\n- The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has\n`WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\nwith `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)\nNote that it is possible to ramp from one Version to another Version, or from unversioned\nworkers to a particular Version, or from a particular Version to unversioned workers."
         },
         "rampingVersionPercentage": {
           "type": "number",
           "format": "float",
-          "description": "Percentage of tasks that are routed to the Ramping Version instead of the Current Version.\nSpecial case: it is possible that `ramping_version_percentage` is non-zero while\n`ramping_version` is absent. That case represents gradual migration out of the Current\nVersion to unversioned workers."
+          "description": "Percentage of tasks that are routed to the Ramping Version instead of the Current Version.\nValid range: [0, 100]. A 100% value means the Ramping Version is receiving full traffic but\nnot yet \"promoted\" to be the Current Version, likely due to pending validations."
         },
         "currentVersionUpdateTime": {
           "type": "string",
@@ -12091,18 +12121,26 @@
     "v1SetWorkerDeploymentCurrentVersionResponse": {
       "type": "object",
       "properties": {
+        "conflictToken": {
+          "type": "string",
+          "format": "byte"
+        },
         "previousVersion": {
           "type": "string",
-          "description": "The version that was current before executing this operation."
+          "description": "The Build ID of the version that was current before executing this operation. Can also be the\n`__unversioned__` special value."
         }
       }
     },
     "v1SetWorkerDeploymentRampingVersionResponse": {
       "type": "object",
       "properties": {
+        "conflictToken": {
+          "type": "string",
+          "format": "byte"
+        },
         "previousVersion": {
           "type": "string",
-          "description": "The ramping version before executing this operation."
+          "description": "The Build ID of the version that was ramping before executing this operation. Can also be\nempty or the `__unversioned__` special value."
         },
         "previousPercentage": {
           "type": "number",
@@ -12930,12 +12968,12 @@
         },
         "rampingVersion": {
           "$ref": "#/definitions/v1WorkerDeploymentVersion",
-          "description": "Ramping Version is set during gradual rollout of a new Version. It takes a share of tasks\naccording to `ramping_version_percentage`."
+          "description": "Ramping Version is set during gradual rollout of a new Version. It takes a share of tasks\naccording to `ramping_version_percentage`.\nIt is possible that Ramping Version belong to a Deployment other than that of the Current\nVersion. This happens when a Task Queue is being moved from one Deployment to another."
         },
         "rampingVersionPercentage": {
           "type": "number",
           "format": "float",
-          "description": "Percentage of tasks that are routed to the Ramping Version instead of the Current Version.\nSpecial case: it is possible that `ramping_version_percentage` is non-zero while\n`ramping_version` is absent. That case represents gradual migration out of the Current\nVersion to unversioned workers."
+          "description": "Percentage of tasks that are routed to the Ramping Version instead of the Current Version.\nValid range: [0, 100]. A 100% value means the Ramping Version is receiving full traffic but\nnot yet \"promoted\" to be the Current Version, likely due to pending validations.\nSpecial case: it is possible that `ramping_version_percentage` is non-zero while\n`ramping_version` is absent. That case represents gradual migration out of the Current\nVersion to unversioned workers."
         },
         "updateTime": {
           "type": "string",
@@ -13371,6 +13409,18 @@
       },
       "description": "VersionInfo contains details about current and recommended release versions as well as alerts and upgrade instructions."
     },
+    "v1VersionMetadata": {
+      "type": "object",
+      "properties": {
+        "entries": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/v1Payload"
+          },
+          "description": "Arbitrary key-values."
+        }
+      }
+    },
     "v1VersioningBehavior": {
       "type": "string",
       "enum": [
@@ -13430,6 +13480,10 @@
         },
         "routingInfo": {
           "$ref": "#/definitions/v1RoutingInfo"
+        },
+        "lastModifierIdentity": {
+          "type": "string",
+          "description": "Identity of the last client who modified the configuration of this Deployment. Set to the\n`identity` value sent by APIs such as `SetWorkerDeploymentCurrentVersion` and\n`SetWorkerDeploymentRampingVersion`."
         }
       },
       "description": "A Worker Deployment (Deployment, for short) represents all workers serving \na shared set of Task Queues. Typically, a Deployment represents one service or \napplication.\nA Deployment contains multiple Deployment Versions, each representing a different \nversion of workers. (see documentation of WorkerDeploymentVersionInfo)\nDeployment records are created in Temporal server automatically when their \nfirst poller arrives to the server."
@@ -13437,17 +13491,17 @@
     "v1WorkerDeploymentOptions": {
       "type": "object",
       "properties": {
-        "name": {
+        "deploymentName": {
           "type": "string",
-          "description": "Required. Worker deployment name."
+          "description": "Required. Worker Deployment name."
         },
-        "version": {
+        "buildId": {
           "type": "string",
-          "description": "Required. Worker deployment version."
+          "description": "Required. Build ID of the worker. `deployment_name` and `build_id` together identify this\nWorker Deployment Version."
         },
         "workflowVersioningMode": {
           "$ref": "#/definitions/v1WorkflowVersioningMode",
-          "description": "Required. Workflow versioning mode for this deployment version. Must be the same for all\npollers in a given deployment version, across all task queues."
+          "description": "Required. Workflow versioning mode for this Deployment Version. Must be the same for all\npollers in a given Deployment Version, across all Task Queues."
         }
       },
       "description": "Worker Deployment options set in SDK that need to be sent to server in every poll."
@@ -13455,26 +13509,25 @@
     "v1WorkerDeploymentVersion": {
       "type": "object",
       "properties": {
-        "version": {
-          "type": "string",
-          "description": "Uniquely identifies the worker deployment version."
-        },
         "deploymentName": {
           "type": "string",
-          "description": "The name of the deployment this version belongs too."
+          "description": "The name of the Deployment this version belongs too."
+        },
+        "buildId": {
+          "type": "string",
+          "description": "Build ID uniquely identifies the Deployment Version within a Deployment, but the same Build\nID can be used in multiple Deployments."
         }
-      }
+      },
+      "description": "Identifies a Worker Deployment Version. The combination of `deployment_name` and `build_id`\nserve as the identifier."
     },
     "v1WorkerDeploymentVersionInfo": {
       "type": "object",
       "properties": {
         "version": {
-          "type": "string",
-          "description": "Identifies a Worker Deployment Version. Must be unique within the namespace.\nSame ID cannot be used in multiple Deployments.\nIn some contexts, such as Reset-by-build-id, version might be used\nas \"Build ID\"."
+          "$ref": "#/definitions/v1WorkerDeploymentVersion"
         },
-        "deploymentName": {
-          "type": "string",
-          "description": "Each Worker Version belongs to exactly one Deployment."
+        "workflowVersioningMode": {
+          "$ref": "#/definitions/v1WorkflowVersioningMode"
         },
         "createTime": {
           "type": "string",
@@ -13490,17 +13543,26 @@
           "format": "date-time",
           "description": "\nNil if not ramping."
         },
+        "rampPercentage": {
+          "type": "number",
+          "format": "float",
+          "description": "Zero if the version is not ramping (i.e. `ramping_since_time` is nil)."
+        },
         "taskQueueInfos": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/WorkerDeploymentVersionInfoDeploymentVersionTaskQueueInfo"
+            "$ref": "#/definitions/WorkerDeploymentVersionInfoVersionTaskQueueInfo"
           },
           "description": "All the Task Queues that have ever polled from this Deployment version."
         },
         "drainageInfo": {
           "$ref": "#/definitions/v1VersionDrainageInfo",
           "description": "Helps user determine when it is safe to decommission the workers of this\nVersion. Not present when accepts_new_executions is true.\nCurrent limitations:\n- Not supported for Unversioned mode.\n- Periodically refreshed, may have delays up to few minutes (consult the\n  last_checked_time value).\n- Refreshed only when accepts_new_executions is false AND the status is not\n  \"drained\" yet.\n- Once the status is changed to \"drained\", it is not changed until the Version\n  becomes Current or Ramping again, at which time the drainage info is cleared.\n  This means if the Version is \"drained\" but new workflows are sent to it via\n  Pinned Versioning Override, the status does not account for those Pinned-override\n  executions and remains \"drained\"."
+        },
+        "metadata": {
+          "$ref": "#/definitions/v1VersionMetadata",
+          "description": "Arbitrary user-provided metadata attached to this version."
         }
       },
       "title": "A Worker Deployment Version (Version, for short) represents all workers of the same \ncode and config within a Deployment. Workers of the same Version are expected to \nbehave exactly the same so when executions move between them there are no \nnon-determinism issues.\nWorker Deployment Versions are created in Temporal server automatically when \ntheir first poller arrives to the server.\nEach Version has a Workflow Versioning Mode which is chosen by the app\ndeveloper. (see WorkflowVersioningMode enum documentation)"

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -11487,6 +11487,34 @@
       ],
       "default": "RETRY_STATE_UNSPECIFIED"
     },
+    "v1RoutingInfo": {
+      "type": "object",
+      "properties": {
+        "currentVersion": {
+          "type": "string",
+          "title": "Current Version receives all the tasks except the portion that is routed to the Ramping\nVersion according to `ramping_version_percentage`.\nIt is possible that Current Version is not present when user is ramping from unversioned to\nversioned workers. In that case, remaining tasks after `ramping_version_percentage` go to\nunversioned workers. (Unversioned workers are those with UNVERSIONED (or unspecified)\nWorkflowVersioningMode.)"
+        },
+        "rampingVersion": {
+          "type": "string",
+          "description": "Ramping Version is set during gradual rollout of a new Version. It takes a share of tasks\naccording to `ramping_version_percentage`."
+        },
+        "rampingVersionPercentage": {
+          "type": "number",
+          "format": "float",
+          "description": "Percentage of tasks that are routed to the Ramping Version instead of the Current Version.\nSpecial case: it is possible that `ramping_version_percentage` is non-zero while\n`ramping_version` is absent. That case represents gradual migration out of the Current\nVersion to unversioned workers."
+        },
+        "currentVersionUpdateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last time current version was updated."
+        },
+        "rampingVersionUpdateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last time ramping version was updated."
+        }
+      }
+    },
     "v1ScanWorkflowExecutionsResponse": {
       "type": "object",
       "properties": {
@@ -13248,6 +13276,9 @@
         "createTime": {
           "type": "string",
           "format": "date-time"
+        },
+        "routingInfo": {
+          "$ref": "#/definitions/v1RoutingInfo"
         }
       },
       "description": "A Worker Deployment (Deployment, for short) represents all workers serving \na shared set of Task Queues. Typically, a Deployment represents one service or \napplication.\nA Deployment contains multiple Deployment Versions, each representing a different \nversion of workers. (see documentation of WorkerDeploymentVersionInfo)\nDeployment records are created in Temporal server automatically when their \nfirst poller arrives to the server."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -1567,36 +1567,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/worker-deployments-version/{version}:
-    get:
-      tags:
-        - WorkflowService
-      description: Describes a worker deployment version.
-      operationId: DescribeWorkerDeploymentVersion
-      parameters:
-        - name: namespace
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: version
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DescribeWorkerDeploymentVersionResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
   /api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}:
     get:
       tags:
@@ -1696,6 +1666,53 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SetWorkerDeploymentRampingVersionResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/worker-deployments/{version.deployment_name}/version/{version.build_id}:
+    get:
+      tags:
+        - WorkflowService
+      description: Describes a worker deployment version.
+      operationId: DescribeWorkerDeploymentVersion
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: version.deployment_name
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: version.build_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: version.deploymentName
+          in: query
+          description: The name of the Deployment this version belongs too.
+          schema:
+            type: string
+        - name: version.buildId
+          in: query
+          description: |-
+            Build ID uniquely identifies the Deployment Version within a Deployment, but the same Build
+             ID can be used in multiple Deployments.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DescribeWorkerDeploymentVersionResponse'
         default:
           description: Default error response
           content:
@@ -4346,36 +4363,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/worker-deployments-version/{version}:
-    get:
-      tags:
-        - WorkflowService
-      description: Describes a worker deployment version.
-      operationId: DescribeWorkerDeploymentVersion
-      parameters:
-        - name: namespace
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: version
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DescribeWorkerDeploymentVersionResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
   /namespaces/{namespace}/worker-deployments/{deploymentName}:
     get:
       tags:
@@ -4475,6 +4462,53 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SetWorkerDeploymentRampingVersionResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/worker-deployments/{version.deployment_name}/version/{version.build_id}:
+    get:
+      tags:
+        - WorkflowService
+      description: Describes a worker deployment version.
+      operationId: DescribeWorkerDeploymentVersion
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: version.deployment_name
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: version.build_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: version.deploymentName
+          in: query
+          description: The name of the Deployment this version belongs too.
+          schema:
+            type: string
+        - name: version.buildId
+          in: query
+          description: |-
+            Build ID uniquely identifies the Deployment Version within a Deployment, but the same Build
+             ID can be used in multiple Deployments.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DescribeWorkerDeploymentVersionResponse'
         default:
           description: Default error response
           content:
@@ -6513,6 +6547,9 @@ components:
     DescribeWorkerDeploymentResponse:
       type: object
       properties:
+        conflictToken:
+          type: string
+          format: bytes
         workerDeploymentInfo:
           $ref: '#/components/schemas/WorkerDeploymentInfo'
     DescribeWorkerDeploymentVersionResponse:
@@ -8946,24 +8983,33 @@ components:
         currentVersion:
           type: string
           description: |-
-            Current Version receives all the tasks except the portion that is routed to the Ramping
-             Version according to `ramping_version_percentage`.
-             It is possible that Current Version is not present when user is ramping from unversioned to
-             versioned workers. In that case, remaining tasks after `ramping_version_percentage` go to
-             unversioned workers. (Unversioned workers are those with UNVERSIONED (or unspecified)
-             WorkflowVersioningMode.)
+            Always present. Specifies what Deployment Version should should receive new workflow
+             executions and tasks of existing unversioned or AutoUpgrade workflows.
+             Can be one of the following:
+             - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
+             `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
+             - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
+             with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
+             Note: Current Version is overridden by the Ramping Version for a portion of traffic when a ramp
+             is set (see `ramping_version`.)
         rampingVersion:
           type: string
           description: |-
-            Ramping Version is set during gradual rollout of a new Version. It takes a share of tasks
-             according to `ramping_version_percentage`.
+            When present, it means the traffic is being shifted from the Current Version to the Ramping
+             Version.
+             Must always be different from Current Version. Can be one of the following:
+             - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
+             `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
+             - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
+             with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
+             Note that it is possible to ramp from one Version to another Version, or from unversioned
+             workers to a particular Version, or from a particular Version to unversioned workers.
         rampingVersionPercentage:
           type: number
           description: |-
             Percentage of tasks that are routed to the Ramping Version instead of the Current Version.
-             Special case: it is possible that `ramping_version_percentage` is non-zero while
-             `ramping_version` is absent. That case represents gradual migration out of the Current
-             Version to unversioned workers.
+             Valid range: [0, 100]. A 100% value means the Ramping Version is receiving full traffic but
+             not yet "promoted" to be the Current Version, likely due to pending validations.
           format: float
         currentVersionUpdateTime:
           type: string
@@ -9375,7 +9421,20 @@ components:
           type: string
         version:
           type: string
-          description: Must be a Versioned Build. Pass empty string to unset.
+          description: |-
+            Required. Can be one of the following:
+             - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
+             `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
+             - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
+             with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
+        conflictToken:
+          type: string
+          description: |-
+            Optional. This can be the value of conflict_token from a Describe, or another Worker
+             Deployment API. Passing conflict token which will cause this request to fail if the
+             Deployment's configuration has been modified between the previous API call and
+             this one.
+          format: bytes
         identity:
           type: string
           description: Optional. The identity of the client who initiated this request.
@@ -9383,9 +9442,14 @@ components:
     SetWorkerDeploymentCurrentVersionResponse:
       type: object
       properties:
+        conflictToken:
+          type: string
+          format: bytes
         previousVersion:
           type: string
-          description: The version that was current before executing this operation.
+          description: |-
+            The Build ID of the version that was current before executing this operation. Can also be the
+             `__unversioned__` special value.
     SetWorkerDeploymentRampingVersionRequest:
       type: object
       properties:
@@ -9396,29 +9460,39 @@ components:
         version:
           type: string
           description: |-
-            The Version to be set as the Ramping Version of the Deployment. Optional when `percentage` is
-             zero (unset case), but if given, it must match the current Ramping Version to be unset.
-             Can be an empty string and paired with a non-zero `percentage`, in which case it will set the ramp
-             percentage without a Ramping Version which means unversioned workers are being ramped.
-             (Useful for migrating to unversioned workers from Deployment's Current Version.)
+            Can be one of the following:
+             - Absent/empty value to unset the Ramping Version. Must be paired with `percentage=0`.
+             - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
+             `WorkflowVersioningMode==VERSIONING_BEHAVIORS`) to set it as the Ramping Version.
+             - Or, the "__unversioned__" special value, to ramp unversioned workers (those with
+             `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
         percentage:
           type: number
-          description: 'Valid range: [0,100]. Zero value will unset the Ramping Version.'
+          description: 'Ramp percentage to set. Valid range: [0,100].'
           format: float
+        conflictToken:
+          type: string
+          description: |-
+            Optional. This can be the value of conflict_token from a Describe, or another Worker
+             Deployment API. Passing conflict token which will cause this request to fail if the
+             Deployment's configuration has been modified between the previous API call and
+             this one.
+          format: bytes
         identity:
           type: string
           description: Optional. The identity of the client who initiated this request.
-      description: |-
-        Set/unset the Ramping Version of a Worker Deployment and its ramp percentage.
-         To unset, pass zero `percentage`.
-         To ramp to unversioned workers (from Deployment's Current Version), pass `version=""` with
-         non-zero `percentage`.
+      description: Set/unset the Ramping Version of a Worker Deployment and its ramp percentage.
     SetWorkerDeploymentRampingVersionResponse:
       type: object
       properties:
+        conflictToken:
+          type: string
+          format: bytes
         previousVersion:
           type: string
-          description: The ramping version before executing this operation.
+          description: |-
+            The Build ID of the version that was ramping before executing this operation. Can also be
+             empty or the `__unversioned__` special value.
         previousPercentage:
           type: number
           description: The ramping version percentage before executing this operation.
@@ -10199,10 +10273,14 @@ components:
           description: |-
             Ramping Version is set during gradual rollout of a new Version. It takes a share of tasks
              according to `ramping_version_percentage`.
+             It is possible that Ramping Version belong to a Deployment other than that of the Current
+             Version. This happens when a Task Queue is being moved from one Deployment to another.
         rampingVersionPercentage:
           type: number
           description: |-
             Percentage of tasks that are routed to the Ramping Version instead of the Current Version.
+             Valid range: [0, 100]. A 100% value means the Ramping Version is receiving full traffic but
+             not yet "promoted" to be the Current Version, likely due to pending validations.
              Special case: it is possible that `ramping_version_percentage` is non-zero while
              `ramping_version` is absent. That case represents gradual migration out of the Current
              Version to unversioned workers.
@@ -10722,6 +10800,14 @@ components:
           type: string
           format: date-time
       description: VersionInfo contains details about current and recommended release versions as well as alerts and upgrade instructions.
+    VersionMetadata:
+      type: object
+      properties:
+        entries:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/Payload'
+          description: Arbitrary key-values.
     VersioningOverride:
       type: object
       properties:
@@ -10786,6 +10872,12 @@ components:
           format: date-time
         routingInfo:
           $ref: '#/components/schemas/RoutingInfo'
+        lastModifierIdentity:
+          type: string
+          description: |-
+            Identity of the last client who modified the configuration of this Deployment. Set to the
+             `identity` value sent by APIs such as `SetWorkerDeploymentCurrentVersion` and
+             `SetWorkerDeploymentRampingVersion`.
       description: "A Worker Deployment (Deployment, for short) represents all workers serving \n a shared set of Task Queues. Typically, a Deployment represents one service or \n application.\n A Deployment contains multiple Deployment Versions, each representing a different \n version of workers. (see documentation of WorkerDeploymentVersionInfo)\n Deployment records are created in Temporal server automatically when their \n first poller arrives to the server."
     WorkerDeploymentInfo_WorkerDeploymentVersionSummary:
       type: object
@@ -10802,17 +10894,24 @@ components:
         createTime:
           type: string
           format: date-time
-        acceptsNewExecutions:
-          type: boolean
+        drainageStatus:
+          enum:
+            - VERSION_DRAINAGE_STATUS_UNSPECIFIED
+            - VERSION_DRAINAGE_STATUS_DRAINING
+            - VERSION_DRAINAGE_STATUS_DRAINED
+          type: string
+          format: enum
     WorkerDeploymentOptions:
       type: object
       properties:
-        name:
+        deploymentName:
           type: string
-          description: Required. Worker deployment name.
-        version:
+          description: Required. Worker Deployment name.
+        buildId:
           type: string
-          description: Required. Worker deployment version.
+          description: |-
+            Required. Build ID of the worker. `deployment_name` and `build_id` together identify this
+             Worker Deployment Version.
         workflowVersioningMode:
           enum:
             - WORKFLOW_VERSIONING_MODE_UNSPECIFIED
@@ -10820,32 +10919,36 @@ components:
             - WORKFLOW_VERSIONING_MODE_VERSIONING_BEHAVIORS
           type: string
           description: |-
-            Required. Workflow versioning mode for this deployment version. Must be the same for all
-             pollers in a given deployment version, across all task queues.
+            Required. Workflow versioning mode for this Deployment Version. Must be the same for all
+             pollers in a given Deployment Version, across all Task Queues.
           format: enum
       description: Worker Deployment options set in SDK that need to be sent to server in every poll.
     WorkerDeploymentVersion:
       type: object
       properties:
-        version:
-          type: string
-          description: Uniquely identifies the worker deployment version.
         deploymentName:
           type: string
-          description: The name of the deployment this version belongs too.
+          description: The name of the Deployment this version belongs too.
+        buildId:
+          type: string
+          description: |-
+            Build ID uniquely identifies the Deployment Version within a Deployment, but the same Build
+             ID can be used in multiple Deployments.
+      description: |-
+        Identifies a Worker Deployment Version. The combination of `deployment_name` and `build_id`
+         serve as the identifier.
     WorkerDeploymentVersionInfo:
       type: object
       properties:
         version:
+          $ref: '#/components/schemas/WorkerDeploymentVersion'
+        workflowVersioningMode:
+          enum:
+            - WORKFLOW_VERSIONING_MODE_UNSPECIFIED
+            - WORKFLOW_VERSIONING_MODE_UNVERSIONED
+            - WORKFLOW_VERSIONING_MODE_VERSIONING_BEHAVIORS
           type: string
-          description: |-
-            Identifies a Worker Deployment Version. Must be unique within the namespace.
-             Same ID cannot be used in multiple Deployments.
-             In some contexts, such as Reset-by-build-id, version might be used
-             as "Build ID".
-        deploymentName:
-          type: string
-          description: Each Worker Version belongs to exactly one Deployment.
+          format: enum
         createTime:
           type: string
           format: date-time
@@ -10863,10 +10966,14 @@ components:
                  aip.dev/not-precedent: 'Since' captures the field semantics despite being a preposition. --)
              Nil if not ramping.
           format: date-time
+        rampPercentage:
+          type: number
+          description: Zero if the version is not ramping (i.e. `ramping_since_time` is nil).
+          format: float
         taskQueueInfos:
           type: array
           items:
-            $ref: '#/components/schemas/WorkerDeploymentVersionInfo_DeploymentVersionTaskQueueInfo'
+            $ref: '#/components/schemas/WorkerDeploymentVersionInfo_VersionTaskQueueInfo'
           description: All the Task Queues that have ever polled from this Deployment version.
         drainageInfo:
           allOf:
@@ -10885,8 +10992,12 @@ components:
                This means if the Version is "drained" but new workflows are sent to it via
                Pinned Versioning Override, the status does not account for those Pinned-override
                executions and remains "drained".
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/VersionMetadata'
+          description: Arbitrary user-provided metadata attached to this version.
       description: "A Worker Deployment Version (Version, for short) represents all workers of the same \n code and config within a Deployment. Workers of the same Version are expected to \n behave exactly the same so when executions move between them there are no \n non-determinism issues.\n Worker Deployment Versions are created in Temporal server automatically when \n their first poller arrives to the server.\n Each Version has a Workflow Versioning Mode which is chosen by the app\n developer. (see WorkflowVersioningMode enum documentation)"
-    WorkerDeploymentVersionInfo_DeploymentVersionTaskQueueInfo:
+    WorkerDeploymentVersionInfo_VersionTaskQueueInfo:
       type: object
       properties:
         name:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9445,7 +9445,7 @@ components:
         conflictToken:
           type: string
           format: bytes
-        previousVersion:
+        previousBuildId:
           type: string
           description: |-
             The Build ID of the version that was current before executing this operation. Can also be the
@@ -9488,7 +9488,7 @@ components:
         conflictToken:
           type: string
           format: bytes
-        previousVersion:
+        previousBuildId:
           type: string
           description: |-
             The Build ID of the version that was ramping before executing this operation. Can also be

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -8987,9 +8987,9 @@ components:
              executions and tasks of existing unversioned or AutoUpgrade workflows.
              Can be one of the following:
              - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
-             `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
+               `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
              - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
-             with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
+               with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
              Note: Current Version is overridden by the Ramping Version for a portion of traffic when a ramp
              is set (see `ramping_version`.)
         rampingVersion:
@@ -8999,9 +8999,9 @@ components:
              Version.
              Must always be different from Current Version. Can be one of the following:
              - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
-             `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
+               `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
              - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
-             with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
+               with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
              Note that it is possible to ramp from one Version to another Version, or from unversioned
              workers to a particular Version, or from a particular Version to unversioned workers.
         rampingVersionPercentage:
@@ -9424,9 +9424,9 @@ components:
           description: |-
             Required. Can be one of the following:
              - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
-             `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
+               `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
              - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
-             with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
+               with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
         conflictToken:
           type: string
           description: |-
@@ -9463,9 +9463,9 @@ components:
             Can be one of the following:
              - Absent/empty value to unset the Ramping Version. Must be paired with `percentage=0`.
              - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
-             `WorkflowVersioningMode==VERSIONING_BEHAVIORS`) to set it as the Ramping Version.
+               `WorkflowVersioningMode==VERSIONING_BEHAVIORS`) to set it as the Ramping Version.
              - Or, the "__unversioned__" special value, to ramp unversioned workers (those with
-             `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
+               `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
         percentage:
           type: number
           description: 'Ramp percentage to set. Valid range: [0,100].'
@@ -10261,29 +10261,34 @@ components:
           allOf:
             - $ref: '#/components/schemas/WorkerDeploymentVersion'
           description: |-
-            Current Version receives all the tasks except the portion that is routed to the Ramping
-             Version according to `ramping_version_percentage`.
-             It is possible that Current Version is not present when user is ramping from unversioned to
-             versioned workers. In that case, remaining tasks after `ramping_version_percentage` go to
-             unversioned workers. (Unversioned workers are those with UNVERSIONED (or unspecified)
-             WorkflowVersioningMode.)
+            Always present. Specifies which Deployment Version should should receive new workflow
+             executions and tasks of existing unversioned or AutoUpgrade workflows.
+             Can be one of the following:
+             - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
+               `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
+             - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
+               with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
+             Note: Current Version is overridden by the Ramping Version for a portion of traffic when a ramp
+             is set (see `ramping_version`.)
         rampingVersion:
           allOf:
             - $ref: '#/components/schemas/WorkerDeploymentVersion'
           description: |-
-            Ramping Version is set during gradual rollout of a new Version. It takes a share of tasks
-             according to `ramping_version_percentage`.
-             It is possible that Ramping Version belong to a Deployment other than that of the Current
-             Version. This happens when a Task Queue is being moved from one Deployment to another.
+            When present, it means the traffic is being shifted from the Current Version to the Ramping
+             Version.
+             Must always be different from Current Version. Can be one of the following:
+             - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
+               `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
+             - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
+               with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
+             Note that it is possible to ramp from one Version to another Version, or from unversioned
+             workers to a particular Version, or from a particular Version to unversioned workers.
         rampingVersionPercentage:
           type: number
           description: |-
             Percentage of tasks that are routed to the Ramping Version instead of the Current Version.
              Valid range: [0, 100]. A 100% value means the Ramping Version is receiving full traffic but
              not yet "promoted" to be the Current Version, likely due to pending validations.
-             Special case: it is possible that `ramping_version_percentage` is non-zero while
-             `ramping_version` is absent. That case represents gradual migration out of the Current
-             Version to unversioned workers.
           format: float
         updateTime:
           type: string
@@ -10769,7 +10774,7 @@ components:
             - VERSION_DRAINAGE_STATUS_DRAINED
           type: string
           description: |-
-            Set to DRAINING when the version stops accepting new executions (is no longer current or ramping).
+            Set to DRAINING when the version first stops accepting new executions (is no longer current or ramping).
              Set to DRAINED when no more open pinned workflows exist on this version.
           format: enum
         lastChangedTime:
@@ -10782,7 +10787,7 @@ components:
           format: date-time
       description: |-
         Information about workflow drainage to help the user determine when it is safe
-         to decommission a Version. Not present while the version is current or ramping.
+         to decommission a Version. Not present while version is current or ramping.
     VersionInfo:
       type: object
       properties:
@@ -10984,7 +10989,20 @@ components:
         drainageInfo:
           allOf:
             - $ref: '#/components/schemas/VersionDrainageInfo'
-          description: "Helps user determine when it is safe to decommission the workers of this\n Version. Not present when the workflow is accepting new workflow executions because it's current or ramping.\n Current limitations:\n - Not supported for Unversioned mode.\n - Periodically refreshed, may have delays up to few minutes (consult the\n   last_checked_time value).\n - Refreshed only when the version is neither current nor ramping AND \n the status is not \"drained\" yet.\n - Once the status is changed to \"drained\", it is not changed until the Version\n   becomes Current or Ramping again, at which time the drainage info is cleared.\n   This means if the Version is \"drained\" but new workflows are sent to it via\n   Pinned Versioning Override, the status does not account for those Pinned-override\n   executions and remains \"drained\"."
+          description: |-
+            Helps user determine when it is safe to decommission the workers of this
+             Version. Not present when version is current or ramping.
+             Current limitations:
+             - Not supported for Unversioned mode.
+             - Periodically refreshed, may have delays up to few minutes (consult the
+               last_checked_time value).
+             - Refreshed only when version is not current or ramping AND the status is not
+               "drained" yet.
+             - Once the status is changed to "drained", it is not changed until the Version
+               becomes Current or Ramping again, at which time the drainage info is cleared.
+               This means if the Version is "drained" but new workflows are sent to it via
+               Pinned Versioning Override, the status does not account for those Pinned-override
+               executions and remains "drained".
         metadata:
           allOf:
             - $ref: '#/components/schemas/VersionMetadata'
@@ -11003,7 +11021,6 @@ components:
             - TASK_QUEUE_TYPE_NEXUS
           type: string
           format: enum
-      description: 'TODO (Shivam): + Poller_status + WorkerDeploymentVersionMetadata'
     WorkerVersionCapabilities:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -1533,42 +1533,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/worker-deployment/{deploymentName}/set-current-version:
-    post:
-      tags:
-        - WorkflowService
-      description: Sets a deployment version as the current version for its deployment.
-      operationId: SetCurrentDeploymentVersion
-      parameters:
-        - name: namespace
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: deploymentName
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SetCurrentDeploymentVersionRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SetCurrentDeploymentVersionResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
   /api/v1/namespaces/{namespace}/worker-deployments-version/{version}:
     get:
       tags:
@@ -1622,6 +1586,82 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DescribeWorkerDeploymentResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}/set-current-version:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        Set/unset the Current Version of a Worker Deployment. Automatically unsets the Ramping
+         Version if it is the Version being set as Current.
+      operationId: SetWorkerDeploymentCurrentVersion
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: deploymentName
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetWorkerDeploymentCurrentVersionRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SetWorkerDeploymentCurrentVersionResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}/set-ramping-version:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for
+         gradual ramp to unversioned workers too.
+      operationId: SetWorkerDeploymentRampingVersion
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: deploymentName
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetWorkerDeploymentRampingVersionRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SetWorkerDeploymentRampingVersionResponse'
         default:
           description: Default error response
           content:
@@ -4238,42 +4278,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/worker-deployment/{deploymentName}/set-current-version:
-    post:
-      tags:
-        - WorkflowService
-      description: Sets a deployment version as the current version for its deployment.
-      operationId: SetCurrentDeploymentVersion
-      parameters:
-        - name: namespace
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: deploymentName
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SetCurrentDeploymentVersionRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SetCurrentDeploymentVersionResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
   /namespaces/{namespace}/worker-deployments-version/{version}:
     get:
       tags:
@@ -4327,6 +4331,82 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DescribeWorkerDeploymentResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/worker-deployments/{deploymentName}/set-current-version:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        Set/unset the Current Version of a Worker Deployment. Automatically unsets the Ramping
+         Version if it is the Version being set as Current.
+      operationId: SetWorkerDeploymentCurrentVersion
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: deploymentName
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetWorkerDeploymentCurrentVersionRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SetWorkerDeploymentCurrentVersionResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/worker-deployments/{deploymentName}/set-ramping-version:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for
+         gradual ramp to unversioned workers too.
+      operationId: SetWorkerDeploymentRampingVersion
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: deploymentName
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetWorkerDeploymentRampingVersionRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SetWorkerDeploymentRampingVersionResponse'
         default:
           description: Default error response
           content:
@@ -6349,6 +6429,19 @@ components:
           description: |-
             This map contains Task Queue information for each Build ID. Empty string as key value means unversioned.
              Only set in `ENHANCED` mode.
+        versioningInfo:
+          allOf:
+            - $ref: '#/components/schemas/TaskQueueVersioningInfo'
+          description: |-
+            Specifies which Worker Deployment Version(s) Server routes this Task Queue's tasks to.
+             When not present, it means the tasks are routed to "unversioned" workers. Unversioned workers
+             are those with UNVERSIONED (or unspecified) WorkflowVersioningMode.
+             Task Queue Versioning info is updated indirectly by calling SetWorkerDeploymentCurrentVersion
+             and SetWorkerDeploymentRampingVersion on Worker Deployments.
+             Note: This information is not relevant to Pinned workflow executions and their activities as
+             they are always routed to their Pinned Deployment Version. However, new workflow executions
+             are typically not Pinned until they complete their first task (unless they are started with
+             a Pinned VersioningOverride or are Child Workflows of a Pinned parent).
     DescribeWorkerDeploymentResponse:
       type: object
       properties:
@@ -9150,7 +9243,7 @@ components:
             - $ref: '#/components/schemas/DeploymentInfo'
           description: Info of the deployment that was current before executing this operation.
       description: '[cleanup-wv-pre-release] Pre-release deployment APIs, clean up later'
-    SetCurrentDeploymentVersionRequest:
+    SetWorkerDeploymentCurrentVersionRequest:
       type: object
       properties:
         namespace:
@@ -9163,12 +9256,50 @@ components:
         identity:
           type: string
           description: Optional. The identity of the client who initiated this request.
-    SetCurrentDeploymentVersionResponse:
+      description: Set/unset the Current Version of a Worker Deployment.
+    SetWorkerDeploymentCurrentVersionResponse:
       type: object
       properties:
         previousVersion:
           type: string
-          description: Info of the version that was current before executing this operation.
+          description: The version that was current before executing this operation.
+    SetWorkerDeploymentRampingVersionRequest:
+      type: object
+      properties:
+        namespace:
+          type: string
+        deploymentName:
+          type: string
+        version:
+          type: string
+          description: |-
+            The Version to be set as the Ramping Version of the Deployment. Optional when `percentage` is
+             zero (unset case), but if given, it must match the current Ramping Version to be unset.
+             Can be an empty string and paired with a non-zero `percentage`, in which case it will set the ramp
+             percentage without a Ramping Version which means unversioned workers are being ramped.
+             (Useful for migrating to unversioned workers from Deployment's Current Version.)
+        percentage:
+          type: number
+          description: 'Valid range: [0,100]. Zero value will unset the Ramping Version.'
+          format: float
+        identity:
+          type: string
+          description: Optional. The identity of the client who initiated this request.
+      description: |-
+        Set/unset the Ramping Version of a Worker Deployment and its ramp percentage.
+         To unset, pass zero `percentage`.
+         To ramp to unversioned workers (from Deployment's Current Version), pass `version=""` with
+         non-zero `percentage`.
+    SetWorkerDeploymentRampingVersionResponse:
+      type: object
+      properties:
+        previousVersion:
+          type: string
+          description: The ramping version before executing this operation.
+        previousPercentage:
+          type: number
+          description: The ramping version percentage before executing this operation.
+          format: float
     SignalExternalWorkflowExecutionFailedEventAttributes:
       type: object
       properties:
@@ -9926,6 +10057,37 @@ components:
              who inherit the parent/previous workflow's Build ID but not its Task Queue. In those cases, make
              sure to query reachability for the parent/previous workflow's Task Queue as well.
           format: enum
+    TaskQueueVersioningInfo:
+      type: object
+      properties:
+        currentVersion:
+          allOf:
+            - $ref: '#/components/schemas/WorkerDeploymentVersion'
+          description: |-
+            Current Version receives all the tasks except the portion that is routed to the Ramping
+             Version according to `ramping_version_percentage`.
+             It is possible that Current Version is not present when user is ramping from unversioned to
+             versioned workers. In that case, remaining tasks after `ramping_version_percentage` go to
+             unversioned workers. (Unversioned workers are those with UNVERSIONED (or unspecified)
+             WorkflowVersioningMode.)
+        rampingVersion:
+          allOf:
+            - $ref: '#/components/schemas/WorkerDeploymentVersion'
+          description: |-
+            Ramping Version is set during gradual rollout of a new Version. It takes a share of tasks
+             according to `ramping_version_percentage`.
+        rampingVersionPercentage:
+          type: number
+          description: |-
+            Percentage of tasks that are routed to the Ramping Version instead of the Current Version.
+             Special case: it is possible that `ramping_version_percentage` is non-zero while
+             `ramping_version` is absent. That case represents gradual migration out of the Current
+             Version to unversioned workers.
+          format: float
+        updateTime:
+          type: string
+          description: Last time versioning information of this Task Queue changed.
+          format: date-time
     TerminateWorkflowExecutionRequest:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -10446,10 +10446,10 @@ components:
         taskQueueInfos:
           type: array
           items:
-            $ref: '#/components/schemas/WorkerDeploymentVersionInfo_WorkerBuildTaskQueueInfo'
+            $ref: '#/components/schemas/WorkerDeploymentVersionInfo_DeploymentVersionTaskQueueInfo'
           description: All the Task Queues that have ever polled from this Deployment version.
       description: "A Worker Deployment Version (Version, for short) represents all workers of the same \n code and config within a Deployment. Workers of the same Version are expected to \n behave exactly the same so when executions move between them there are no \n non-determinism issues.\n Worker Deployment Versions are created in Temporal server automatically when \n their first poller arrives to the server.\n Each Version has a Workflow Versioning Mode which is chosen by the app\n developer. (see WorkflowVersioningMode enum documentation)"
-    WorkerDeploymentVersionInfo_WorkerBuildTaskQueueInfo:
+    WorkerDeploymentVersionInfo_DeploymentVersionTaskQueueInfo:
       type: object
       properties:
         name:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -1533,6 +1533,40 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/worker-deployments:
+    get:
+      tags:
+        - WorkflowService
+      operationId: ListWorkerDeployments
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: pageSize
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: nextPageToken
+          in: query
+          schema:
+            type: string
+            format: bytes
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListWorkerDeploymentsResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
   /api/v1/namespaces/{namespace}/worker-deployments-version/{version}:
     get:
       tags:
@@ -4272,6 +4306,40 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DescribeTaskQueueResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/worker-deployments:
+    get:
+      tags:
+        - WorkflowService
+      operationId: ListWorkerDeployments
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: pageSize
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: nextPageToken
+          in: query
+          schema:
+            type: string
+            format: bytes
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListWorkerDeploymentsResponse'
         default:
           description: Default error response
           content:
@@ -7316,6 +7384,28 @@ components:
           additionalProperties:
             type: string
           description: Mapping from the attribute name to the visibility storage native type.
+    ListWorkerDeploymentsResponse:
+      type: object
+      properties:
+        nextPageToken:
+          type: string
+          format: bytes
+        workerDeployments:
+          type: array
+          items:
+            $ref: '#/components/schemas/ListWorkerDeploymentsResponse_WorkerDeploymentSummary'
+          description: The list of worker deployments.
+    ListWorkerDeploymentsResponse_WorkerDeploymentSummary:
+      type: object
+      properties:
+        name:
+          type: string
+        createTime:
+          type: string
+          format: date-time
+        routingInfo:
+          $ref: '#/components/schemas/RoutingInfo'
+      description: A subset of WorkerDeploymentInfo
     ListWorkflowExecutionsResponse:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -8850,6 +8850,39 @@ components:
             Non-Retryable errors types. Will stop retrying if the error type matches this list. Note that
              this is not a substring match, the error *type* (not message) must match exactly.
       description: How retries ought to be handled, usable by both workflows and activities
+    RoutingInfo:
+      type: object
+      properties:
+        currentVersion:
+          type: string
+          description: |-
+            Current Version receives all the tasks except the portion that is routed to the Ramping
+             Version according to `ramping_version_percentage`.
+             It is possible that Current Version is not present when user is ramping from unversioned to
+             versioned workers. In that case, remaining tasks after `ramping_version_percentage` go to
+             unversioned workers. (Unversioned workers are those with UNVERSIONED (or unspecified)
+             WorkflowVersioningMode.)
+        rampingVersion:
+          type: string
+          description: |-
+            Ramping Version is set during gradual rollout of a new Version. It takes a share of tasks
+             according to `ramping_version_percentage`.
+        rampingVersionPercentage:
+          type: number
+          description: |-
+            Percentage of tasks that are routed to the Ramping Version instead of the Current Version.
+             Special case: it is possible that `ramping_version_percentage` is non-zero while
+             `ramping_version` is absent. That case represents gradual migration out of the Current
+             Version to unversioned workers.
+          format: float
+        currentVersionUpdateTime:
+          type: string
+          description: Last time current version was updated.
+          format: date-time
+        rampingVersionUpdateTime:
+          type: string
+          description: Last time ramping version was updated.
+          format: date-time
     Schedule:
       type: object
       properties:
@@ -10637,6 +10670,8 @@ components:
         createTime:
           type: string
           format: date-time
+        routingInfo:
+          $ref: '#/components/schemas/RoutingInfo'
       description: "A Worker Deployment (Deployment, for short) represents all workers serving \n a shared set of Task Queues. Typically, a Deployment represents one service or \n application.\n A Deployment contains multiple Deployment Versions, each representing a different \n version of workers. (see documentation of WorkerDeploymentVersionInfo)\n Deployment records are created in Temporal server automatically when their \n first poller arrives to the server."
     WorkerDeploymentInfo_WorkerDeploymentVersionSummary:
       type: object

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -1599,6 +1599,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}:
+    get:
+      tags:
+        - WorkflowService
+      operationId: DescribeWorkerDeployment
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: deploymentName
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DescribeWorkerDeploymentResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
   /api/v1/namespaces/{namespace}/worker-task-reachability:
     get:
       tags:
@@ -4275,6 +4304,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/worker-deployments/{deploymentName}:
+    get:
+      tags:
+        - WorkflowService
+      operationId: DescribeWorkerDeployment
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: deploymentName
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DescribeWorkerDeploymentResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
   /namespaces/{namespace}/worker-task-reachability:
     get:
       tags:
@@ -6291,6 +6349,11 @@ components:
           description: |-
             This map contains Task Queue information for each Build ID. Empty string as key value means unversioned.
              Only set in `ENHANCED` mode.
+    DescribeWorkerDeploymentResponse:
+      type: object
+      properties:
+        workerDeploymentInfo:
+          $ref: '#/components/schemas/WorkerDeploymentInfo'
     DescribeWorkerDeploymentVersionResponse:
       type: object
       properties:
@@ -10398,6 +10461,38 @@ components:
              user specified timeout, API call returns even if specified stage is not reached.
           format: enum
       description: Specifies client's intent to wait for Update results.
+    WorkerDeploymentInfo:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Identifies a Worker Deployment. Must be unique within the namespace.
+        versionSummaries:
+          type: array
+          items:
+            $ref: '#/components/schemas/WorkerDeploymentInfo_WorkerDeploymentVersionSummary'
+          description: "Deployment Versions that are currently tracked in this Deployment. A DeploymentVersion will be\n cleaned up automatically if all the following conditions meet:\n - It does not receive new executions (see WorkerDeploymentVersionInfo.accepts_new_executions) \n - It has no active pollers (see WorkerDeploymentVersionInfo.pollers_status) \n - It is drained (see WorkerDeploymentVersionInfo.drainage_status)"
+        createTime:
+          type: string
+          format: date-time
+      description: "A Worker Deployment (Deployment, for short) represents all workers serving \n a shared set of Task Queues. Typically, a Deployment represents one service or \n application.\n A Deployment contains multiple Deployment Versions, each representing a different \n version of workers. (see documentation of WorkerDeploymentVersionInfo)\n Deployment records are created in Temporal server automatically when their \n first poller arrives to the server."
+    WorkerDeploymentInfo_WorkerDeploymentVersionSummary:
+      type: object
+      properties:
+        version:
+          type: string
+        workflowVersioningMode:
+          enum:
+            - WORKFLOW_VERSIONING_MODE_UNSPECIFIED
+            - WORKFLOW_VERSIONING_MODE_UNVERSIONED
+            - WORKFLOW_VERSIONING_MODE_VERSIONING_BEHAVIORS
+          type: string
+          format: enum
+        createTime:
+          type: string
+          format: date-time
+        acceptsNewExecutions:
+          type: boolean
     WorkerDeploymentOptions:
       type: object
       properties:

--- a/temporal/api/deployment/v1/message.proto
+++ b/temporal/api/deployment/v1/message.proto
@@ -171,7 +171,7 @@ message WorkerDeploymentVersionInfo {
 // Information about workflow drainage to help the user determine when it is safe
 // to decommission a Version. Not present while the version is current or ramping.
 message VersionDrainageInfo {
-    // Set to DRAINING when accepts_new_executions first becomes false.
+    // Set to DRAINING when the version stops accepting new executions (is no longer current or ramping).
     // Set to DRAINED when no more open pinned workflows exist on this version.
     enums.v1.VersionDrainageStatus status = 1;
     // Last time the drainage status changed.

--- a/temporal/api/deployment/v1/message.proto
+++ b/temporal/api/deployment/v1/message.proto
@@ -145,7 +145,7 @@ message WorkerDeploymentVersionInfo {
     repeated VersionTaskQueueInfo task_queue_infos = 7;
 
     // Helps user determine when it is safe to decommission the workers of this
-    // Version. Not present when accepts_new_executions is true.
+    // Version. Not present when the workflow is accepting new workflow executions because it's current or ramping.
     // Current limitations:
     // - Not supported for Unversioned mode.
     // - Periodically refreshed, may have delays up to few minutes (consult the

--- a/temporal/api/deployment/v1/message.proto
+++ b/temporal/api/deployment/v1/message.proto
@@ -221,7 +221,7 @@ message VersionMetadata {
 }
 
 message RoutingInfo {
-    // Always present. Specifies what Deployment Version should should receive new workflow
+    // Always present. Specifies which Deployment Version should should receive new workflow
     // executions and tasks of existing unversioned or AutoUpgrade workflows.
     // Can be one of the following:
     // - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has

--- a/temporal/api/deployment/v1/message.proto
+++ b/temporal/api/deployment/v1/message.proto
@@ -208,7 +208,7 @@ message WorkerDeploymentInfo {
     string last_modifier_identity = 5;
 
     message WorkerDeploymentVersionSummary {
-        string version = 1;
+        string build_id = 1;
         temporal.api.enums.v1.WorkflowVersioningMode workflow_versioning_mode = 2;
         google.protobuf.Timestamp create_time = 3;
         enums.v1.VersionDrainageStatus drainage_status = 4;

--- a/temporal/api/deployment/v1/message.proto
+++ b/temporal/api/deployment/v1/message.proto
@@ -132,9 +132,9 @@ message WorkerDeploymentVersionInfo {
 
     google.protobuf.Timestamp create_time = 3;
     // All the Task Queues that have ever polled from this Deployment version.
-    repeated WorkerBuildTaskQueueInfo task_queue_infos = 4;
+    repeated DeploymentVersionTaskQueueInfo task_queue_infos = 4;
 
-    message WorkerBuildTaskQueueInfo {
+    message DeploymentVersionTaskQueueInfo {
         string name = 1;
         temporal.api.enums.v1.TaskQueueType type = 2;
     }

--- a/temporal/api/deployment/v1/message.proto
+++ b/temporal/api/deployment/v1/message.proto
@@ -169,7 +169,7 @@ message WorkerDeploymentVersionInfo {
 }
 
 // Information about workflow drainage to help the user determine when it is safe
-// to decommission a Version. Not present while accepts_new_executions is true.
+// to decommission a Version. Not present while the version is current or ramping.
 message VersionDrainageInfo {
     // Set to DRAINING when accepts_new_executions first becomes false.
     // Set to DRAINED when no more open pinned workflows exist on this version.

--- a/temporal/api/deployment/v1/message.proto
+++ b/temporal/api/deployment/v1/message.proto
@@ -138,6 +138,39 @@ message WorkerDeploymentVersionInfo {
         string name = 1;
         temporal.api.enums.v1.TaskQueueType type = 2;
     }
+
+    // TODO (Shivam): Accepts_new_executions + Poller_status + Drainage_status + WorkerBuildMetadata
+}
+
+// A Worker Deployment (Deployment, for short) represents all workers serving 
+// a shared set of Task Queues. Typically, a Deployment represents one service or 
+// application.
+// A Deployment contains multiple Deployment Versions, each representing a different 
+// version of workers. (see documentation of WorkerDeploymentVersionInfo)
+// Deployment records are created in Temporal server automatically when their 
+// first poller arrives to the server.
+message WorkerDeploymentInfo {
+    // Identifies a Worker Deployment. Must be unique within the namespace.
+    string name = 1;
+
+    // Deployment Versions that are currently tracked in this Deployment. A DeploymentVersion will be
+    // cleaned up automatically if all the following conditions meet:
+    // - It does not receive new executions (see WorkerDeploymentVersionInfo.accepts_new_executions) 
+    // - It has no active pollers (see WorkerDeploymentVersionInfo.pollers_status) 
+    // - It is drained (see WorkerDeploymentVersionInfo.drainage_status) 
+    repeated WorkerDeploymentVersionSummary version_summaries = 2;
+
+    google.protobuf.Timestamp create_time = 3;
+
+    message WorkerDeploymentVersionSummary {
+        string version = 1;
+        temporal.api.enums.v1.WorkflowVersioningMode workflow_versioning_mode = 2;
+        google.protobuf.Timestamp create_time = 3;
+        bool accepts_new_executions = 4;
+    }
+    
+    // TODO (Shivam): WorkerDeploymentVersionSummary.PollerStatus + TaskQueueInfo + RampingInfo +
+    // AggregatedPollerStatus + DrainageStatus 
 }
 
 

--- a/temporal/api/deployment/v1/message.proto
+++ b/temporal/api/deployment/v1/message.proto
@@ -162,6 +162,8 @@ message WorkerDeploymentInfo {
 
     google.protobuf.Timestamp create_time = 3;
 
+    RoutingInfo routing_info = 4;
+
     message WorkerDeploymentVersionSummary {
         string version = 1;
         temporal.api.enums.v1.WorkflowVersioningMode workflow_versioning_mode = 2;
@@ -174,3 +176,24 @@ message WorkerDeploymentInfo {
 }
 
 
+message RoutingInfo {
+    // Current Version receives all the tasks except the portion that is routed to the Ramping
+    // Version according to `ramping_version_percentage`.
+    // It is possible that Current Version is not present when user is ramping from unversioned to
+    // versioned workers. In that case, remaining tasks after `ramping_version_percentage` go to
+    // unversioned workers. (Unversioned workers are those with UNVERSIONED (or unspecified)
+    // WorkflowVersioningMode.)
+    string current_version = 1;
+    // Ramping Version is set during gradual rollout of a new Version. It takes a share of tasks
+    // according to `ramping_version_percentage`.
+    string ramping_version = 2;
+    // Percentage of tasks that are routed to the Ramping Version instead of the Current Version.
+    // Special case: it is possible that `ramping_version_percentage` is non-zero while
+    // `ramping_version` is absent. That case represents gradual migration out of the Current
+    // Version to unversioned workers.
+    float ramping_version_percentage = 3;
+    // Last time current version was updated.
+    google.protobuf.Timestamp current_version_update_time = 4;
+    // Last time ramping version was updated.
+    google.protobuf.Timestamp ramping_version_update_time = 5;
+}

--- a/temporal/api/deployment/v1/message.proto
+++ b/temporal/api/deployment/v1/message.proto
@@ -150,8 +150,8 @@ message WorkerDeploymentVersionInfo {
     // - Not supported for Unversioned mode.
     // - Periodically refreshed, may have delays up to few minutes (consult the
     //   last_checked_time value).
-    // - Refreshed only when accepts_new_executions is false AND the status is not
-    //   "drained" yet.
+    // - Refreshed only when the version is neither current nor ramping AND 
+    // the status is not "drained" yet.
     // - Once the status is changed to "drained", it is not changed until the Version
     //   becomes Current or Ramping again, at which time the drainage info is cleared.
     //   This means if the Version is "drained" but new workflows are sent to it via

--- a/temporal/api/deployment/v1/message.proto
+++ b/temporal/api/deployment/v1/message.proto
@@ -39,12 +39,13 @@ import "temporal/api/common/v1/message.proto";
 
 // Worker Deployment options set in SDK that need to be sent to server in every poll.
 message WorkerDeploymentOptions {
-    // Required. Worker deployment name.
-    string name = 1;
-    // Required. Worker deployment version.
-    string version = 2;
-    // Required. Workflow versioning mode for this deployment version. Must be the same for all
-    // pollers in a given deployment version, across all task queues.
+    // Required. Worker Deployment name.
+    string deployment_name = 1;
+    // Required. Build ID of the worker. `deployment_name` and `build_id` together identify this
+    // Worker Deployment Version.
+    string build_id = 2;
+    // Required. Workflow versioning mode for this Deployment Version. Must be the same for all
+    // pollers in a given Deployment Version, across all Task Queues.
     temporal.api.enums.v1.WorkflowVersioningMode workflow_versioning_mode = 3;
 }
 
@@ -64,11 +65,14 @@ message Deployment {
     string build_id = 2;
 }
 
+// Identifies a Worker Deployment Version. The combination of `deployment_name` and `build_id`
+// serve as the identifier.
 message WorkerDeploymentVersion {
-    // Uniquely identifies the worker deployment version.
-    string version = 1;
-    // The name of the deployment this version belongs too.
+    // The name of the Deployment this version belongs too.
     string deployment_name = 2;
+    // Build ID uniquely identifies the Deployment Version within a Deployment, but the same Build
+    // ID can be used in multiple Deployments.
+    string build_id = 1;
 }
 
 // `DeploymentInfo` holds information about a deployment. Deployment information is tracked
@@ -121,15 +125,8 @@ message DeploymentListInfo {
 // Each Version has a Workflow Versioning Mode which is chosen by the app
 // developer. (see WorkflowVersioningMode enum documentation)
 message WorkerDeploymentVersionInfo {
-    // Identifies a Worker Deployment Version. Must be unique within the namespace.
-    // Same ID cannot be used in multiple Deployments.
-    // In some contexts, such as Reset-by-build-id, version might be used
-    // as "Build ID".
-    string version = 1;
-
-    // Each Worker Version belongs to exactly one Deployment.
-    string deployment_name = 2;
-
+    WorkerDeploymentVersion version = 1;
+    temporal.api.enums.v1.WorkflowVersioningMode workflow_versioning_mode = 2;
     google.protobuf.Timestamp create_time = 3;
 
     // (-- api-linter: core::0140::prepositions=disabled
@@ -141,14 +138,11 @@ message WorkerDeploymentVersionInfo {
     //     aip.dev/not-precedent: 'Since' captures the field semantics despite being a preposition. --)
     // Nil if not ramping.
     google.protobuf.Timestamp ramping_since_time = 5;
+    // Zero if the version is not ramping (i.e. `ramping_since_time` is nil).
+    float ramp_percentage = 6;
 
     // All the Task Queues that have ever polled from this Deployment version.
-    repeated DeploymentVersionTaskQueueInfo task_queue_infos = 6;
-
-    message DeploymentVersionTaskQueueInfo {
-        string name = 1;
-        temporal.api.enums.v1.TaskQueueType type = 2;
-    }
+    repeated VersionTaskQueueInfo task_queue_infos = 7;
 
     // Helps user determine when it is safe to decommission the workers of this
     // Version. Not present when accepts_new_executions is true.
@@ -163,9 +157,15 @@ message WorkerDeploymentVersionInfo {
     //   This means if the Version is "drained" but new workflows are sent to it via
     //   Pinned Versioning Override, the status does not account for those Pinned-override
     //   executions and remains "drained".
-    VersionDrainageInfo drainage_info = 7;
+    VersionDrainageInfo drainage_info = 8;
 
-    // TODO (Shivam): + Poller_status + WorkerDeploymentVersionMetadata
+    // Arbitrary user-provided metadata attached to this version.
+    VersionMetadata metadata = 9;
+
+    message VersionTaskQueueInfo {
+        string name = 1;
+        temporal.api.enums.v1.TaskQueueType type = 2;
+    }
 }
 
 // Information about workflow drainage to help the user determine when it is safe
@@ -202,33 +202,48 @@ message WorkerDeploymentInfo {
 
     RoutingInfo routing_info = 4;
 
+    // Identity of the last client who modified the configuration of this Deployment. Set to the
+    // `identity` value sent by APIs such as `SetWorkerDeploymentCurrentVersion` and
+    // `SetWorkerDeploymentRampingVersion`.
+    string last_modifier_identity = 5;
+
     message WorkerDeploymentVersionSummary {
         string version = 1;
         temporal.api.enums.v1.WorkflowVersioningMode workflow_versioning_mode = 2;
         google.protobuf.Timestamp create_time = 3;
-        bool accepts_new_executions = 4;
+        enums.v1.VersionDrainageStatus drainage_status = 4;
     }
-    
-    // TODO (Shivam): WorkerDeploymentVersionSummary.PollerStatus + TaskQueueInfo + RampingInfo +
-    // AggregatedPollerStatus + DrainageStatus 
 }
 
+message VersionMetadata {
+    // Arbitrary key-values.
+    map<string, temporal.api.common.v1.Payload> entries = 1;
+}
 
 message RoutingInfo {
-    // Current Version receives all the tasks except the portion that is routed to the Ramping
-    // Version according to `ramping_version_percentage`.
-    // It is possible that Current Version is not present when user is ramping from unversioned to
-    // versioned workers. In that case, remaining tasks after `ramping_version_percentage` go to
-    // unversioned workers. (Unversioned workers are those with UNVERSIONED (or unspecified)
-    // WorkflowVersioningMode.)
+    // Always present. Specifies what Deployment Version should should receive new workflow
+    // executions and tasks of existing unversioned or AutoUpgrade workflows.
+    // Can be one of the following:
+    // - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
+    // `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
+    // - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
+    // with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
+    // Note: Current Version is overridden by the Ramping Version for a portion of traffic when a ramp
+    // is set (see `ramping_version`.)
     string current_version = 1;
-    // Ramping Version is set during gradual rollout of a new Version. It takes a share of tasks
-    // according to `ramping_version_percentage`.
+    // When present, it means the traffic is being shifted from the Current Version to the Ramping
+    // Version.
+    // Must always be different from Current Version. Can be one of the following:
+    // - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
+    // `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
+    // - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
+    // with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
+    // Note that it is possible to ramp from one Version to another Version, or from unversioned
+    // workers to a particular Version, or from a particular Version to unversioned workers.
     string ramping_version = 2;
     // Percentage of tasks that are routed to the Ramping Version instead of the Current Version.
-    // Special case: it is possible that `ramping_version_percentage` is non-zero while
-    // `ramping_version` is absent. That case represents gradual migration out of the Current
-    // Version to unversioned workers.
+    // Valid range: [0, 100]. A 100% value means the Ramping Version is receiving full traffic but
+    // not yet "promoted" to be the Current Version, likely due to pending validations.
     float ramping_version_percentage = 3;
     // Last time current version was updated.
     google.protobuf.Timestamp current_version_update_time = 4;

--- a/temporal/api/deployment/v1/message.proto
+++ b/temporal/api/deployment/v1/message.proto
@@ -148,15 +148,19 @@ message WorkerDeploymentVersionInfo {
 
     // All the Task Queues that have ever polled from this Deployment version.
     repeated VersionTaskQueueInfo task_queue_infos = 8;
+    message VersionTaskQueueInfo {
+        string name = 1;
+        temporal.api.enums.v1.TaskQueueType type = 2;
+    }
 
     // Helps user determine when it is safe to decommission the workers of this
-    // Version. Not present when the workflow is accepting new workflow executions because it's current or ramping.
+    // Version. Not present when version is current or ramping.
     // Current limitations:
     // - Not supported for Unversioned mode.
     // - Periodically refreshed, may have delays up to few minutes (consult the
     //   last_checked_time value).
-    // - Refreshed only when the version is neither current nor ramping AND 
-    // the status is not "drained" yet.
+    // - Refreshed only when version is not current or ramping AND the status is not
+    //   "drained" yet.
     // - Once the status is changed to "drained", it is not changed until the Version
     //   becomes Current or Ramping again, at which time the drainage info is cleared.
     //   This means if the Version is "drained" but new workflows are sent to it via
@@ -168,16 +172,12 @@ message WorkerDeploymentVersionInfo {
     VersionMetadata metadata = 10;
 
     // TODO (Shivam): + Poller_status + WorkerDeploymentVersionMetadata
-    message VersionTaskQueueInfo {
-        string name = 1;
-        temporal.api.enums.v1.TaskQueueType type = 2;
-    }
 }
 
 // Information about workflow drainage to help the user determine when it is safe
-// to decommission a Version. Not present while the version is current or ramping.
+// to decommission a Version. Not present while version is current or ramping.
 message VersionDrainageInfo {
-    // Set to DRAINING when the version stops accepting new executions (is no longer current or ramping).
+    // Set to DRAINING when the version first stops accepting new executions (is no longer current or ramping).
     // Set to DRAINED when no more open pinned workflows exist on this version.
     enums.v1.VersionDrainageStatus status = 1;
     // Last time the drainage status changed.
@@ -231,9 +231,9 @@ message RoutingInfo {
     // executions and tasks of existing unversioned or AutoUpgrade workflows.
     // Can be one of the following:
     // - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
-    // `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
+    //   `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
     // - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
-    // with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
+    //   with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
     // Note: Current Version is overridden by the Ramping Version for a portion of traffic when a ramp
     // is set (see `ramping_version`.)
     string current_version = 1;
@@ -241,9 +241,9 @@ message RoutingInfo {
     // Version.
     // Must always be different from Current Version. Can be one of the following:
     // - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
-    // `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
+    //   `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
     // - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
-    // with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
+    //   with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
     // Note that it is possible to ramp from one Version to another Version, or from unversioned
     // workers to a particular Version, or from a particular Version to unversioned workers.
     string ramping_version = 2;

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -56,24 +56,29 @@ message TaskQueueMetadata {
 }
 
 message TaskQueueVersioningInfo {
-    // Current Version receives all the tasks except the portion that is routed to the Ramping
-    // Version according to `ramping_version_percentage`.
-    // It is possible that Current Version is not present when user is ramping from unversioned to
-    // versioned workers. In that case, remaining tasks after `ramping_version_percentage` go to
-    // unversioned workers. (Unversioned workers are those with UNVERSIONED (or unspecified)
-    // WorkflowVersioningMode.)
+    // Always present. Specifies which Deployment Version should should receive new workflow
+    // executions and tasks of existing unversioned or AutoUpgrade workflows.
+    // Can be one of the following:
+    // - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
+    //   `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
+    // - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
+    //   with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
+    // Note: Current Version is overridden by the Ramping Version for a portion of traffic when a ramp
+    // is set (see `ramping_version`.)
     temporal.api.deployment.v1.WorkerDeploymentVersion current_version = 1;
-    // Ramping Version is set during gradual rollout of a new Version. It takes a share of tasks
-    // according to `ramping_version_percentage`.
-    // It is possible that Ramping Version belong to a Deployment other than that of the Current
-    // Version. This happens when a Task Queue is being moved from one Deployment to another.
+    // When present, it means the traffic is being shifted from the Current Version to the Ramping
+    // Version.
+    // Must always be different from Current Version. Can be one of the following:
+    // - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
+    //   `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
+    // - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
+    //   with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
+    // Note that it is possible to ramp from one Version to another Version, or from unversioned
+    // workers to a particular Version, or from a particular Version to unversioned workers.
     temporal.api.deployment.v1.WorkerDeploymentVersion ramping_version = 2;
     // Percentage of tasks that are routed to the Ramping Version instead of the Current Version.
     // Valid range: [0, 100]. A 100% value means the Ramping Version is receiving full traffic but
     // not yet "promoted" to be the Current Version, likely due to pending validations.
-    // Special case: it is possible that `ramping_version_percentage` is non-zero while
-    // `ramping_version` is absent. That case represents gradual migration out of the Current
-    // Version to unversioned workers.
     float ramping_version_percentage = 3;
     // Last time versioning information of this Task Queue changed.
     google.protobuf.Timestamp update_time = 4;

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -55,6 +55,26 @@ message TaskQueueMetadata {
     google.protobuf.DoubleValue max_tasks_per_second = 1;
 }
 
+message TaskQueueVersioningInfo {
+    // Current Version receives all the tasks except the portion that is routed to the Ramping
+    // Version according to `ramping_version_percentage`.
+    // It is possible that Current Version is not present when user is ramping from unversioned to
+    // versioned workers. In that case, remaining tasks after `ramping_version_percentage` go to
+    // unversioned workers. (Unversioned workers are those with UNVERSIONED (or unspecified)
+    // WorkflowVersioningMode.)
+    temporal.api.deployment.v1.WorkerDeploymentVersion current_version = 1;
+    // Ramping Version is set during gradual rollout of a new Version. It takes a share of tasks
+    // according to `ramping_version_percentage`.
+    temporal.api.deployment.v1.WorkerDeploymentVersion ramping_version = 2;
+    // Percentage of tasks that are routed to the Ramping Version instead of the Current Version.
+    // Special case: it is possible that `ramping_version_percentage` is non-zero while
+    // `ramping_version` is absent. That case represents gradual migration out of the Current
+    // Version to unversioned workers.
+    float ramping_version_percentage = 3;
+    // Last time versioning information of this Task Queue changed.
+    google.protobuf.Timestamp update_time = 4;
+}
+
 // Used for specifying versions the caller is interested in.
 message TaskQueueVersionSelection {
     // Include specific Build IDs.

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -65,8 +65,12 @@ message TaskQueueVersioningInfo {
     temporal.api.deployment.v1.WorkerDeploymentVersion current_version = 1;
     // Ramping Version is set during gradual rollout of a new Version. It takes a share of tasks
     // according to `ramping_version_percentage`.
+    // It is possible that Ramping Version belong to a Deployment other than that of the Current
+    // Version. This happens when a Task Queue is being moved from one Deployment to another.
     temporal.api.deployment.v1.WorkerDeploymentVersion ramping_version = 2;
     // Percentage of tasks that are routed to the Ramping Version instead of the Current Version.
+    // Valid range: [0, 100]. A 100% value means the Ramping Version is receiving full traffic but
+    // not yet "promoted" to be the Current Version, likely due to pending validations.
     // Special case: it is possible that `ramping_version_percentage` is non-zero while
     // `ramping_version` is absent. That case represents gradual migration out of the Current
     // Version to unversioned workers.

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2029,6 +2029,27 @@ message SetWorkerDeploymentRampingVersionResponse {
     float previous_percentage = 2;
 }
 
+message ListWorkerDeploymentsRequest {
+    string namespace = 1;
+    int32 page_size = 2;
+    bytes next_page_token = 3;
+}
+
+message ListWorkerDeploymentsResponse {
+    bytes next_page_token = 1;
+    // The list of worker deployments.
+    repeated WorkerDeploymentSummary worker_deployments = 2;
+  
+    // (-- api-linter: core::0123::resource-annotation=disabled --)
+    // A subset of WorkerDeploymentInfo
+    message WorkerDeploymentSummary {
+        string name = 1;
+        google.protobuf.Timestamp create_time = 2;
+        temporal.api.deployment.v1.RoutingInfo routing_info = 3;
+    }
+}
+
+
 // Returns the Current Deployment of a deployment series.
 // [cleanup-wv-pre-release] Pre-release deployment APIs, clean up later
 message GetCurrentDeploymentRequest {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1992,9 +1992,9 @@ message SetWorkerDeploymentCurrentVersionRequest {
     string deployment_name = 2;
     // Required. Can be one of the following:
     // - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
-    // `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
+    //   `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
     // - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
-    // with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
+    //   with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
     string build_id = 3;
     // Optional. This can be the value of conflict_token from a Describe, or another Worker
     // Deployment API. Passing conflict token which will cause this request to fail if the
@@ -2019,9 +2019,9 @@ message SetWorkerDeploymentRampingVersionRequest {
     // Can be one of the following:
     // - Absent/empty value to unset the Ramping Version. Must be paired with `percentage=0`.
     // - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
-    // `WorkflowVersioningMode==VERSIONING_BEHAVIORS`) to set it as the Ramping Version.
+    //   `WorkflowVersioningMode==VERSIONING_BEHAVIORS`) to set it as the Ramping Version.
     // - Or, the "__unversioned__" special value, to ramp unversioned workers (those with
-    // `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
+    //   `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
     string build_id = 3;
     // Ramp percentage to set. Valid range: [0,100].
     float percentage = 6;

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1928,7 +1928,16 @@ message DescribeWorkerDeploymentVersionRequest {
 }
 
 message DescribeWorkerDeploymentVersionResponse {
-    deployment.v1.WorkerDeploymentVersionInfo worker_deployment_version_info = 1;
+    temporal.api.deployment.v1.WorkerDeploymentVersionInfo worker_deployment_version_info = 1;
+}
+
+message DescribeWorkerDeploymentRequest {
+    string namespace = 1;
+    string deployment_name = 2;
+}
+
+message DescribeWorkerDeploymentResponse {
+    temporal.api.deployment.v1.WorkerDeploymentInfo worker_deployment_info = 1;
 }
 
 // [cleanup-wv-pre-release] Pre-release deployment APIs, clean up later

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1995,7 +1995,7 @@ message SetWorkerDeploymentCurrentVersionRequest {
     // `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
     // - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
     // with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
-    string version = 3;
+    string build_id = 3;
     // Optional. This can be the value of conflict_token from a Describe, or another Worker
     // Deployment API. Passing conflict token which will cause this request to fail if the
     // Deployment's configuration has been modified between the previous API call and

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -61,9 +61,11 @@ import "temporal/api/batch/v1/message.proto";
 import "temporal/api/sdk/v1/task_complete_metadata.proto";
 import "temporal/api/sdk/v1/user_metadata.proto";
 import "temporal/api/nexus/v1/message.proto";
+
 import "google/protobuf/duration.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
 
 message RegisterNamespaceRequest {
     string namespace = 1;
@@ -1052,6 +1054,17 @@ message DescribeTaskQueueResponse {
     // This map contains Task Queue information for each Build ID. Empty string as key value means unversioned.
     // Only set in `ENHANCED` mode.
     map<string, temporal.api.taskqueue.v1.TaskQueueVersionInfo> versions_info = 3;
+
+    // Specifies which Worker Deployment Version(s) Server routes this Task Queue's tasks to.
+    // When not present, it means the tasks are routed to "unversioned" workers. Unversioned workers
+    // are those with UNVERSIONED (or unspecified) WorkflowVersioningMode.
+    // Task Queue Versioning info is updated indirectly by calling SetWorkerDeploymentCurrentVersion
+    // and SetWorkerDeploymentRampingVersion on Worker Deployments.
+    // Note: This information is not relevant to Pinned workflow executions and their activities as
+    // they are always routed to their Pinned Deployment Version. However, new workflow executions
+    // are typically not Pinned until they complete their first task (unless they are started with
+    // a Pinned VersioningOverride or are Child Workflows of a Pinned parent).
+    temporal.api.taskqueue.v1.TaskQueueVersioningInfo versioning_info = 4;
 }
 
 message GetClusterInfoRequest {
@@ -1973,18 +1986,47 @@ message SetCurrentDeploymentResponse {
     temporal.api.deployment.v1.DeploymentInfo previous_deployment_info = 2;
 }
 
-message SetCurrentDeploymentVersionRequest {
+// Set/unset the Current Version of a Worker Deployment.
+message SetWorkerDeploymentCurrentVersionRequest {
     string namespace = 1;
     string deployment_name = 2;
     // Must be a Versioned Build. Pass empty string to unset.
-    string version = 3;
+    google.protobuf.StringValue version = 3;
     // Optional. The identity of the client who initiated this request.
     string identity = 4;
 }
 
-message SetCurrentDeploymentVersionResponse {
-    // Info of the version that was current before executing this operation.
+message SetWorkerDeploymentCurrentVersionResponse {
+    // The version that was current before executing this operation.
     string previous_version = 1;
+}
+
+// Set/unset the Ramping Version of a Worker Deployment and its ramp percentage.
+// To unset, pass zero `percentage`.
+// To ramp to unversioned workers (from Deployment's Current Version), pass `version=""` with
+// non-zero `percentage`.
+message SetWorkerDeploymentRampingVersionRequest {
+    string namespace = 1;
+    string deployment_name = 2;
+
+    // The Version to be set as the Ramping Version of the Deployment. Optional when `percentage` is
+    // zero (unset case), but if given, it must match the current Ramping Version to be unset.
+    // Can be an empty string and paired with a non-zero `percentage`, in which case it will set the ramp
+    // percentage without a Ramping Version which means unversioned workers are being ramped.
+    // (Useful for migrating to unversioned workers from Deployment's Current Version.)
+    google.protobuf.StringValue version = 3;
+    // Valid range: [0,100]. Zero value will unset the Ramping Version.
+    float percentage = 6;
+
+    // Optional. The identity of the client who initiated this request.
+    string identity = 7;
+}
+
+message SetWorkerDeploymentRampingVersionResponse {
+    // The ramping version before executing this operation.
+    string previous_version = 1;
+    // The ramping version percentage before executing this operation.
+    float previous_percentage = 2;
 }
 
 // Returns the Current Deployment of a deployment series.

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -65,7 +65,6 @@ import "temporal/api/nexus/v1/message.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/timestamp.proto";
-import "google/protobuf/wrappers.proto";
 
 message RegisterNamespaceRequest {
     string namespace = 1;
@@ -345,7 +344,6 @@ message RespondWorkflowTaskCompletedRequest {
     // one would not otherwise have been generated. This is used when the worker knows it is doing
     // something useful, but cannot complete it within the workflow task timeout. Local activities
     // which run for longer than the task timeout being the prime example.
-    // slg: originally created for heartbeat, but may be used to paginate requests with big payloads
     bool force_create_new_workflow_task = 6;
     // DEPRECATED since 1.21 - use `worker_version_stamp` instead.
     // Worker process' unique binary id
@@ -1938,7 +1936,7 @@ message DescribeDeploymentResponse {
 
 message DescribeWorkerDeploymentVersionRequest {
 	string namespace = 1;
-	string version = 2;
+  temporal.api.deployment.v1.WorkerDeploymentVersion version = 2;
 }
 
 message DescribeWorkerDeploymentVersionResponse {
@@ -1951,7 +1949,8 @@ message DescribeWorkerDeploymentRequest {
 }
 
 message DescribeWorkerDeploymentResponse {
-    temporal.api.deployment.v1.WorkerDeploymentInfo worker_deployment_info = 1;
+    bytes conflict_token = 1;
+    temporal.api.deployment.v1.WorkerDeploymentInfo worker_deployment_info = 2;
 }
 
 // [cleanup-wv-pre-release] Pre-release deployment APIs, clean up later
@@ -1991,43 +1990,58 @@ message SetCurrentDeploymentResponse {
 message SetWorkerDeploymentCurrentVersionRequest {
     string namespace = 1;
     string deployment_name = 2;
-    // Must be a Versioned Build. Pass empty string to unset.
-    google.protobuf.StringValue version = 3;
+    // Required. Can be one of the following:
+    // - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
+    // `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
+    // - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
+    // with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
+    string version = 3;
+    // Optional. This can be the value of conflict_token from a Describe, or another Worker
+    // Deployment API. Passing conflict token which will cause this request to fail if the
+    // Deployment's configuration has been modified between the previous API call and
+    // this one.
+    bytes conflict_token = 4;
     // Optional. The identity of the client who initiated this request.
-    string identity = 4;
+    string identity = 5;
 }
 
 message SetWorkerDeploymentCurrentVersionResponse {
-    // The version that was current before executing this operation.
-    string previous_version = 1;
+    bytes conflict_token = 1;
+    // The Build ID of the version that was current before executing this operation. Can also be the
+    // `__unversioned__` special value.
+    string previous_version = 2;
 }
 
 // Set/unset the Ramping Version of a Worker Deployment and its ramp percentage.
-// To unset, pass zero `percentage`.
-// To ramp to unversioned workers (from Deployment's Current Version), pass `version=""` with
-// non-zero `percentage`.
 message SetWorkerDeploymentRampingVersionRequest {
     string namespace = 1;
     string deployment_name = 2;
-
-    // The Version to be set as the Ramping Version of the Deployment. Optional when `percentage` is
-    // zero (unset case), but if given, it must match the current Ramping Version to be unset.
-    // Can be an empty string and paired with a non-zero `percentage`, in which case it will set the ramp
-    // percentage without a Ramping Version which means unversioned workers are being ramped.
-    // (Useful for migrating to unversioned workers from Deployment's Current Version.)
-    google.protobuf.StringValue version = 3;
-    // Valid range: [0,100]. Zero value will unset the Ramping Version.
+    // Can be one of the following:
+    // - Absent/empty value to unset the Ramping Version. Must be paired with `percentage=0`.
+    // - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
+    // `WorkflowVersioningMode==VERSIONING_BEHAVIORS`) to set it as the Ramping Version.
+    // - Or, the "__unversioned__" special value, to ramp unversioned workers (those with
+    // `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
+    string version = 3;
+    // Ramp percentage to set. Valid range: [0,100].
     float percentage = 6;
 
+    // Optional. This can be the value of conflict_token from a Describe, or another Worker
+    // Deployment API. Passing conflict token which will cause this request to fail if the
+    // Deployment's configuration has been modified between the previous API call and
+    // this one.
+    bytes conflict_token = 4;
     // Optional. The identity of the client who initiated this request.
     string identity = 7;
 }
 
 message SetWorkerDeploymentRampingVersionResponse {
-    // The ramping version before executing this operation.
-    string previous_version = 1;
+    bytes conflict_token = 1;
+    // The Build ID of the version that was ramping before executing this operation. Can also be
+    // empty or the `__unversioned__` special value.
+    string previous_version = 2;
     // The ramping version percentage before executing this operation.
-    float previous_percentage = 2;
+    float previous_percentage = 3;
 }
 
 message ListWorkerDeploymentsRequest {
@@ -2049,7 +2063,6 @@ message ListWorkerDeploymentsResponse {
         temporal.api.deployment.v1.RoutingInfo routing_info = 3;
     }
 }
-
 
 // Returns the Current Deployment of a deployment series.
 // [cleanup-wv-pre-release] Pre-release deployment APIs, clean up later

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2009,7 +2009,7 @@ message SetWorkerDeploymentCurrentVersionResponse {
     bytes conflict_token = 1;
     // The Build ID of the version that was current before executing this operation. Can also be the
     // `__unversioned__` special value.
-    string previous_version = 2;
+    string previous_build_id = 2;
 }
 
 // Set/unset the Ramping Version of a Worker Deployment and its ramp percentage.
@@ -2039,7 +2039,7 @@ message SetWorkerDeploymentRampingVersionResponse {
     bytes conflict_token = 1;
     // The Build ID of the version that was ramping before executing this operation. Can also be
     // empty or the `__unversioned__` special value.
-    string previous_version = 2;
+    string previous_build_id = 2;
     // The ramping version percentage before executing this operation.
     float previous_percentage = 3;
 }

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2022,7 +2022,7 @@ message SetWorkerDeploymentRampingVersionRequest {
     // `WorkflowVersioningMode==VERSIONING_BEHAVIORS`) to set it as the Ramping Version.
     // - Or, the "__unversioned__" special value, to ramp unversioned workers (those with
     // `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
-    string version = 3;
+    string build_id = 3;
     // Ramp percentage to set. Valid range: [0,100].
     float percentage = 6;
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2024,15 +2024,15 @@ message SetWorkerDeploymentRampingVersionRequest {
     //   `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
     string build_id = 3;
     // Ramp percentage to set. Valid range: [0,100].
-    float percentage = 6;
+    float percentage = 4;
 
     // Optional. This can be the value of conflict_token from a Describe, or another Worker
     // Deployment API. Passing conflict token which will cause this request to fail if the
     // Deployment's configuration has been modified between the previous API call and
     // this one.
-    bytes conflict_token = 4;
+    bytes conflict_token = 5;
     // Optional. The identity of the client who initiated this request.
-    string identity = 7;
+    string identity = 6;
 }
 
 message SetWorkerDeploymentRampingVersionResponse {

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -851,13 +851,14 @@ service WorkflowService {
         };
     }
 
-    // Sets a deployment version as the current version for its deployment.
-    rpc SetCurrentDeploymentVersion (SetCurrentDeploymentVersionRequest) returns (SetCurrentDeploymentVersionResponse) {
+    // Set/unset the Current Version of a Worker Deployment. Automatically unsets the Ramping
+    // Version if it is the Version being set as Current.
+    rpc SetWorkerDeploymentCurrentVersion (SetWorkerDeploymentCurrentVersionRequest) returns (SetWorkerDeploymentCurrentVersionResponse) {
         option (google.api.http) = {
-            post: "/namespaces/{namespace}/worker-deployment/{deployment_name}/set-current-version"
+            post: "/namespaces/{namespace}/worker-deployments/{deployment_name}/set-current-version"
             body: "*"
             additional_bindings {
-                post: "/api/v1/namespaces/{namespace}/worker-deployment/{deployment_name}/set-current-version"
+                post: "/api/v1/namespaces/{namespace}/worker-deployments/{deployment_name}/set-current-version"
                 body: "*"
             }
         };
@@ -868,6 +869,19 @@ service WorkflowService {
             get: "/namespaces/{namespace}/worker-deployments/{deployment_name}"
             additional_bindings {
                 get: "/api/v1/namespaces/{namespace}/worker-deployments/{deployment_name}"
+            }
+        };
+    }
+
+    // Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for
+    // gradual ramp to unversioned workers too.
+    rpc SetWorkerDeploymentRampingVersion (SetWorkerDeploymentRampingVersionRequest) returns (SetWorkerDeploymentRampingVersionResponse) {
+        option (google.api.http) = {
+            post: "/namespaces/{namespace}/worker-deployments/{deployment_name}/set-ramping-version"
+            body: "*"
+            additional_bindings {
+                post: "/api/v1/namespaces/{namespace}/worker-deployments/{deployment_name}/set-ramping-version"
+                body: "*"
             }
         };
     }

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -863,6 +863,15 @@ service WorkflowService {
         };
     }
 
+    rpc DescribeWorkerDeployment (DescribeWorkerDeploymentRequest) returns (DescribeWorkerDeploymentResponse) {
+        option (google.api.http) = {
+            get: "/namespaces/{namespace}/worker-deployments/{deployment_name}"
+            additional_bindings {
+                get: "/api/v1/namespaces/{namespace}/worker-deployments/{deployment_name}"
+            }
+        };
+    }
+
     // Invokes the specified Update function on user Workflow code.
     rpc UpdateWorkflowExecution(UpdateWorkflowExecutionRequest) returns (UpdateWorkflowExecutionResponse) {
         option (google.api.http) = {

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -787,9 +787,9 @@ service WorkflowService {
     // Describes a worker deployment version.
     rpc DescribeWorkerDeploymentVersion (DescribeWorkerDeploymentVersionRequest) returns (DescribeWorkerDeploymentVersionResponse) {
         option (google.api.http) = {
-            get: "/namespaces/{namespace}/worker-deployments-version/{version}"
+            get: "/namespaces/{namespace}/worker-deployments/{version.deployment_name}/version/{version.build_id}"
             additional_bindings {
-                get: "/api/v1/namespaces/{namespace}/worker-deployments-version/{version}"
+                get: "/api/v1/namespaces/{namespace}/worker-deployments/{version.deployment_name}/version/{version.build_id}"
             }
         };
     }

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -886,6 +886,15 @@ service WorkflowService {
         };
     }
 
+    rpc ListWorkerDeployments (ListWorkerDeploymentsRequest) returns (ListWorkerDeploymentsResponse) {
+        option (google.api.http) = {
+            get: "/namespaces/{namespace}/worker-deployments"
+            additional_bindings {
+                get: "/api/v1/namespaces/{namespace}/worker-deployments"
+            }
+        };
+    }
+
     // Invokes the specified Update function on user Workflow code.
     rpc UpdateWorkflowExecution(UpdateWorkflowExecutionRequest) returns (UpdateWorkflowExecutionResponse) {
         option (google.api.http) = {


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
- `version` string fields in `WorkerDeploymentOptions` and `WorkerDeploymentVersion` changed to `build_id`.
- `WorkerDeploymentVersionInfo` and `WorkerDeploymentInfo` messages completed with all the fields that will be implemented before Replay.
- Added `conflict_token` to relevant APIs.
- Now using special `__unversioned__` value instead of empty string to represent unversioned workers.

Note: the following APIs are still to be added:
- `UpdateWorkerDeploymentVersionMetadata`
- `DeleteWorkerDeploymentVersion`
- `DeleteWorkerDeployment`

<!-- Tell your future self why have you made these changes -->
**Why?**
Refinements based on latest design discussions within the crew.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
