### PR TITLE
Add reset_run_id field in api/workflow/v1/WorkflowExecutionInfo

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -14775,6 +14775,10 @@
           "type": "string",
           "format": "date-time",
           "description": "Original workflow start time."
+        },
+        "resetRunId": {
+          "type": "string",
+          "description": "Reset Run ID points to the new run when this execution is reset. If the execution is reset multiple times, it points to the latest run."
         }
       },
       "description": "Holds all the extra information about workflow execution that is not part of Visibility."
@@ -14900,10 +14904,6 @@
         "priority": {
           "$ref": "#/definitions/v1Priority",
           "title": "Priority metadata"
-        },
-        "resetRunId": {
-          "type": "string",
-          "description": "Reset Run ID points to the new nun when this execution is reset. If the execution is reset multiple times, it points to the latest run."
         }
       },
       "description": "Hold basic information about a workflow execution.\nThis structure is a part of visibility, and thus contain a limited subset of information."

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -14900,6 +14900,10 @@
         "priority": {
           "$ref": "#/definitions/v1Priority",
           "title": "Priority metadata"
+        },
+        "resetRunId": {
+          "type": "string",
+          "description": "Reset Run ID points to the new nun when this execution is reset. If the execution is reset multiple times, it points to the latest run."
         }
       },
       "description": "Hold basic information about a workflow execution.\nThis structure is a part of visibility, and thus contain a limited subset of information."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -12297,6 +12297,9 @@ components:
           allOf:
             - $ref: '#/components/schemas/Priority'
           description: Priority metadata
+        resetRunId:
+          type: string
+          description: Reset Run ID points to the new nun when this execution is reset. If the execution is reset multiple times, it points to the latest run.
       description: |-
         Hold basic information about a workflow execution.
          This structure is a part of visibility, and thus contain a limited subset of information.

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -12151,6 +12151,9 @@ components:
           type: string
           description: Original workflow start time.
           format: date-time
+        resetRunId:
+          type: string
+          description: Reset Run ID points to the new run when this execution is reset. If the execution is reset multiple times, it points to the latest run.
       description: Holds all the extra information about workflow execution that is not part of Visibility.
     WorkflowExecutionFailedEventAttributes:
       type: object
@@ -12297,9 +12300,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/Priority'
           description: Priority metadata
-        resetRunId:
-          type: string
-          description: Reset Run ID points to the new nun when this execution is reset. If the execution is reset multiple times, it points to the latest run.
       description: |-
         Hold basic information about a workflow execution.
          This structure is a part of visibility, and thus contain a limited subset of information.

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -137,7 +137,7 @@ message WorkflowExecutionExtendedInfo {
     // Original workflow start time.
     google.protobuf.Timestamp original_start_time = 5;
 
-    // Reset Run ID points to the new nun when this execution is reset. If the execution is reset multiple times, it points to the latest run.
+    // Reset Run ID points to the new run when this execution is reset. If the execution is reset multiple times, it points to the latest run.
     string reset_run_id = 25;
 }
 

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -117,9 +117,6 @@ message WorkflowExecutionInfo {
 
     // Priority metadata
     temporal.api.common.v1.Priority priority = 24;
-
-    // Reset Run ID points to the new nun when this execution is reset. If the execution is reset multiple times, it points to the latest run.
-    string reset_run_id = 25;
 }
 
 // Holds all the extra information about workflow execution that is not part of Visibility.
@@ -139,6 +136,9 @@ message WorkflowExecutionExtendedInfo {
 
     // Original workflow start time.
     google.protobuf.Timestamp original_start_time = 5;
+
+    // Reset Run ID points to the new nun when this execution is reset. If the execution is reset multiple times, it points to the latest run.
+    string reset_run_id = 25;
 }
 
 // Holds all the information about worker versioning for a particular workflow execution.

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -138,7 +138,7 @@ message WorkflowExecutionExtendedInfo {
     google.protobuf.Timestamp original_start_time = 5;
 
     // Reset Run ID points to the new run when this execution is reset. If the execution is reset multiple times, it points to the latest run.
-    string reset_run_id = 25;
+    string reset_run_id = 6;
 }
 
 // Holds all the information about worker versioning for a particular workflow execution.

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -117,6 +117,9 @@ message WorkflowExecutionInfo {
 
     // Priority metadata
     temporal.api.common.v1.Priority priority = 24;
+
+    // Reset Run ID points to the new nun when this execution is reset. If the execution is reset multiple times, it points to the latest run.
+    string reset_run_id = 25;
 }
 
 // Holds all the extra information about workflow execution that is not part of Visibility.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Added `reset_run_id` field in WorkflowExecutionInfo message. This field will be populated in the DescribeWorkflow API calls (coming up in another PR in server repo)


<!-- Tell your future self why have you made these changes -->
This is needed so that we can expose this field to the UI. The UI would use this information to point the user to the new execution when viewing the old execution that was reset. 



