### PR TITLE
Inherit pinned deployment version from parent workflow

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -14470,6 +14470,10 @@
         "versioningOverride": {
           "$ref": "#/definitions/v1VersioningOverride",
           "description": "Versioning override applied to this workflow when it was started."
+        },
+        "parentPinnedWorkerDeploymentVersion": {
+          "type": "string",
+          "description": "When present, it means this is a child workflow of a parent that is Pinned to this Worker\nDeployment Version. In this case, child workflow will start as Pinned to this Version instead\nof starting on the Current Version of its Task Queue.\nThis is set only if the child workflow is starting on a Task Queue belonging to the same\nWorker Deployment Version."
         }
       },
       "title": "Always the first event in workflow history"
@@ -14601,7 +14605,7 @@
       "properties": {
         "behavior": {
           "$ref": "#/definitions/v1VersioningBehavior",
-          "description": "Versioning behavior determines how the server should treat this execution when workers are\nupgraded. When present it means this workflow execution is versioned; UNSPECIFIED means\nunversioned. See the comments in `VersioningBehavior` enum for more info about different\nbehaviors.\nThis field is first set after an execution completes its first workflow task on a versioned\nworker, and set again on completion of every subsequent workflow task.\nNote that `behavior` is overridden by `versioning_override` if the latter is present."
+          "description": "Versioning behavior determines how the server should treat this execution when workers are\nupgraded. When present it means this workflow execution is versioned; UNSPECIFIED means\nunversioned. See the comments in `VersioningBehavior` enum for more info about different\nbehaviors.\nThis field is first set after an execution completes its first workflow task on a versioned\nworker, and set again on completion of every subsequent workflow task.\nFor child workflows of Pinned parents, this will be set to Pinned (along with `version`) when\nthe the child starts so that child's first workflow task goes to the same Version as the\nparent. After the first workflow task, it depends on the child workflow itself if it wants\nto stay pinned or become unpinned (according to Versioning Behavior set in the worker).\nNote that `behavior` is overridden by `versioning_override` if the latter is present."
         },
         "deployment": {
           "$ref": "#/definitions/v1Deployment",
@@ -14609,11 +14613,11 @@
         },
         "version": {
           "type": "string",
-          "description": "The Worker Deployment Version that completed the last workflow task of this workflow\nexecution, in the form \"<deployment_name>.<build_id>\".\nMust be present if and only if `behavior` is set. An absent value means no workflow task is\ncompleted, or the workflow is unversioned.\nNote that if `versioning_override.behavior` is PINNED then `versioning_override.pinned_version`\nwill override this value."
+          "description": "The Worker Deployment Version that completed the last workflow task of this workflow\nexecution, in the form \"<deployment_name>.<build_id>\".\nMust be present if and only if `behavior` is set. An absent value means no workflow task is\ncompleted, or the workflow is unversioned.\nFor child workflows of Pinned parents, this will be set to parent's Pinned Version when the\nthe child starts so that child's first workflow task goes to the same Version as the parent.\nNote that if `versioning_override.behavior` is PINNED then `versioning_override.pinned_version`\nwill override this value."
         },
         "versioningOverride": {
           "$ref": "#/definitions/v1VersioningOverride",
-          "description": "Present if user has set an execution-specific versioning override. This override takes\nprecedence over SDK-sent `behavior` (and `version` when override is PINNED). An\noverride can be set when starting a new execution, as well as afterwards by calling the\n`UpdateWorkflowExecutionOptions` API."
+          "description": "Present if user has set an execution-specific versioning override. This override takes\nprecedence over SDK-sent `behavior` (and `version` when override is PINNED). An\noverride can be set when starting a new execution, as well as afterwards by calling the\n`UpdateWorkflowExecutionOptions` API.\nPinned overrides are automatically inherited by child workflows."
         },
         "deploymentTransition": {
           "$ref": "#/definitions/v1DeploymentTransition",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -11968,6 +11968,14 @@ components:
           allOf:
             - $ref: '#/components/schemas/VersioningOverride'
           description: Versioning override applied to this workflow when it was started.
+        parentPinnedWorkerDeploymentVersion:
+          type: string
+          description: |-
+            When present, it means this is a child workflow of a parent that is Pinned to this Worker
+             Deployment Version. In this case, child workflow will start as Pinned to this Version instead
+             of starting on the Current Version of its Task Queue.
+             This is set only if the child workflow is starting on a Task Queue belonging to the same
+             Worker Deployment Version.
       description: Always the first event in workflow history
     WorkflowExecutionTerminatedEventAttributes:
       type: object
@@ -12088,6 +12096,10 @@ components:
              behaviors.
              This field is first set after an execution completes its first workflow task on a versioned
              worker, and set again on completion of every subsequent workflow task.
+             For child workflows of Pinned parents, this will be set to Pinned (along with `version`) when
+             the the child starts so that child's first workflow task goes to the same Version as the
+             parent. After the first workflow task, it depends on the child workflow itself if it wants
+             to stay pinned or become unpinned (according to Versioning Behavior set in the worker).
              Note that `behavior` is overridden by `versioning_override` if the latter is present.
           format: enum
         deployment:
@@ -12108,6 +12120,8 @@ components:
              execution, in the form "<deployment_name>.<build_id>".
              Must be present if and only if `behavior` is set. An absent value means no workflow task is
              completed, or the workflow is unversioned.
+             For child workflows of Pinned parents, this will be set to parent's Pinned Version when the
+             the child starts so that child's first workflow task goes to the same Version as the parent.
              Note that if `versioning_override.behavior` is PINNED then `versioning_override.pinned_version`
              will override this value.
         versioningOverride:
@@ -12118,6 +12132,7 @@ components:
              precedence over SDK-sent `behavior` (and `version` when override is PINNED). An
              override can be set when starting a new execution, as well as afterwards by calling the
              `UpdateWorkflowExecutionOptions` API.
+             Pinned overrides are automatically inherited by child workflows.
         deploymentTransition:
           allOf:
             - $ref: '#/components/schemas/DeploymentTransition'

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -133,6 +133,12 @@ message WorkflowExecutionStartedEventAttributes {
     string inherited_build_id = 32;
     // Versioning override applied to this workflow when it was started.
     temporal.api.workflow.v1.VersioningOverride versioning_override = 33;
+    // When present, it means this is a child workflow of a parent that is Pinned to this Worker
+    // Deployment Version. In this case, child workflow will start as Pinned to this Version instead
+    // of starting on the Current Version of its Task Queue.
+    // This is set only if the child workflow is starting on a Task Queue belonging to the same
+    // Worker Deployment Version.
+    string parent_pinned_worker_deployment_version = 34;
 }
 
 message WorkflowExecutionCompletedEventAttributes {

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -144,6 +144,10 @@ message WorkflowExecutionVersioningInfo {
     // behaviors.
     // This field is first set after an execution completes its first workflow task on a versioned
     // worker, and set again on completion of every subsequent workflow task.
+    // For child workflows of Pinned parents, this will be set to Pinned (along with `version`) when
+    // the the child starts so that child's first workflow task goes to the same Version as the
+    // parent. After the first workflow task, it depends on the child workflow itself if it wants
+    // to stay pinned or become unpinned (according to Versioning Behavior set in the worker).
     // Note that `behavior` is overridden by `versioning_override` if the latter is present.
     temporal.api.enums.v1.VersioningBehavior behavior = 1;
     // The worker deployment that completed the last workflow task of this workflow execution. Must
@@ -158,6 +162,8 @@ message WorkflowExecutionVersioningInfo {
     // execution, in the form "<deployment_name>.<build_id>".
     // Must be present if and only if `behavior` is set. An absent value means no workflow task is
     // completed, or the workflow is unversioned.
+    // For child workflows of Pinned parents, this will be set to parent's Pinned Version when the
+    // the child starts so that child's first workflow task goes to the same Version as the parent.
     // Note that if `versioning_override.behavior` is PINNED then `versioning_override.pinned_version`
     // will override this value.
     string version = 5;
@@ -165,6 +171,7 @@ message WorkflowExecutionVersioningInfo {
     // precedence over SDK-sent `behavior` (and `version` when override is PINNED). An
     // override can be set when starting a new execution, as well as afterwards by calling the
     // `UpdateWorkflowExecutionOptions` API.
+    // Pinned overrides are automatically inherited by child workflows.
     VersioningOverride versioning_override = 3;
     // When present, indicates the workflow is transitioning to a different deployment. Can
     // indicate one of the following transitions: unversioned -> versioned, versioned -> versioned


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
Child workflows start in parent's pinned Worker Deployment Version.

<!-- Tell your future self why have you made these changes -->
**Why?**
So user do not have to worry about interface compatibility between pinned parents and children.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
