### PR TITLE
Update SetWorkerDeploymentCurrentVersionRequest to have ignore_missing_task_queues

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -6962,6 +6962,11 @@
         "identity": {
           "type": "string",
           "description": "Optional. The identity of the client who initiated this request."
+        },
+        "ignoreMissingTaskQueues": {
+          "type": "boolean",
+          "description": "- The new version must have all the task-queues which were present in the previously set current version.\n\n- If there are any missing task queues from this new version, all of them should have a current deployment version set. In other \nwords, these task queues should not be unversioned. (TaskQueueVersioningInfo.current_version should not be empty && \nTaskQueueVersioningInfo.current_version.build_id != \"__unversioned__\")\n\n- If there are any missing task queues from this new version, all of them should have an add_rate of 0 since\nthis would signify that there are no backlogged tasks being added in these queues. (see TaskQueueStats.tasks_add_rate)",
+          "title": "Optional. By default, false. If true, this operation will succeed even if the new version does not have \nall the task-queues which were present in the previously set current version. If set to false,\nany of the following conditions should hold true before the new version is set as current:"
         }
       },
       "description": "Set/unset the Current Version of a Worker Deployment."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9689,6 +9689,9 @@ components:
         identity:
           type: string
           description: Optional. The identity of the client who initiated this request.
+        ignoreMissingTaskQueues:
+          type: boolean
+          description: "Optional. By default, false. If true, this operation will succeed even if the new version does not have \n all the task-queues which were present in the previously set current version. If set to false,\n any of the following conditions should hold true before the new version is set as current:\n\n - The new version must have all the task-queues which were present in the previously set current version.\n\n - If there are any missing task queues from this new version, all of them should have a current deployment version set. In other \n words, these task queues should not be unversioned. (TaskQueueVersioningInfo.current_version should not be empty && \n TaskQueueVersioningInfo.current_version.build_id != \"__unversioned__\")\n\n - If there are any missing task queues from this new version, all of them should have an add_rate of 0 since\n this would signify that there are no backlogged tasks being added in these queues. (see TaskQueueStats.tasks_add_rate)"
       description: Set/unset the Current Version of a Worker Deployment.
     SetWorkerDeploymentCurrentVersionResponse:
       type: object

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2016,6 +2016,19 @@ message SetWorkerDeploymentCurrentVersionRequest {
     bytes conflict_token = 4;
     // Optional. The identity of the client who initiated this request.
     string identity = 5;
+    // Optional. By default, false. If true, this operation will succeed even if the new version does not have 
+    // all the task-queues which were present in the previously set current version. If set to false,
+    // any of the following conditions should hold true before the new version is set as current:
+    //
+    // - The new version must have all the task-queues which were present in the previously set current version.
+    //
+    // - If there are any missing task queues from this new version, all of them should have a current deployment version set. In other 
+    // words, these task queues should not be unversioned. (TaskQueueVersioningInfo.current_version should not be empty && 
+    // TaskQueueVersioningInfo.current_version.build_id != "__unversioned__")
+    //
+    // - If there are any missing task queues from this new version, all of them should have an add_rate of 0 since
+    // this would signify that there are no backlogged tasks being added in these queues. (see TaskQueueStats.tasks_add_rate)
+    bool ignore_missing_task_queues = 6;
 }
 
 message SetWorkerDeploymentCurrentVersionResponse {


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
- Adding new flag inside SetWorkerDeploymentCurrentVersionRequest for poller verification 


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
