### PR TITLE
Describe API field Change

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -1944,7 +1944,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/worker-deployments/{version.deploymentName}/version/{version.buildId}": {
+    "/api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}/version/{version}": {
       "get": {
         "summary": "Describes a worker deployment version.",
         "operationId": "DescribeWorkerDeploymentVersion2",
@@ -1970,15 +1970,14 @@
             "type": "string"
           },
           {
-            "name": "version.deploymentName",
-            "description": "The name of the Deployment this version belongs too.",
+            "name": "deploymentName",
             "in": "path",
             "required": true,
             "type": "string"
           },
           {
-            "name": "version.buildId",
-            "description": "Build ID uniquely identifies the Deployment Version within a Deployment, but the same Build\nID can be used in multiple Deployments.",
+            "name": "version",
+            "description": "- The fully-qualified string representation of a Version of this Deployment that supports\n  Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`). In the\n  format \"<deployment_name>/<build_id>\".",
             "in": "path",
             "required": true,
             "type": "string"
@@ -1987,7 +1986,9 @@
         "tags": [
           "WorkflowService"
         ]
-      },
+      }
+    },
+    "/api/v1/namespaces/{namespace}/worker-deployments/{version.deploymentName}/version/{version.buildId}": {
       "delete": {
         "summary": "Deletes records of (an old) Version.",
         "operationId": "DeleteWorkerDeploymentVersion2",
@@ -5235,7 +5236,7 @@
         ]
       }
     },
-    "/namespaces/{namespace}/worker-deployments/{version.deploymentName}/version/{version.buildId}": {
+    "/namespaces/{namespace}/worker-deployments/{deploymentName}/version/{version}": {
       "get": {
         "summary": "Describes a worker deployment version.",
         "operationId": "DescribeWorkerDeploymentVersion",
@@ -5261,15 +5262,14 @@
             "type": "string"
           },
           {
-            "name": "version.deploymentName",
-            "description": "The name of the Deployment this version belongs too.",
+            "name": "deploymentName",
             "in": "path",
             "required": true,
             "type": "string"
           },
           {
-            "name": "version.buildId",
-            "description": "Build ID uniquely identifies the Deployment Version within a Deployment, but the same Build\nID can be used in multiple Deployments.",
+            "name": "version",
+            "description": "- The fully-qualified string representation of a Version of this Deployment that supports\n  Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`). In the\n  format \"<deployment_name>/<build_id>\".",
             "in": "path",
             "required": true,
             "type": "string"
@@ -5278,7 +5278,9 @@
         "tags": [
           "WorkflowService"
         ]
-      },
+      }
+    },
+    "/namespaces/{namespace}/worker-deployments/{version.deploymentName}/version/{version.buildId}": {
       "delete": {
         "summary": "Deletes records of (an old) Version.",
         "operationId": "DeleteWorkerDeploymentVersion",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -1712,7 +1712,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/worker-deployments/{version.deployment_name}/version/{version.build_id}:
+  /api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}/version/{version}:
     get:
       tags:
         - WorkflowService
@@ -1724,26 +1724,18 @@ paths:
           required: true
           schema:
             type: string
-        - name: version.deployment_name
+        - name: deploymentName
           in: path
           required: true
           schema:
             type: string
-        - name: version.build_id
+        - name: version
           in: path
-          required: true
-          schema:
-            type: string
-        - name: version.deploymentName
-          in: query
-          description: The name of the Deployment this version belongs too.
-          schema:
-            type: string
-        - name: version.buildId
-          in: query
           description: |-
-            Build ID uniquely identifies the Deployment Version within a Deployment, but the same Build
-             ID can be used in multiple Deployments.
+            - The fully-qualified string representation of a Version of this Deployment that supports
+               Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`). In the
+               format "<deployment_name>/<build_id>".
+          required: true
           schema:
             type: string
       responses:
@@ -1759,6 +1751,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/worker-deployments/{version.deployment_name}/version/{version.build_id}:
     delete:
       tags:
         - WorkflowService
@@ -4639,7 +4632,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/worker-deployments/{version.deployment_name}/version/{version.build_id}:
+  /namespaces/{namespace}/worker-deployments/{deploymentName}/version/{version}:
     get:
       tags:
         - WorkflowService
@@ -4651,26 +4644,18 @@ paths:
           required: true
           schema:
             type: string
-        - name: version.deployment_name
+        - name: deploymentName
           in: path
           required: true
           schema:
             type: string
-        - name: version.build_id
+        - name: version
           in: path
-          required: true
-          schema:
-            type: string
-        - name: version.deploymentName
-          in: query
-          description: The name of the Deployment this version belongs too.
-          schema:
-            type: string
-        - name: version.buildId
-          in: query
           description: |-
-            Build ID uniquely identifies the Deployment Version within a Deployment, but the same Build
-             ID can be used in multiple Deployments.
+            - The fully-qualified string representation of a Version of this Deployment that supports
+               Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`). In the
+               format "<deployment_name>/<build_id>".
+          required: true
           schema:
             type: string
       responses:
@@ -4686,6 +4671,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/worker-deployments/{version.deployment_name}/version/{version.build_id}:
     delete:
       tags:
         - WorkflowService

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1946,7 +1946,11 @@ message DescribeDeploymentResponse {
 
 message DescribeWorkerDeploymentVersionRequest {
 	string namespace = 1;
-  temporal.api.deployment.v1.WorkerDeploymentVersion version = 2;
+    string deployment_name = 2;
+    // - The fully-qualified string representation of a Version of this Deployment that supports
+    //   Versioning Behaviors (i.e. has `WorkflowVersioningMode==VERSIONING_BEHAVIORS`). In the
+    //   format "<deployment_name>/<build_id>".
+    string version = 3;
 }
 
 message DescribeWorkerDeploymentVersionResponse {

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -787,9 +787,9 @@ service WorkflowService {
     // Describes a worker deployment version.
     rpc DescribeWorkerDeploymentVersion (DescribeWorkerDeploymentVersionRequest) returns (DescribeWorkerDeploymentVersionResponse) {
         option (google.api.http) = {
-            get: "/namespaces/{namespace}/worker-deployments/{version.deployment_name}/version/{version.build_id}"
+            get: "/namespaces/{namespace}/worker-deployments/{deployment_name}/version/{version}"
             additional_bindings {
-                get: "/api/v1/namespaces/{namespace}/worker-deployments/{version.deployment_name}/version/{version.build_id}"
+                get: "/api/v1/namespaces/{namespace}/worker-deployments/{deployment_name}/version/{version}"
             }
         };
     }


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
- I noticed that all other version related API's, apart from DescribeVersion, were accepting in `deploymentName`, `version` as separate parameters. I think DescribeVersion should do the same.


<!-- Tell your future self why have you made these changes -->
**Why?**
- Might be easier for folks to just copy-paste deployment/buildID strings from UI rather than make version objects (which is how it would be right now)
- Consistency with other API's
- I understand this should not be called on "unversioned" and we can def have safe-guards for that


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
