### PR TITLE
Deprecate ScanWorkflowExecutions

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -12060,7 +12060,8 @@
           "type": "string",
           "format": "byte"
         }
-      }
+      },
+      "description": "Deprecated: Use with `ListWorkflowExecutions`."
     },
     "v1Schedule": {
       "type": "object",

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -899,6 +899,7 @@ message ListArchivedWorkflowExecutionsResponse {
     bytes next_page_token = 2;
 }
 
+// Deprecated: Use with `ListWorkflowExecutions`.
 message ScanWorkflowExecutionsRequest {
     string namespace = 1;
     int32 page_size = 2;
@@ -906,6 +907,7 @@ message ScanWorkflowExecutionsRequest {
     string query = 4;
 }
 
+// Deprecated: Use with `ListWorkflowExecutions`.
 message ScanWorkflowExecutionsResponse {
     repeated temporal.api.workflow.v1.WorkflowExecutionInfo executions = 1;
     bytes next_page_token = 2;

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -482,6 +482,7 @@ service WorkflowService {
 
     // ScanWorkflowExecutions is a visibility API to list large amount of workflow executions in a specific namespace without order.
     //
+    // Deprecated: Replaced with `ListWorkflowExecutions`.
     // (-- api-linter: core::0127::http-annotation=disabled
     //     aip.dev/not-precedent: HTTP users should use ListWorkflowExecutions instead. --)
     rpc ScanWorkflowExecutions (ScanWorkflowExecutionsRequest) returns (ScanWorkflowExecutionsResponse) {


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
Deprecate ScanWorkflowExecutions


<!-- Tell your future self why have you made these changes -->
To ultimately remove ScanWorkflowExecutions in favor of ListWorkflowExecutions


<!-- Are there any breaking changes on binary or code level? -->
No


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
