### PR TITLE
Use fully-qualified version string (deployment_name/build_id) for routing APIs

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -6554,8 +6554,9 @@
     "WorkerDeploymentInfoWorkerDeploymentVersionSummary": {
       "type": "object",
       "properties": {
-        "buildId": {
-          "type": "string"
+        "version": {
+          "type": "string",
+          "description": "The fully-qualified string representation of the version, in the form \"<deployment_name>/<build_id>\"."
         },
         "workflowVersioningMode": {
           "$ref": "#/definitions/v1WorkflowVersioningMode"
@@ -7054,9 +7055,9 @@
     "WorkflowServiceSetWorkerDeploymentCurrentVersionBody": {
       "type": "object",
       "properties": {
-        "buildId": {
+        "version": {
           "type": "string",
-          "title": "Required. Can be one of the following:\n- The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has\n  `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\n  with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)"
+          "title": "Required. Can be one of the following:\n- The fully-qualified string representation of a Version of this Deployment that supports\n  Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.). In the\n  format \"<deployment_name>/<build_id>\".\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\n  with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)"
         },
         "conflictToken": {
           "type": "string",
@@ -7077,9 +7078,9 @@
     "WorkflowServiceSetWorkerDeploymentRampingVersionBody": {
       "type": "object",
       "properties": {
-        "buildId": {
+        "version": {
           "type": "string",
-          "title": "Can be one of the following:\n- Absent/empty value to unset the Ramping Version. Must be paired with `percentage=0`.\n- The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has\n  `WorkflowVersioningMode==VERSIONING_BEHAVIORS`) to set it as the Ramping Version.\n- Or, the \"__unversioned__\" special value, to ramp unversioned workers (those with\n  `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)"
+          "title": "Can be one of the following:\n- Absent/empty value to unset the Ramping Version. Must be paired with `percentage=0`.\n- The fully-qualified string representation of a Version of this Deployment that supports\n  Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.). In the\n  format \"<deployment_name>/<build_id>\".\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\n  with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)"
         },
         "percentage": {
           "type": "number",
@@ -12009,11 +12010,11 @@
       "properties": {
         "currentVersion": {
           "type": "string",
-          "title": "Always present. Specifies which Deployment Version should should receive new workflow\nexecutions and tasks of existing unversioned or AutoUpgrade workflows.\nCan be one of the following:\n- The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has\n  `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\n  with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)\nNote: Current Version is overridden by the Ramping Version for a portion of traffic when a ramp\nis set (see `ramping_version`.)"
+          "title": "Always present. Specifies which Deployment Version should should receive new workflow\nexecutions and tasks of existing unversioned or AutoUpgrade workflows.\nCan be one of the following:\n- The fully-qualified string representation of a Version of this Deployment that supports\n  Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.). In the\n  format \"<deployment_name>/<build_id>\".\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\n  with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)\nNote: Current Version is overridden by the Ramping Version for a portion of traffic when a ramp\nis set (see `ramping_version`.)"
         },
         "rampingVersion": {
           "type": "string",
-          "description": "When present, it means the traffic is being shifted from the Current Version to the Ramping\nVersion.\nMust always be different from Current Version. Can be one of the following:\n- The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has\n  `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\n  with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)\nNote that it is possible to ramp from one Version to another Version, or from unversioned\nworkers to a particular Version, or from a particular Version to unversioned workers."
+          "description": "When present, it means the traffic is being shifted from the Current Version to the Ramping\nVersion.\nMust always be different from Current Version. Can be one of the following:\n- The fully-qualified string representation of a Version of this Deployment that supports\n  Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.). In the\n  format \"<deployment_name>/<build_id>\".\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\n  with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)\nNote that it is possible to ramp from one Version to another Version, or from unversioned\nworkers to a particular Version, or from a particular Version to unversioned workers."
         },
         "rampingVersionPercentage": {
           "type": "number",
@@ -12497,9 +12498,9 @@
           "format": "byte",
           "description": "This value is returned so that it can be optionally passed to APIs\nthat write to the Worker Deployment state to ensure that the state\ndid not change between this API call and a future write."
         },
-        "previousBuildId": {
+        "previousVersion": {
           "type": "string",
-          "description": "The Build ID of the version that was current before executing this operation. Can also be the\n`__unversioned__` special value."
+          "description": "The version that was current before executing this operation, in the form \"<deployment_name>/<build_id>\".\nCan also be the `__unversioned__` special value."
         }
       }
     },
@@ -12511,9 +12512,9 @@
           "format": "byte",
           "description": "This value is returned so that it can be optionally passed to APIs\nthat write to the Worker Deployment state to ensure that the state\ndid not change between this API call and a future write."
         },
-        "previousBuildId": {
+        "previousVersion": {
           "type": "string",
-          "description": "The Build ID of the version that was ramping before executing this operation. Can also be\nempty or the `__unversioned__` special value."
+          "description": "The version that was ramping before executing this operation, in the form \"<deployment_name>/<build_id>\".\nCan also be the `__unversioned__` special value."
         },
         "previousPercentage": {
           "type": "number",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -7057,7 +7057,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "title": "Required. Can be one of the following:\n- The fully-qualified string representation of a Version of this Deployment that supports\n  Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.). In the\n  format \"<deployment_name>/<build_id>\".\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\n  with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)"
+          "title": "Required. Can be one of the following:\n- The fully-qualified string representation of a Version of this Deployment that supports\n  Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`). In the\n  format \"<deployment_name>/<build_id>\".\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\n  with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)"
         },
         "conflictToken": {
           "type": "string",
@@ -7080,7 +7080,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "title": "Can be one of the following:\n- Absent/empty value to unset the Ramping Version. Must be paired with `percentage=0`.\n- The fully-qualified string representation of a Version of this Deployment that supports\n  Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.). In the\n  format \"<deployment_name>/<build_id>\".\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\n  with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)"
+          "title": "Can be one of the following:\n- Absent/empty value to unset the Ramping Version. Must be paired with `percentage=0`.\n- The fully-qualified string representation of a Version of this Deployment that supports\n  Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`). In the\n  format \"<deployment_name>/<build_id>\".\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\n  with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)"
         },
         "percentage": {
           "type": "number",
@@ -12010,11 +12010,11 @@
       "properties": {
         "currentVersion": {
           "type": "string",
-          "title": "Always present. Specifies which Deployment Version should should receive new workflow\nexecutions and tasks of existing unversioned or AutoUpgrade workflows.\nCan be one of the following:\n- The fully-qualified string representation of a Version of this Deployment that supports\n  Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.). In the\n  format \"<deployment_name>/<build_id>\".\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\n  with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)\nNote: Current Version is overridden by the Ramping Version for a portion of traffic when a ramp\nis set (see `ramping_version`.)"
+          "title": "Always present. Specifies which Deployment Version should should receive new workflow\nexecutions and tasks of existing unversioned or AutoUpgrade workflows.\nCan be one of the following:\n- The fully-qualified string representation of a Version of this Deployment that supports\n  Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`). In the\n  format \"<deployment_name>/<build_id>\".\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\n  with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)\nNote: Current Version is overridden by the Ramping Version for a portion of traffic when a ramp\nis set (see `ramping_version`.)"
         },
         "rampingVersion": {
           "type": "string",
-          "description": "When present, it means the traffic is being shifted from the Current Version to the Ramping\nVersion.\nMust always be different from Current Version. Can be one of the following:\n- The fully-qualified string representation of a Version of this Deployment that supports\n  Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.). In the\n  format \"<deployment_name>/<build_id>\".\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\n  with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)\nNote that it is possible to ramp from one Version to another Version, or from unversioned\nworkers to a particular Version, or from a particular Version to unversioned workers."
+          "description": "When present, it means the traffic is being shifted from the Current Version to the Ramping\nVersion.\nMust always be different from Current Version. Can be one of the following:\n- The fully-qualified string representation of a Version of this Deployment that supports\n  Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`). In the\n  format \"<deployment_name>/<build_id>\".\n- Or, the \"__unversioned__\" special value, to represent all the unversioned workers (those\n  with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)\nNote that it is possible to ramp from one Version to another Version, or from unversioned\nworkers to a particular Version, or from a particular Version to unversioned workers."
         },
         "rampingVersionPercentage": {
           "type": "number",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9311,8 +9311,9 @@ components:
             Always present. Specifies which Deployment Version should should receive new workflow
              executions and tasks of existing unversioned or AutoUpgrade workflows.
              Can be one of the following:
-             - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
-               `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
+             - The fully-qualified string representation of a Version of this Deployment that supports
+               Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.). In the
+               format "<deployment_name>/<build_id>".
              - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
                with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
              Note: Current Version is overridden by the Ramping Version for a portion of traffic when a ramp
@@ -9323,8 +9324,9 @@ components:
             When present, it means the traffic is being shifted from the Current Version to the Ramping
              Version.
              Must always be different from Current Version. Can be one of the following:
-             - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
-               `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
+             - The fully-qualified string representation of a Version of this Deployment that supports
+               Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.). In the
+               format "<deployment_name>/<build_id>".
              - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
                with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
              Note that it is possible to ramp from one Version to another Version, or from unversioned
@@ -9750,12 +9752,13 @@ components:
           type: string
         deploymentName:
           type: string
-        buildId:
+        version:
           type: string
           description: |-
             Required. Can be one of the following:
-             - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
-               `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
+             - The fully-qualified string representation of a Version of this Deployment that supports
+               Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.). In the
+               format "<deployment_name>/<build_id>".
              - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
                with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
         conflictToken:
@@ -9783,11 +9786,11 @@ components:
              that write to the Worker Deployment state to ensure that the state
              did not change between this API call and a future write.
           format: bytes
-        previousBuildId:
+        previousVersion:
           type: string
           description: |-
-            The Build ID of the version that was current before executing this operation. Can also be the
-             `__unversioned__` special value.
+            The version that was current before executing this operation, in the form "<deployment_name>/<build_id>".
+             Can also be the `__unversioned__` special value.
     SetWorkerDeploymentRampingVersionRequest:
       type: object
       properties:
@@ -9795,15 +9798,16 @@ components:
           type: string
         deploymentName:
           type: string
-        buildId:
+        version:
           type: string
           description: |-
             Can be one of the following:
              - Absent/empty value to unset the Ramping Version. Must be paired with `percentage=0`.
-             - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
-               `WorkflowVersioningMode==VERSIONING_BEHAVIORS`) to set it as the Ramping Version.
-             - Or, the "__unversioned__" special value, to ramp unversioned workers (those with
-               `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
+             - The fully-qualified string representation of a Version of this Deployment that supports
+               Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.). In the
+               format "<deployment_name>/<build_id>".
+             - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
+               with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
         percentage:
           type: number
           description: 'Ramp percentage to set. Valid range: [0,100].'
@@ -9833,11 +9837,11 @@ components:
              that write to the Worker Deployment state to ensure that the state
              did not change between this API call and a future write.
           format: bytes
-        previousBuildId:
+        previousVersion:
           type: string
           description: |-
-            The Build ID of the version that was ramping before executing this operation. Can also be
-             empty or the `__unversioned__` special value.
+            The version that was ramping before executing this operation, in the form "<deployment_name>/<build_id>".
+             Can also be the `__unversioned__` special value.
         previousPercentage:
           type: number
           description: The ramping version percentage before executing this operation.
@@ -11242,8 +11246,9 @@ components:
     WorkerDeploymentInfo_WorkerDeploymentVersionSummary:
       type: object
       properties:
-        buildId:
+        version:
           type: string
+          description: The fully-qualified string representation of the version, in the form "<deployment_name>/<build_id>".
         workflowVersioningMode:
           enum:
             - WORKFLOW_VERSIONING_MODE_UNSPECIFIED

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9312,7 +9312,7 @@ components:
              executions and tasks of existing unversioned or AutoUpgrade workflows.
              Can be one of the following:
              - The fully-qualified string representation of a Version of this Deployment that supports
-               Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.). In the
+               Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`). In the
                format "<deployment_name>/<build_id>".
              - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
                with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
@@ -9325,7 +9325,7 @@ components:
              Version.
              Must always be different from Current Version. Can be one of the following:
              - The fully-qualified string representation of a Version of this Deployment that supports
-               Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.). In the
+               Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`). In the
                format "<deployment_name>/<build_id>".
              - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
                with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
@@ -9757,7 +9757,7 @@ components:
           description: |-
             Required. Can be one of the following:
              - The fully-qualified string representation of a Version of this Deployment that supports
-               Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.). In the
+               Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`). In the
                format "<deployment_name>/<build_id>".
              - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
                with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
@@ -9804,7 +9804,7 @@ components:
             Can be one of the following:
              - Absent/empty value to unset the Ramping Version. Must be paired with `percentage=0`.
              - The fully-qualified string representation of a Version of this Deployment that supports
-               Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.). In the
+               Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`). In the
                format "<deployment_name>/<build_id>".
              - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
                with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)

--- a/temporal/api/deployment/v1/message.proto
+++ b/temporal/api/deployment/v1/message.proto
@@ -214,7 +214,8 @@ message WorkerDeploymentInfo {
 
 
     message WorkerDeploymentVersionSummary {
-        string build_id = 1;
+        // The fully-qualified string representation of the version, in the form "<deployment_name>/<build_id>".
+        string version = 1;
         temporal.api.enums.v1.WorkflowVersioningMode workflow_versioning_mode = 2;
         google.protobuf.Timestamp create_time = 3;
         enums.v1.VersionDrainageStatus drainage_status = 4;
@@ -230,8 +231,9 @@ message RoutingInfo {
     // Always present. Specifies which Deployment Version should should receive new workflow
     // executions and tasks of existing unversioned or AutoUpgrade workflows.
     // Can be one of the following:
-    // - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
-    //   `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
+    // - The fully-qualified string representation of a Version of this Deployment that supports
+    //   Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.). In the
+    //   format "<deployment_name>/<build_id>".
     // - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
     //   with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
     // Note: Current Version is overridden by the Ramping Version for a portion of traffic when a ramp
@@ -240,8 +242,9 @@ message RoutingInfo {
     // When present, it means the traffic is being shifted from the Current Version to the Ramping
     // Version.
     // Must always be different from Current Version. Can be one of the following:
-    // - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
-    //   `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
+    // - The fully-qualified string representation of a Version of this Deployment that supports
+    //   Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.). In the
+    //   format "<deployment_name>/<build_id>".
     // - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
     //   with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
     // Note that it is possible to ramp from one Version to another Version, or from unversioned

--- a/temporal/api/deployment/v1/message.proto
+++ b/temporal/api/deployment/v1/message.proto
@@ -69,10 +69,10 @@ message Deployment {
 // serve as the identifier.
 message WorkerDeploymentVersion {
     // The name of the Deployment this version belongs too.
-    string deployment_name = 2;
+    string deployment_name = 1;
     // Build ID uniquely identifies the Deployment Version within a Deployment, but the same Build
     // ID can be used in multiple Deployments.
-    string build_id = 1;
+    string build_id = 2;
 }
 
 // `DeploymentInfo` holds information about a deployment. Deployment information is tracked
@@ -232,7 +232,7 @@ message RoutingInfo {
     // executions and tasks of existing unversioned or AutoUpgrade workflows.
     // Can be one of the following:
     // - The fully-qualified string representation of a Version of this Deployment that supports
-    //   Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.). In the
+    //   Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`). In the
     //   format "<deployment_name>/<build_id>".
     // - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
     //   with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
@@ -243,7 +243,7 @@ message RoutingInfo {
     // Version.
     // Must always be different from Current Version. Can be one of the following:
     // - The fully-qualified string representation of a Version of this Deployment that supports
-    //   Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.). In the
+    //   Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`). In the
     //   format "<deployment_name>/<build_id>".
     // - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
     //   with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2005,7 +2005,7 @@ message SetWorkerDeploymentCurrentVersionRequest {
     string deployment_name = 2;
     // Required. Can be one of the following:
     // - The fully-qualified string representation of a Version of this Deployment that supports
-    //   Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.). In the
+    //   Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`). In the
     //   format "<deployment_name>/<build_id>".
     // - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
     //   with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
@@ -2047,7 +2047,7 @@ message SetWorkerDeploymentRampingVersionRequest {
     // Can be one of the following:
     // - Absent/empty value to unset the Ramping Version. Must be paired with `percentage=0`.
     // - The fully-qualified string representation of a Version of this Deployment that supports
-    //   Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.). In the
+    //   Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`). In the
     //   format "<deployment_name>/<build_id>".
     // - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
     //   with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2004,11 +2004,12 @@ message SetWorkerDeploymentCurrentVersionRequest {
     string namespace = 1;
     string deployment_name = 2;
     // Required. Can be one of the following:
-    // - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
-    //   `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.)
+    // - The fully-qualified string representation of a Version of this Deployment that supports
+    //   Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.). In the
+    //   format "<deployment_name>/<build_id>".
     // - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
     //   with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
-    string build_id = 3;
+    string version = 3;
     // Optional. This can be the value of conflict_token from a Describe, or another Worker
     // Deployment API. Passing a non-nil conflict token will cause this request to fail if the
     // Deployment's configuration has been modified between the API call that generated the
@@ -2034,9 +2035,9 @@ message SetWorkerDeploymentCurrentVersionResponse {
     // that write to the Worker Deployment state to ensure that the state
     // did not change between this API call and a future write.
     bytes conflict_token = 1;
-    // The Build ID of the version that was current before executing this operation. Can also be the
-    // `__unversioned__` special value.
-    string previous_build_id = 2;
+    // The version that was current before executing this operation, in the form "<deployment_name>/<build_id>".
+    // Can also be the `__unversioned__` special value.
+    string previous_version = 2;
 }
 
 // Set/unset the Ramping Version of a Worker Deployment and its ramp percentage.
@@ -2045,11 +2046,12 @@ message SetWorkerDeploymentRampingVersionRequest {
     string deployment_name = 2;
     // Can be one of the following:
     // - Absent/empty value to unset the Ramping Version. Must be paired with `percentage=0`.
-    // - The Build ID of a Version of this Deployment that supports Versioning Behaviors (i.e. has
-    //   `WorkflowVersioningMode==VERSIONING_BEHAVIORS`) to set it as the Ramping Version.
-    // - Or, the "__unversioned__" special value, to ramp unversioned workers (those with
-    //   `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
-    string build_id = 3;
+    // - The fully-qualified string representation of a Version of this Deployment that supports
+    //   Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`.). In the
+    //   format "<deployment_name>/<build_id>".
+    // - Or, the "__unversioned__" special value, to represent all the unversioned workers (those
+    //   with `UNVERSIONED` (or unspecified) `WorkflowVersioningMode`.)
+    string version = 3;
     // Ramp percentage to set. Valid range: [0,100].
     float percentage = 4;
 
@@ -2080,9 +2082,9 @@ message SetWorkerDeploymentRampingVersionResponse {
     // that write to the Worker Deployment state to ensure that the state
     // did not change between this API call and a future write.
     bytes conflict_token = 1;
-    // The Build ID of the version that was ramping before executing this operation. Can also be
-    // empty or the `__unversioned__` special value.
-    string previous_build_id = 2;
+    // The version that was ramping before executing this operation, in the form "<deployment_name>/<build_id>".
+    // Can also be the `__unversioned__` special value.
+    string previous_version = 2;
     // The ramping version percentage before executing this operation.
     float previous_percentage = 3;
 }


### PR DESCRIPTION

_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
Switch `string build_id` to `string version` in SetCurrent and SetRamp.
Explain that in RoutingInfo the `current_version` and `ramping_version` strings will be the fully-qualified version string instead of just build id.

btw, I'm assuming that when we add BYOK, we will simply add to `WorkerDeploymentOptions` and `WorkerDeploymentVersion`, so I'm not renaming build id there.
Right now they are:
```
// Identifies a Worker Deployment Version. The combination of `deployment_name` and `build_id`
// serve as the identifier.
message WorkerDeploymentVersion {
    // The name of the Deployment this version belongs too.
    string deployment_name = 1;
    // Build ID uniquely identifies the Deployment Version within a Deployment, but the same Build
    // ID can be used in multiple Deployments.
    string build_id = 2;
}

// Worker Deployment options set in SDK that need to be sent to server in every poll.
message WorkerDeploymentOptions {
    // Required. Worker Deployment name.
    string deployment_name = 1;
    // Required. Build ID of the worker. `deployment_name` and `build_id` together identify this
    // Worker Deployment Version.
    string build_id = 2;
    // Required. Workflow versioning mode for this Deployment Version. Must be the same for all
    // pollers in a given Deployment Version, across all Task Queues.
    temporal.api.enums.v1.WorkflowVersioningMode workflow_versioning_mode = 3;
}
```

Not trying to design this now, just trying to validate that the current structure is BYOK-compatible -- I'm imagining that in the future they could look something like:
```
+ // Identifies a Worker Deployment Version, which is identified by either:
+ //    - The combination of `deployment_name` and `build_id`.
+ //    - If present, `id`. 
message WorkerDeploymentVersion {
    // The name of the Deployment this version belongs too.
    string deployment_name = 1;
    // Build ID uniquely identifies the Deployment Version within a Deployment, but the same Build
    // ID can be used in multiple Deployments.
    string build_id = 2;
+    // Uniquely identifies the Deployment Version across a Namespace.
+    string id = 3;
}

// Worker Deployment options set in SDK that need to be sent to server in every poll.
message WorkerDeploymentOptions {
+    // Required unless `version_id` is present. Worker Deployment name.
    string deployment_name = 1;
+    // Required unless `version_id` is present. Build ID of the worker. `deployment_name` and 
+    // `build_id` together identify this Worker Deployment Version.
    string build_id = 2;
    // Required. Workflow versioning mode for this Deployment Version. Must be the same for all
    // pollers in a given Deployment Version, across all Task Queues.
    temporal.api.enums.v1.WorkflowVersioningMode workflow_versioning_mode = 3;
+    // Required only if `deployment_name` or `build_id` are not present.
+    // Uniquely identifies this Worker Deployment Version in the namespace.
+    string version_id 4;
}
```

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
