### PR TITLE
Poller Scaling Decisions

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -11438,7 +11438,7 @@
           "description": "How many poll requests to suggest should be added or removed, if any. As of now, server only\nscales up or down by 1. However, SDKs should allow for other values (while staying within\ndefined min/max).\n\nThe SDK is free to ignore this suggestion, EX: making more polls would not make sense because\nall slots are already occupied."
         }
       },
-      "description": "Attached to task responsese to give hints to the SDK about how it may adjust its number of\npollers."
+      "description": "Attached to task responses to give hints to the SDK about how it may adjust its number of\npollers."
     },
     "v1ProtocolMessageCommandAttributes": {
       "type": "object",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -11281,6 +11281,10 @@
         "retryPolicy": {
           "$ref": "#/definitions/v1RetryPolicy",
           "description": "This is the retry policy the service uses which may be different from the one provided\n(or not) during activity scheduling. The service can override the provided one if some\nvalues are not specified or exceed configured system limits."
+        },
+        "pollerScalingDecision": {
+          "$ref": "#/definitions/v1PollerScalingDecision",
+          "description": "Server-advised information the SDK may use to adjust its poller count."
         }
       }
     },
@@ -11295,6 +11299,10 @@
         "request": {
           "$ref": "#/definitions/apinexusv1Request",
           "description": "Embedded request as translated from the incoming frontend request."
+        },
+        "pollerScalingDecision": {
+          "$ref": "#/definitions/v1PollerScalingDecision",
+          "description": "Server-advised information the SDK may use to adjust its poller count."
         }
       }
     },
@@ -11390,6 +11398,10 @@
             "$ref": "#/definitions/v1Message"
           },
           "title": "Protocol messages piggybacking on a WFT as a transport"
+        },
+        "pollerScalingDecision": {
+          "$ref": "#/definitions/v1PollerScalingDecision",
+          "description": "Server-advised information the SDK may use to adjust its poller count."
         }
       }
     },
@@ -11416,6 +11428,17 @@
           "description": "Worker deployment options that SDK sent to server."
         }
       }
+    },
+    "v1PollerScalingDecision": {
+      "type": "object",
+      "properties": {
+        "pollRequestDeltaSuggestion": {
+          "type": "integer",
+          "format": "int32",
+          "description": "How many poll requests to suggest should be added or removed, if any. As of now, server only\nscales up or down by 1. However, SDKs should allow for other values (while staying within\ndefined min/max).\n\nThe SDK is free to ignore this suggestion, EX: making more polls would not make sense because\nall slots are already occupied."
+        }
+      },
+      "description": "Attached to task responsese to give hints to the SDK about how it may adjust its number of\npollers."
     },
     "v1ProtocolMessageCommandAttributes": {
       "type": "object",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -8566,6 +8566,10 @@ components:
           items:
             $ref: '#/components/schemas/Message'
           description: Protocol messages piggybacking on a WFT as a transport
+        pollerScalingDecision:
+          allOf:
+            - $ref: '#/components/schemas/PollerScalingDecision'
+          description: Server-advised information the SDK may use to adjust its poller count.
     PollerInfo:
       type: object
       properties:
@@ -8588,6 +8592,22 @@ components:
           allOf:
             - $ref: '#/components/schemas/WorkerDeploymentOptions'
           description: Worker deployment options that SDK sent to server.
+    PollerScalingDecision:
+      type: object
+      properties:
+        pollRequestDeltaSuggestion:
+          type: integer
+          description: |-
+            How many poll requests to suggest should be added or removed, if any. As of now, server only
+             scales up or down by 1. However, SDKs should allow for other values (while staying within
+             defined min/max).
+
+             The SDK is free to ignore this suggestion, EX: making more polls would not make sense because
+             all slots are already occupied.
+          format: int32
+      description: |-
+        Attached to task responsese to give hints to the SDK about how it may adjust its number of
+         pollers.
     QueryRejected:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -8606,7 +8606,7 @@ components:
              all slots are already occupied.
           format: int32
       description: |-
-        Attached to task responsese to give hints to the SDK about how it may adjust its number of
+        Attached to task responses to give hints to the SDK about how it may adjust its number of
          pollers.
     QueryRejected:
       type: object

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -325,7 +325,7 @@ message TimestampedCompatibleBuildIdRedirectRule {
     google.protobuf.Timestamp create_time = 2;
 }
 
-// Attached to task responsese to give hints to the SDK about how it may adjust its number of
+// Attached to task responses to give hints to the SDK about how it may adjust its number of
 // pollers.
 message PollerScalingDecision {
   // How many poll requests to suggest should be added or removed, if any. As of now, server only

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -324,3 +324,15 @@ message TimestampedCompatibleBuildIdRedirectRule {
     CompatibleBuildIdRedirectRule rule = 1;
     google.protobuf.Timestamp create_time = 2;
 }
+
+// Attached to task responsese to give hints to the SDK about how it may adjust its number of
+// pollers.
+message PollerScalingDecision {
+  // How many poll requests to suggest should be added or removed, if any. As of now, server only
+  // scales up or down by 1. However, SDKs should allow for other values (while staying within
+  // defined min/max).
+  //
+  // The SDK is free to ignore this suggestion, EX: making more polls would not make sense because
+  // all slots are already occupied.
+  int32 poll_request_delta_suggestion = 1;
+}

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -331,6 +331,8 @@ message PollWorkflowTaskQueueResponse {
     map<string, temporal.api.query.v1.WorkflowQuery> queries = 14;
     // Protocol messages piggybacking on a WFT as a transport
     repeated temporal.api.protocol.v1.Message messages = 15;
+    // Server-advised information the SDK may use to adjust its poller count.
+    temporal.api.taskqueue.v1.PollerScalingDecision poller_scaling_decision = 16;
 }
 
 message RespondWorkflowTaskCompletedRequest {
@@ -496,6 +498,8 @@ message PollActivityTaskQueueResponse {
     // (or not) during activity scheduling. The service can override the provided one if some
     // values are not specified or exceed configured system limits.
     temporal.api.common.v1.RetryPolicy retry_policy = 17;
+    // Server-advised information the SDK may use to adjust its poller count.
+    temporal.api.taskqueue.v1.PollerScalingDecision poller_scaling_decision = 18;
 }
 
 message RecordActivityTaskHeartbeatRequest {
@@ -1733,6 +1737,8 @@ message PollNexusTaskQueueResponse {
     bytes task_token = 1;
     // Embedded request as translated from the incoming frontend request.
     temporal.api.nexus.v1.Request request = 2;
+    // Server-advised information the SDK may use to adjust its poller count.
+    temporal.api.taskqueue.v1.PollerScalingDecision poller_scaling_decision = 3;
 }
 
 message RespondNexusTaskCompletedRequest {
@@ -2106,7 +2112,7 @@ message ListWorkerDeploymentsResponse {
     bytes next_page_token = 1;
     // The list of worker deployments.
     repeated WorkerDeploymentSummary worker_deployments = 2;
-  
+
     // (-- api-linter: core::0123::resource-annotation=disabled --)
     // A subset of WorkerDeploymentInfo
     message WorkerDeploymentSummary {


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
Added a proto that is optionally attached to task responses and contains data for the SDK about whether or not pollers should be scaled up or down.

<!-- Tell your future self why have you made these changes -->
**Why?**
Part of the worker management effort to simplify configuration of workers for users.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
Nope

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
It's nonbreaking, but the PR is here: https://github.com/temporalio/temporal/pull/7300