### PR TITLE
Add more state to the pending activity state

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -11608,9 +11608,12 @@
         "PENDING_ACTIVITY_STATE_UNSPECIFIED",
         "PENDING_ACTIVITY_STATE_SCHEDULED",
         "PENDING_ACTIVITY_STATE_STARTED",
-        "PENDING_ACTIVITY_STATE_CANCEL_REQUESTED"
+        "PENDING_ACTIVITY_STATE_CANCEL_REQUESTED",
+        "PENDING_ACTIVITY_STATE_PAUSED",
+        "PENDING_ACTIVITY_STATE_PAUSE_REQUESTED"
       ],
-      "default": "PENDING_ACTIVITY_STATE_UNSPECIFIED"
+      "default": "PENDING_ACTIVITY_STATE_UNSPECIFIED",
+      "title": "- PENDING_ACTIVITY_STATE_PAUSED: PAUSED means activity is paused on the server, and is not running in the worker\n - PENDING_ACTIVITY_STATE_PAUSE_REQUESTED: PAUSE_REQUESTED means activity is currently running on the worker, but paused on the server"
     },
     "v1PendingChildExecutionInfo": {
       "type": "object",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -8715,6 +8715,8 @@ components:
             - PENDING_ACTIVITY_STATE_SCHEDULED
             - PENDING_ACTIVITY_STATE_STARTED
             - PENDING_ACTIVITY_STATE_CANCEL_REQUESTED
+            - PENDING_ACTIVITY_STATE_PAUSED
+            - PENDING_ACTIVITY_STATE_PAUSE_REQUESTED
           type: string
           format: enum
         heartbeatDetails:

--- a/temporal/api/enums/v1/workflow.proto
+++ b/temporal/api/enums/v1/workflow.proto
@@ -106,6 +106,10 @@ enum PendingActivityState {
     PENDING_ACTIVITY_STATE_SCHEDULED = 1;
     PENDING_ACTIVITY_STATE_STARTED = 2;
     PENDING_ACTIVITY_STATE_CANCEL_REQUESTED = 3;
+    // PAUSED means activity is paused on the server, and is not running in the worker
+    PENDING_ACTIVITY_STATE_PAUSED = 4;
+    // PAUSE_REQUESTED means activity is currently running on the worker, but paused on the server
+    PENDING_ACTIVITY_STATE_PAUSE_REQUESTED = 5;
 }
 
 enum PendingWorkflowTaskState {


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
Add PAUSED/PAUSE_REQUESTED states to the PendictActivityState enum.

<!-- Tell your future self why have you made these changes -->
**Why?**
To easily differentiate between "activity is paused on server and still running on worker" and "activity is paused on server and not running on worker". This is the result of our discussion for activity commands.

In old terms:
"state == PAUSED" is "state = SCHEDULLED and paused_flag = true"
"state == PAUSE_REQUESTED" is "state = STARTED and paused_flag = true"