### PR TITLE
flag for ramping

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -6990,6 +6990,10 @@
         "identity": {
           "type": "string",
           "description": "Optional. The identity of the client who initiated this request."
+        },
+        "ignoreMissingTaskQueues": {
+          "type": "boolean",
+          "description": "Optional. By default this protects against accidentally removing a task queue from the current ramping version.\nIf false, one of the following conditions must hold true for the new version to be set as ramping version:\n- The new ramping version must have all the task-queues that are present in the existing ramping version.\nor\n- If the new ramping version is missing task queues that are present in the existing ramping version, \n  each missing task queue should have either:\n    - A current deployment version set, signifying that the task queue has been added to another deployment.\n    - An add_rate of 0, signifying that there are no backlogged tasks being added in these queues. (see TaskQueueStats.tasks_add_rate)\nIf true, this operation will succeed even if the new ramping version does not have all the task-queues that were\npresent in the existing ramping version.\nNote: This flag will only be applicable if the version is being set as the ramping version for the first time, signifying\nthat these checks will be ignored when the ramping version is being unset or on just a percentage change."
         }
       },
       "description": "Set/unset the Ramping Version of a Worker Deployment and its ramp percentage."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9739,6 +9739,9 @@ components:
         identity:
           type: string
           description: Optional. The identity of the client who initiated this request.
+        ignoreMissingTaskQueues:
+          type: boolean
+          description: "Optional. By default this protects against accidentally removing a task queue from the current ramping version.\n If false, one of the following conditions must hold true for the new version to be set as ramping version:\n - The new ramping version must have all the task-queues that are present in the existing ramping version.\n or\n - If the new ramping version is missing task queues that are present in the existing ramping version, \n   each missing task queue should have either:\n     - A current deployment version set, signifying that the task queue has been added to another deployment.\n     - An add_rate of 0, signifying that there are no backlogged tasks being added in these queues. (see TaskQueueStats.tasks_add_rate)\n If true, this operation will succeed even if the new ramping version does not have all the task-queues that were\n present in the existing ramping version.\n Note: This flag will only be applicable if the version is being set as the ramping version for the first time, signifying\n that these checks will be ignored when the ramping version is being unset or on just a percentage change."
       description: Set/unset the Ramping Version of a Worker Deployment and its ramp percentage.
     SetWorkerDeploymentRampingVersionResponse:
       type: object

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2060,6 +2060,19 @@ message SetWorkerDeploymentRampingVersionRequest {
     bytes conflict_token = 5;
     // Optional. The identity of the client who initiated this request.
     string identity = 6;
+    // Optional. By default this protects against accidentally removing a task queue from the current ramping version.
+    // If false, one of the following conditions must hold true for the new version to be set as ramping version:
+    // - The new ramping version must have all the task-queues that are present in the existing ramping version.
+    // or
+    // - If the new ramping version is missing task queues that are present in the existing ramping version, 
+    //   each missing task queue should have either:
+    //     - A current deployment version set, signifying that the task queue has been added to another deployment.
+    //     - An add_rate of 0, signifying that there are no backlogged tasks being added in these queues. (see TaskQueueStats.tasks_add_rate)
+    // If true, this operation will succeed even if the new ramping version does not have all the task-queues that were
+    // present in the existing ramping version.
+    // Note: This flag will only be applicable if the version is being set as the ramping version for the first time, signifying
+    // that these checks will be ignored when the ramping version is being unset or on just a percentage change.
+    bool ignore_missing_task_queues = 7;
 }
 
 message SetWorkerDeploymentRampingVersionResponse {


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
- Similar to https://github.com/temporalio/api/pull/541 in that this flag should also be added to the ramping request


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
