### PR TITLE
Add ResourceExhaustedCause for namespace operations

### DIFF
--- a/temporal/api/enums/v1/failed_cause.proto
+++ b/temporal/api/enums/v1/failed_cause.proto
@@ -142,7 +142,7 @@ enum ResourceExhaustedCause {
     // Circuit breaker is open/half-open.
     RESOURCE_EXHAUSTED_CAUSE_CIRCUIT_BREAKER_OPEN = 8;
     // Namespace exceeds operations rate limit.
-    RESOURCE_EXHAUSTED_CAUSE_OPERATIONS_RATE_LIMIT = 9;
+    RESOURCE_EXHAUSTED_CAUSE_OPS_EXCEEDED = 9;
 }
 
 enum ResourceExhaustedScope {

--- a/temporal/api/enums/v1/failed_cause.proto
+++ b/temporal/api/enums/v1/failed_cause.proto
@@ -141,6 +141,8 @@ enum ResourceExhaustedCause {
     RESOURCE_EXHAUSTED_CAUSE_PERSISTENCE_STORAGE_LIMIT = 7;
     // Circuit breaker is open/half-open.
     RESOURCE_EXHAUSTED_CAUSE_CIRCUIT_BREAKER_OPEN = 8;
+    // Namespace exceeds operations rate limit.
+    RESOURCE_EXHAUSTED_CAUSE_OPERATIONS_RATE_LIMIT = 9;
 }
 
 enum ResourceExhaustedScope {

--- a/temporal/api/enums/v1/failed_cause.proto
+++ b/temporal/api/enums/v1/failed_cause.proto
@@ -142,7 +142,7 @@ enum ResourceExhaustedCause {
     // Circuit breaker is open/half-open.
     RESOURCE_EXHAUSTED_CAUSE_CIRCUIT_BREAKER_OPEN = 8;
     // Namespace exceeds operations rate limit.
-    RESOURCE_EXHAUSTED_CAUSE_OPS_EXCEEDED = 9;
+    RESOURCE_EXHAUSTED_CAUSE_OPERATIONS_RATE_LIMIT = 9;
 }
 
 enum ResourceExhaustedScope {

--- a/temporal/api/enums/v1/failed_cause.proto
+++ b/temporal/api/enums/v1/failed_cause.proto
@@ -142,7 +142,7 @@ enum ResourceExhaustedCause {
     // Circuit breaker is open/half-open.
     RESOURCE_EXHAUSTED_CAUSE_CIRCUIT_BREAKER_OPEN = 8;
     // Namespace exceeds operations rate limit.
-    RESOURCE_EXHAUSTED_CAUSE_OPERATIONS_RATE_LIMIT = 9;
+    RESOURCE_EXHAUSTED_CAUSE_OPS_LIMIT = 9;
 }
 
 enum ResourceExhaustedScope {


### PR DESCRIPTION
**What changed?**
Added a new ResourceExhaustedCause RESOURCE_EXHAUSTED_CAUSE_OPERATIONS_RATE_LIMIT.

**Why?**
We are introducing a new namespace operations rate limit which can throttle frontendRPS, poll requests and history tasks. That rate limiter will return this cause.

**Breaking changes**
No

