### PR TITLE
Add ApplicationErrorCategory to ApplicationFailureInfo

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -8535,6 +8535,15 @@
       },
       "description": "Alert contains notification and severity."
     },
+    "v1ApplicationErrorCategory": {
+      "type": "string",
+      "enum": [
+        "APPLICATION_ERROR_CATEGORY_UNSPECIFIED",
+        "APPLICATION_ERROR_CATEGORY_BENIGN"
+      ],
+      "default": "APPLICATION_ERROR_CATEGORY_UNSPECIFIED",
+      "description": " - APPLICATION_ERROR_CATEGORY_BENIGN: Expected application error with little/no severity."
+    },
     "v1ApplicationFailureInfo": {
       "type": "object",
       "properties": {
@@ -8550,6 +8559,9 @@
         "nextRetryDelay": {
           "type": "string",
           "description": "next_retry_delay can be used by the client to override the activity\nretry interval calculated by the retry policy. Retry attempts will\nstill be subject to the maximum retries limit and total time limit\ndefined by the policy."
+        },
+        "category": {
+          "$ref": "#/definitions/v1ApplicationErrorCategory"
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -6189,6 +6189,12 @@ components:
              retry interval calculated by the retry policy. Retry attempts will
              still be subject to the maximum retries limit and total time limit
              defined by the policy.
+        category:
+          enum:
+            - APPLICATION_ERROR_CATEGORY_UNSPECIFIED
+            - APPLICATION_ERROR_CATEGORY_BENIGN
+          type: string
+          format: enum
     BackfillRequest:
       type: object
       properties:

--- a/temporal/api/enums/v1/common.proto
+++ b/temporal/api/enums/v1/common.proto
@@ -113,3 +113,9 @@ enum WorkflowRuleActionScope {
     // The action will be applied to a specific activity.
     WORKFLOW_RULE_ACTION_SCOPE_ACTIVITY = 2;
 }
+
+enum ApplicationErrorCategory {
+    APPLICATION_ERROR_CATEGORY_UNSPECIFIED = 0;
+    // Expected application error with little/no severity.
+    APPLICATION_ERROR_CATEGORY_BENIGN = 1;
+}

--- a/temporal/api/failure/v1/message.proto
+++ b/temporal/api/failure/v1/message.proto
@@ -34,6 +34,7 @@ option csharp_namespace = "Temporalio.Api.Failure.V1";
 import "temporal/api/common/v1/message.proto";
 import "temporal/api/enums/v1/workflow.proto";
 import "temporal/api/enums/v1/nexus.proto";
+import "temporal/api/enums/v1/common.proto";
 
 import "google/protobuf/duration.proto";
 
@@ -46,6 +47,7 @@ message ApplicationFailureInfo {
     // still be subject to the maximum retries limit and total time limit
     // defined by the policy.
     google.protobuf.Duration next_retry_delay = 4;
+    temporal.api.enums.v1.ApplicationErrorCategory category = 5;
 }
 
 message TimeoutFailureInfo {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added an ENUM `ApplicationErrorCategory`, used in `ApplicationFailureInfo` proto.

<!-- Tell your future self why have you made these changes -->
**Why?**
Give users a way to categorize application failures. Error categories map to different observability behaviours SDK-side (i.e. logging/metrics), part of the work for benign exceptions. Categories could also be used with rules in the future.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
No

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
Don't believe this breaks server or requires any changes to server