### PR TITLE
Deployment and TaskQueue Stats API

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -1610,7 +1610,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/task-queues/{taskQueue.name}/type/{taskQueueType}/get-stats": {
+    "/api/v1/namespaces/{namespace}/task-queues/{taskQueue}/type/{taskQueueType}/get-stats": {
       "post": {
         "summary": "GetTaskQueueStats returns stats for a single task queue.",
         "operationId": "GetTaskQueueStats2",
@@ -1636,7 +1636,7 @@
             "type": "string"
           },
           {
-            "name": "taskQueue.name",
+            "name": "taskQueue",
             "in": "path",
             "required": true,
             "type": "string"
@@ -1652,26 +1652,6 @@
               "TASK_QUEUE_TYPE_ACTIVITY",
               "TASK_QUEUE_TYPE_NEXUS"
             ]
-          },
-          {
-            "name": "taskQueue.kind",
-            "description": "Default: TASK_QUEUE_KIND_NORMAL.\n\n - TASK_QUEUE_KIND_NORMAL: Tasks from a normal workflow task queue always include complete workflow history\n\nThe task queue specified by the user is always a normal task queue. There can be as many\nworkers as desired for a single normal task queue. All those workers may pick up tasks from\nthat queue.\n - TASK_QUEUE_KIND_STICKY: A sticky queue only includes new history since the last workflow task, and they are\nper-worker.\n\nSticky queues are created dynamically by each worker during their start up. They only exist\nfor the lifetime of the worker process. Tasks in a sticky task queue are only available to\nthe worker that created the sticky queue.\n\nSticky queues are only for workflow tasks. There are no sticky task queues for activities.",
-            "in": "query",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "TASK_QUEUE_KIND_UNSPECIFIED",
-              "TASK_QUEUE_KIND_NORMAL",
-              "TASK_QUEUE_KIND_STICKY"
-            ],
-            "default": "TASK_QUEUE_KIND_UNSPECIFIED"
-          },
-          {
-            "name": "taskQueue.normalName",
-            "description": "Iff kind == TASK_QUEUE_KIND_STICKY, then this field contains the name of\nthe normal task queue that the sticky worker is running on.",
-            "in": "query",
-            "required": false,
-            "type": "string"
           }
         ],
         "tags": [
@@ -2149,7 +2129,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}/{deploymentVersion}/stats": {
+    "/api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}/stats": {
       "get": {
         "summary": "GetWorkerDeploymentStats returns the stats for all task queues in a deployment version.",
         "operationId": "GetWorkerDeploymentStats2",
@@ -2182,10 +2162,10 @@
             "type": "string"
           },
           {
-            "name": "deploymentVersion",
-            "description": "Optional. Deployment version to return stats for.\nIf left empty, the current version will be queried.",
-            "in": "path",
-            "required": true,
+            "name": "buildId",
+            "description": "Optional. Build ID to return stats for.\nIf left empty, the deployment's current one will be queried.",
+            "in": "query",
+            "required": false,
             "type": "string"
           }
         ],
@@ -5237,7 +5217,7 @@
         ]
       }
     },
-    "/namespaces/{namespace}/task-queues/{taskQueue.name}/type/{taskQueueType}/get-stats": {
+    "/namespaces/{namespace}/task-queues/{taskQueue}/type/{taskQueueType}/get-stats": {
       "post": {
         "summary": "GetTaskQueueStats returns stats for a single task queue.",
         "operationId": "GetTaskQueueStats",
@@ -5263,7 +5243,7 @@
             "type": "string"
           },
           {
-            "name": "taskQueue.name",
+            "name": "taskQueue",
             "in": "path",
             "required": true,
             "type": "string"
@@ -5279,26 +5259,6 @@
               "TASK_QUEUE_TYPE_ACTIVITY",
               "TASK_QUEUE_TYPE_NEXUS"
             ]
-          },
-          {
-            "name": "taskQueue.kind",
-            "description": "Default: TASK_QUEUE_KIND_NORMAL.\n\n - TASK_QUEUE_KIND_NORMAL: Tasks from a normal workflow task queue always include complete workflow history\n\nThe task queue specified by the user is always a normal task queue. There can be as many\nworkers as desired for a single normal task queue. All those workers may pick up tasks from\nthat queue.\n - TASK_QUEUE_KIND_STICKY: A sticky queue only includes new history since the last workflow task, and they are\nper-worker.\n\nSticky queues are created dynamically by each worker during their start up. They only exist\nfor the lifetime of the worker process. Tasks in a sticky task queue are only available to\nthe worker that created the sticky queue.\n\nSticky queues are only for workflow tasks. There are no sticky task queues for activities.",
-            "in": "query",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "TASK_QUEUE_KIND_UNSPECIFIED",
-              "TASK_QUEUE_KIND_NORMAL",
-              "TASK_QUEUE_KIND_STICKY"
-            ],
-            "default": "TASK_QUEUE_KIND_UNSPECIFIED"
-          },
-          {
-            "name": "taskQueue.normalName",
-            "description": "Iff kind == TASK_QUEUE_KIND_STICKY, then this field contains the name of\nthe normal task queue that the sticky worker is running on.",
-            "in": "query",
-            "required": false,
-            "type": "string"
           }
         ],
         "tags": [
@@ -5737,7 +5697,7 @@
         ]
       }
     },
-    "/namespaces/{namespace}/worker-deployments/{deploymentName}/{deploymentVersion}/stats": {
+    "/namespaces/{namespace}/worker-deployments/{deploymentName}/stats": {
       "get": {
         "summary": "GetWorkerDeploymentStats returns the stats for all task queues in a deployment version.",
         "operationId": "GetWorkerDeploymentStats",
@@ -5770,10 +5730,10 @@
             "type": "string"
           },
           {
-            "name": "deploymentVersion",
-            "description": "Optional. Deployment version to return stats for.\nIf left empty, the current version will be queried.",
-            "in": "path",
-            "required": true,
+            "name": "buildId",
+            "description": "Optional. Build ID to return stats for.\nIf left empty, the deployment's current one will be queried.",
+            "in": "query",
+            "required": false,
             "type": "string"
           }
         ],

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -1610,6 +1610,75 @@
         ]
       }
     },
+    "/api/v1/namespaces/{namespace}/task-queues/{taskQueue.name}/type/{taskQueueType}/get-stats": {
+      "post": {
+        "summary": "GetTaskQueueStats returns stats for a single task queue.",
+        "operationId": "GetTaskQueueStats2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetTaskQueueStatsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "taskQueue.name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "taskQueueType",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "TASK_QUEUE_TYPE_UNSPECIFIED",
+              "TASK_QUEUE_TYPE_WORKFLOW",
+              "TASK_QUEUE_TYPE_ACTIVITY",
+              "TASK_QUEUE_TYPE_NEXUS"
+            ]
+          },
+          {
+            "name": "taskQueue.kind",
+            "description": "Default: TASK_QUEUE_KIND_NORMAL.\n\n - TASK_QUEUE_KIND_NORMAL: Tasks from a normal workflow task queue always include complete workflow history\n\nThe task queue specified by the user is always a normal task queue. There can be as many\nworkers as desired for a single normal task queue. All those workers may pick up tasks from\nthat queue.\n - TASK_QUEUE_KIND_STICKY: A sticky queue only includes new history since the last workflow task, and they are\nper-worker.\n\nSticky queues are created dynamically by each worker during their start up. They only exist\nfor the lifetime of the worker process. Tasks in a sticky task queue are only available to\nthe worker that created the sticky queue.\n\nSticky queues are only for workflow tasks. There are no sticky task queues for activities.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "TASK_QUEUE_KIND_UNSPECIFIED",
+              "TASK_QUEUE_KIND_NORMAL",
+              "TASK_QUEUE_KIND_STICKY"
+            ],
+            "default": "TASK_QUEUE_KIND_UNSPECIFIED"
+          },
+          {
+            "name": "taskQueue.normalName",
+            "description": "Iff kind == TASK_QUEUE_KIND_STICKY, then this field contains the name of\nthe normal task queue that the sticky worker is running on.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
     "/api/v1/namespaces/{namespace}/task-queues/{taskQueue}/worker-build-id-compatibility": {
       "get": {
         "summary": "Deprecated. Use `GetWorkerVersioningRules`.\nFetches the worker build id versioning sets for a task queue.",
@@ -2073,6 +2142,51 @@
             "schema": {
               "$ref": "#/definitions/WorkflowServiceSetWorkerDeploymentRampingVersionBody"
             }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}/{deploymentVersion}/stats": {
+      "get": {
+        "summary": "GetWorkerDeploymentStats returns the stats for all task queues in a deployment version.",
+        "operationId": "GetWorkerDeploymentStats2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetWorkerDeploymentStatsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deploymentName",
+            "description": "Name of the deployment to return stats for.\n",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deploymentVersion",
+            "description": "Optional. Deployment version to return stats for.\nIf left empty, the current version will be queried.",
+            "in": "path",
+            "required": true,
+            "type": "string"
           }
         ],
         "tags": [
@@ -5123,6 +5237,75 @@
         ]
       }
     },
+    "/namespaces/{namespace}/task-queues/{taskQueue.name}/type/{taskQueueType}/get-stats": {
+      "post": {
+        "summary": "GetTaskQueueStats returns stats for a single task queue.",
+        "operationId": "GetTaskQueueStats",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetTaskQueueStatsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "taskQueue.name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "taskQueueType",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "TASK_QUEUE_TYPE_UNSPECIFIED",
+              "TASK_QUEUE_TYPE_WORKFLOW",
+              "TASK_QUEUE_TYPE_ACTIVITY",
+              "TASK_QUEUE_TYPE_NEXUS"
+            ]
+          },
+          {
+            "name": "taskQueue.kind",
+            "description": "Default: TASK_QUEUE_KIND_NORMAL.\n\n - TASK_QUEUE_KIND_NORMAL: Tasks from a normal workflow task queue always include complete workflow history\n\nThe task queue specified by the user is always a normal task queue. There can be as many\nworkers as desired for a single normal task queue. All those workers may pick up tasks from\nthat queue.\n - TASK_QUEUE_KIND_STICKY: A sticky queue only includes new history since the last workflow task, and they are\nper-worker.\n\nSticky queues are created dynamically by each worker during their start up. They only exist\nfor the lifetime of the worker process. Tasks in a sticky task queue are only available to\nthe worker that created the sticky queue.\n\nSticky queues are only for workflow tasks. There are no sticky task queues for activities.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "TASK_QUEUE_KIND_UNSPECIFIED",
+              "TASK_QUEUE_KIND_NORMAL",
+              "TASK_QUEUE_KIND_STICKY"
+            ],
+            "default": "TASK_QUEUE_KIND_UNSPECIFIED"
+          },
+          {
+            "name": "taskQueue.normalName",
+            "description": "Iff kind == TASK_QUEUE_KIND_STICKY, then this field contains the name of\nthe normal task queue that the sticky worker is running on.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
     "/namespaces/{namespace}/task-queues/{taskQueue}/worker-build-id-compatibility": {
       "get": {
         "summary": "Deprecated. Use `GetWorkerVersioningRules`.\nFetches the worker build id versioning sets for a task queue.",
@@ -5547,6 +5730,51 @@
             "schema": {
               "$ref": "#/definitions/WorkflowServiceSetWorkerDeploymentRampingVersionBody"
             }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/namespaces/{namespace}/worker-deployments/{deploymentName}/{deploymentVersion}/stats": {
+      "get": {
+        "summary": "GetWorkerDeploymentStats returns the stats for all task queues in a deployment version.",
+        "operationId": "GetWorkerDeploymentStats",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetWorkerDeploymentStatsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deploymentName",
+            "description": "Name of the deployment to return stats for.\n",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deploymentVersion",
+            "description": "Optional. Deployment version to return stats for.\nIf left empty, the current version will be queried.",
+            "in": "path",
+            "required": true,
+            "type": "string"
           }
         ],
         "tags": [
@@ -10306,6 +10534,14 @@
       },
       "description": "System capability details."
     },
+    "v1GetTaskQueueStatsResponse": {
+      "type": "object",
+      "properties": {
+        "taskQueueStats": {
+          "$ref": "#/definitions/v1TaskQueueStats"
+        }
+      }
+    },
     "v1GetWorkerBuildIdCompatibilityResponse": {
       "type": "object",
       "properties": {
@@ -10319,6 +10555,24 @@
         }
       },
       "title": "[cleanup-wv-pre-release]"
+    },
+    "v1GetWorkerDeploymentStatsResponse": {
+      "type": "object",
+      "properties": {
+        "perQueueMetrics": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1TaskQueueStatsInfo"
+          },
+          "title": "Collection of stats for all task queues in the requested deployment.\nNote that the data is"
+        },
+        "approximateTotalBacklogCount": {
+          "type": "string",
+          "format": "int64",
+          "title": "The sum of backlog counts across all task queues in the deployment.\nNote that same as the task queue metrics, this value is"
+        }
+      }
     },
     "v1GetWorkerTaskReachabilityResponse": {
       "type": "object",
@@ -13983,6 +14237,20 @@
         }
       },
       "description": "TaskQueueStats contains statistics about task queue backlog and activity.\n\nFor workflow task queue type, this result is partial because tasks sent to sticky queues are not included. Read\ncomments above each metric to understand the impact of sticky queue exclusion on that metric accuracy."
+    },
+    "v1TaskQueueStatsInfo": {
+      "type": "object",
+      "properties": {
+        "taskQueue": {
+          "$ref": "#/definitions/v1TaskQueue"
+        },
+        "taskQueueType": {
+          "$ref": "#/definitions/v1TaskQueueType"
+        },
+        "taskQueueStats": {
+          "$ref": "#/definitions/v1TaskQueueStats"
+        }
+      }
     },
     "v1TaskQueueStatus": {
       "type": "object",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -1300,6 +1300,47 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/task-queues/{taskQueue}/type/{taskQueueType}/get-stats:
+    post:
+      tags:
+        - WorkflowService
+      description: GetTaskQueueStats returns stats for a single task queue.
+      operationId: GetTaskQueueStats
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: taskQueue
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: taskQueueType
+          in: path
+          required: true
+          schema:
+            enum:
+              - TASK_QUEUE_TYPE_UNSPECIFIED
+              - TASK_QUEUE_TYPE_WORKFLOW
+              - TASK_QUEUE_TYPE_ACTIVITY
+              - TASK_QUEUE_TYPE_NEXUS
+            type: string
+            format: enum
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetTaskQueueStatsResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
   /api/v1/namespaces/{namespace}/task-queues/{taskQueue}/worker-build-id-compatibility:
     get:
       tags:
@@ -1498,68 +1539,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DescribeTaskQueueResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/task-queues/{task_queue.name}/type/{taskQueueType}/get-stats:
-    post:
-      tags:
-        - WorkflowService
-      description: GetTaskQueueStats returns stats for a single task queue.
-      operationId: GetTaskQueueStats
-      parameters:
-        - name: namespace
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: task_queue.name
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: taskQueueType
-          in: path
-          required: true
-          schema:
-            enum:
-              - TASK_QUEUE_TYPE_UNSPECIFIED
-              - TASK_QUEUE_TYPE_WORKFLOW
-              - TASK_QUEUE_TYPE_ACTIVITY
-              - TASK_QUEUE_TYPE_NEXUS
-            type: string
-            format: enum
-        - name: taskQueue.name
-          in: query
-          schema:
-            type: string
-        - name: taskQueue.kind
-          in: query
-          description: 'Default: TASK_QUEUE_KIND_NORMAL.'
-          schema:
-            enum:
-              - TASK_QUEUE_KIND_UNSPECIFIED
-              - TASK_QUEUE_KIND_NORMAL
-              - TASK_QUEUE_KIND_STICKY
-            type: string
-            format: enum
-        - name: taskQueue.normalName
-          in: query
-          description: |-
-            Iff kind == TASK_QUEUE_KIND_STICKY, then this field contains the name of
-             the normal task queue that the sticky worker is running on.
-          schema:
-            type: string
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetTaskQueueStatsResponse'
         default:
           description: Default error response
           content:
@@ -1904,7 +1883,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}/{deploymentVersion}/stats:
+  /api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}/stats:
     get:
       tags:
         - WorkflowService
@@ -1925,12 +1904,11 @@ paths:
           required: true
           schema:
             type: string
-        - name: deploymentVersion
-          in: path
+        - name: buildId
+          in: query
           description: |-
-            Optional. Deployment version to return stats for.
-             If left empty, the current version will be queried.
-          required: true
+            Optional. Build ID to return stats for.
+             If left empty, the deployment's current one will be queried.
           schema:
             type: string
       responses:
@@ -4524,6 +4502,47 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/task-queues/{taskQueue}/type/{taskQueueType}/get-stats:
+    post:
+      tags:
+        - WorkflowService
+      description: GetTaskQueueStats returns stats for a single task queue.
+      operationId: GetTaskQueueStats
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: taskQueue
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: taskQueueType
+          in: path
+          required: true
+          schema:
+            enum:
+              - TASK_QUEUE_TYPE_UNSPECIFIED
+              - TASK_QUEUE_TYPE_WORKFLOW
+              - TASK_QUEUE_TYPE_ACTIVITY
+              - TASK_QUEUE_TYPE_NEXUS
+            type: string
+            format: enum
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetTaskQueueStatsResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
   /namespaces/{namespace}/task-queues/{taskQueue}/worker-build-id-compatibility:
     get:
       tags:
@@ -4722,68 +4741,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DescribeTaskQueueResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/task-queues/{task_queue.name}/type/{taskQueueType}/get-stats:
-    post:
-      tags:
-        - WorkflowService
-      description: GetTaskQueueStats returns stats for a single task queue.
-      operationId: GetTaskQueueStats
-      parameters:
-        - name: namespace
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: task_queue.name
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: taskQueueType
-          in: path
-          required: true
-          schema:
-            enum:
-              - TASK_QUEUE_TYPE_UNSPECIFIED
-              - TASK_QUEUE_TYPE_WORKFLOW
-              - TASK_QUEUE_TYPE_ACTIVITY
-              - TASK_QUEUE_TYPE_NEXUS
-            type: string
-            format: enum
-        - name: taskQueue.name
-          in: query
-          schema:
-            type: string
-        - name: taskQueue.kind
-          in: query
-          description: 'Default: TASK_QUEUE_KIND_NORMAL.'
-          schema:
-            enum:
-              - TASK_QUEUE_KIND_UNSPECIFIED
-              - TASK_QUEUE_KIND_NORMAL
-              - TASK_QUEUE_KIND_STICKY
-            type: string
-            format: enum
-        - name: taskQueue.normalName
-          in: query
-          description: |-
-            Iff kind == TASK_QUEUE_KIND_STICKY, then this field contains the name of
-             the normal task queue that the sticky worker is running on.
-          schema:
-            type: string
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetTaskQueueStatsResponse'
         default:
           description: Default error response
           content:
@@ -5095,7 +5052,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/worker-deployments/{deploymentName}/{deploymentVersion}/stats:
+  /namespaces/{namespace}/worker-deployments/{deploymentName}/stats:
     get:
       tags:
         - WorkflowService
@@ -5116,12 +5073,11 @@ paths:
           required: true
           schema:
             type: string
-        - name: deploymentVersion
-          in: path
+        - name: buildId
+          in: query
           description: |-
-            Optional. Deployment version to return stats for.
-             If left empty, the current version will be queried.
-          required: true
+            Optional. Build ID to return stats for.
+             If left empty, the deployment's current one will be queried.
           schema:
             type: string
       responses:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -1504,6 +1504,68 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/task-queues/{task_queue.name}/type/{taskQueueType}/get-stats:
+    post:
+      tags:
+        - WorkflowService
+      description: GetTaskQueueStats returns stats for a single task queue.
+      operationId: GetTaskQueueStats
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: task_queue.name
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: taskQueueType
+          in: path
+          required: true
+          schema:
+            enum:
+              - TASK_QUEUE_TYPE_UNSPECIFIED
+              - TASK_QUEUE_TYPE_WORKFLOW
+              - TASK_QUEUE_TYPE_ACTIVITY
+              - TASK_QUEUE_TYPE_NEXUS
+            type: string
+            format: enum
+        - name: taskQueue.name
+          in: query
+          schema:
+            type: string
+        - name: taskQueue.kind
+          in: query
+          description: 'Default: TASK_QUEUE_KIND_NORMAL.'
+          schema:
+            enum:
+              - TASK_QUEUE_KIND_UNSPECIFIED
+              - TASK_QUEUE_KIND_NORMAL
+              - TASK_QUEUE_KIND_STICKY
+            type: string
+            format: enum
+        - name: taskQueue.normalName
+          in: query
+          description: |-
+            Iff kind == TASK_QUEUE_KIND_STICKY, then this field contains the name of
+             the normal task queue that the sticky worker is running on.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetTaskQueueStatsResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
   /api/v1/namespaces/{namespace}/update:
     post:
       tags:
@@ -1836,6 +1898,48 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SetWorkerDeploymentRampingVersionResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}/{deploymentVersion}/stats:
+    get:
+      tags:
+        - WorkflowService
+      description: GetWorkerDeploymentStats returns the stats for all task queues in a deployment version.
+      operationId: GetWorkerDeploymentStats
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: deploymentName
+          in: path
+          description: |-
+            Name of the deployment to return stats for.
+
+             (-- api-linter: core::0122::name-suffix=disabled
+          required: true
+          schema:
+            type: string
+        - name: deploymentVersion
+          in: path
+          description: |-
+            Optional. Deployment version to return stats for.
+             If left empty, the current version will be queried.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetWorkerDeploymentStatsResponse'
         default:
           description: Default error response
           content:
@@ -4624,6 +4728,68 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/task-queues/{task_queue.name}/type/{taskQueueType}/get-stats:
+    post:
+      tags:
+        - WorkflowService
+      description: GetTaskQueueStats returns stats for a single task queue.
+      operationId: GetTaskQueueStats
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: task_queue.name
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: taskQueueType
+          in: path
+          required: true
+          schema:
+            enum:
+              - TASK_QUEUE_TYPE_UNSPECIFIED
+              - TASK_QUEUE_TYPE_WORKFLOW
+              - TASK_QUEUE_TYPE_ACTIVITY
+              - TASK_QUEUE_TYPE_NEXUS
+            type: string
+            format: enum
+        - name: taskQueue.name
+          in: query
+          schema:
+            type: string
+        - name: taskQueue.kind
+          in: query
+          description: 'Default: TASK_QUEUE_KIND_NORMAL.'
+          schema:
+            enum:
+              - TASK_QUEUE_KIND_UNSPECIFIED
+              - TASK_QUEUE_KIND_NORMAL
+              - TASK_QUEUE_KIND_STICKY
+            type: string
+            format: enum
+        - name: taskQueue.normalName
+          in: query
+          description: |-
+            Iff kind == TASK_QUEUE_KIND_STICKY, then this field contains the name of
+             the normal task queue that the sticky worker is running on.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetTaskQueueStatsResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
   /namespaces/{namespace}/worker-deployment-versions/{version}:
     get:
       tags:
@@ -4923,6 +5089,48 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SetWorkerDeploymentRampingVersionResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/worker-deployments/{deploymentName}/{deploymentVersion}/stats:
+    get:
+      tags:
+        - WorkflowService
+      description: GetWorkerDeploymentStats returns the stats for all task queues in a deployment version.
+      operationId: GetWorkerDeploymentStats
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: deploymentName
+          in: path
+          description: |-
+            Name of the deployment to return stats for.
+
+             (-- api-linter: core::0122::name-suffix=disabled
+          required: true
+          schema:
+            type: string
+        - name: deploymentVersion
+          in: path
+          description: |-
+            Optional. Deployment version to return stats for.
+             If left empty, the current version will be queried.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetWorkerDeploymentStatsResponse'
         default:
           description: Default error response
           content:
@@ -7600,6 +7808,11 @@ components:
             True if the server supports Nexus operations.
              This flag is dependent both on server version and for Nexus to be enabled via server configuration.
       description: System capability details.
+    GetTaskQueueStatsResponse:
+      type: object
+      properties:
+        taskQueueStats:
+          $ref: '#/components/schemas/TaskQueueStats'
     GetWorkerBuildIdCompatibilityResponse:
       type: object
       properties:
@@ -7614,6 +7827,21 @@ components:
 
              There may be fewer sets returned than exist, if the request chose to limit this response.
       description: '[cleanup-wv-pre-release]'
+    GetWorkerDeploymentStatsResponse:
+      type: object
+      properties:
+        perQueueMetrics:
+          type: array
+          items:
+            $ref: '#/components/schemas/TaskQueueStatsInfo'
+          description: |-
+            Collection of stats for all task queues in the requested deployment.
+             Note that the data is
+        approximateTotalBacklogCount:
+          type: string
+          description: |-
+            The sum of backlog counts across all task queues in the deployment.
+             Note that same as the task queue metrics, this value is
     GetWorkerTaskReachabilityResponse:
       type: object
       properties:
@@ -11220,6 +11448,21 @@ components:
 
          For workflow task queue type, this result is partial because tasks sent to sticky queues are not included. Read
          comments above each metric to understand the impact of sticky queue exclusion on that metric accuracy.
+    TaskQueueStatsInfo:
+      type: object
+      properties:
+        taskQueue:
+          $ref: '#/components/schemas/TaskQueue'
+        taskQueueType:
+          enum:
+            - TASK_QUEUE_TYPE_UNSPECIFIED
+            - TASK_QUEUE_TYPE_WORKFLOW
+            - TASK_QUEUE_TYPE_ACTIVITY
+            - TASK_QUEUE_TYPE_NEXUS
+          type: string
+          format: enum
+        taskQueueStats:
+          $ref: '#/components/schemas/TaskQueueStats'
     TaskQueueStatus:
       type: object
       properties:

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -336,3 +336,9 @@ message PollerScalingDecision {
   // all slots are already occupied.
   int32 poll_request_delta_suggestion = 1;
 }
+
+message TaskQueueStatsInfo {
+    temporal.api.taskqueue.v1.TaskQueue task_queue = 1;
+    temporal.api.enums.v1.TaskQueueType task_queue_type = 2;
+    temporal.api.taskqueue.v1.TaskQueueStats task_queue_stats = 3;
+}

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1085,6 +1085,16 @@ message DescribeTaskQueueResponse {
     temporal.api.taskqueue.v1.TaskQueueVersioningInfo versioning_info = 4;
 }
 
+message GetTaskQueueStatsRequest {
+    string namespace = 1;
+    temporal.api.taskqueue.v1.TaskQueue task_queue = 2;
+    temporal.api.enums.v1.TaskQueueType task_queue_type = 3;
+}
+
+message GetTaskQueueStatsResponse {
+    temporal.api.taskqueue.v1.TaskQueueStats task_queue_stats = 1;
+}
+
 message GetClusterInfoRequest {
 }
 
@@ -2205,6 +2215,29 @@ message GetDeploymentReachabilityResponse {
     // Reachability level might come from server cache. This timestamp specifies when the value
     // was actually calculated.
     google.protobuf.Timestamp last_update_time = 3;
+}
+
+message GetWorkerDeploymentStatsRequest {
+    string namespace = 1;
+
+    // Name of the deployment to return stats for.
+    //
+    // (-- api-linter: core::0122::name-suffix=disabled
+    string deployment_name = 2;
+
+    // Optional. Deployment version to return stats for.
+    // If left empty, the current version will be queried.
+    string deployment_version = 3;
+}
+
+message GetWorkerDeploymentStatsResponse {
+    // Collection of stats for all task queues in the requested deployment.
+    // Note that the data is
+    repeated temporal.api.taskqueue.v1.TaskQueueStatsInfo per_queue_metrics = 1;
+
+    // The sum of backlog counts across all task queues in the deployment.
+    // Note that same as the task queue metrics, this value is
+    int64 approximate_total_backlog_count = 2;
 }
 
 message CreateWorkflowRuleRequest {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1087,7 +1087,7 @@ message DescribeTaskQueueResponse {
 
 message GetTaskQueueStatsRequest {
     string namespace = 1;
-    temporal.api.taskqueue.v1.TaskQueue task_queue = 2;
+    string task_queue = 2;
     temporal.api.enums.v1.TaskQueueType task_queue_type = 3;
 }
 
@@ -2225,9 +2225,9 @@ message GetWorkerDeploymentStatsRequest {
     // (-- api-linter: core::0122::name-suffix=disabled
     string deployment_name = 2;
 
-    // Optional. Deployment version to return stats for.
-    // If left empty, the current version will be queried.
-    string deployment_version = 3;
+    // Optional. Build ID to return stats for.
+    // If left empty, the deployment's current one will be queried.
+    string build_id = 3;
 }
 
 message GetWorkerDeploymentStatsResponse {

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -585,9 +585,9 @@ service WorkflowService {
     // GetTaskQueueStats returns stats for a single task queue.
     rpc GetTaskQueueStats (GetTaskQueueStatsRequest) returns (GetTaskQueueStatsResponse) {
         option (google.api.http) = {
-            post: "/namespaces/{namespace}/task-queues/{task_queue.name}/type/{task_queue_type}/get-stats"
+            post: "/namespaces/{namespace}/task-queues/{task_queue}/type/{task_queue_type}/get-stats"
             additional_bindings {
-                post: "/api/v1/namespaces/{namespace}/task-queues/{task_queue.name}/type/{task_queue_type}/get-stats"
+                post: "/api/v1/namespaces/{namespace}/task-queues/{task_queue}/type/{task_queue_type}/get-stats"
             }
         };
     }
@@ -891,9 +891,9 @@ service WorkflowService {
     // GetWorkerDeploymentStats returns the stats for all task queues in a deployment version.
     rpc GetWorkerDeploymentStats (GetWorkerDeploymentStatsRequest) returns (GetWorkerDeploymentStatsResponse) {
         option (google.api.http) = {
-            get: "/namespaces/{namespace}/worker-deployments/{deployment_name}/{deployment_version}/stats"
+            get: "/namespaces/{namespace}/worker-deployments/{deployment_name}/stats"
             additional_bindings {
-                get: "/api/v1/namespaces/{namespace}/worker-deployments/{deployment_name}/{deployment_version}/stats"
+                get: "/api/v1/namespaces/{namespace}/worker-deployments/{deployment_name}/stats"
             }
         };
     }

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -582,6 +582,16 @@ service WorkflowService {
         };
     }
 
+    // GetTaskQueueStats returns stats for a single task queue.
+    rpc GetTaskQueueStats (GetTaskQueueStatsRequest) returns (GetTaskQueueStatsResponse) {
+        option (google.api.http) = {
+            post: "/namespaces/{namespace}/task-queues/{task_queue.name}/type/{task_queue_type}/get-stats"
+            additional_bindings {
+                post: "/api/v1/namespaces/{namespace}/task-queues/{task_queue.name}/type/{task_queue_type}/get-stats"
+            }
+        };
+    }
+
     // GetClusterInfo returns information about temporal cluster
     rpc GetClusterInfo(GetClusterInfoRequest) returns (GetClusterInfoResponse) {
         option (google.api.http) = {
@@ -878,6 +888,16 @@ service WorkflowService {
         };
     }
 
+    // GetWorkerDeploymentStats returns the stats for all task queues in a deployment version.
+    rpc GetWorkerDeploymentStats (GetWorkerDeploymentStatsRequest) returns (GetWorkerDeploymentStatsResponse) {
+        option (google.api.http) = {
+            get: "/namespaces/{namespace}/worker-deployments/{deployment_name}/{deployment_version}/stats"
+            additional_bindings {
+                get: "/api/v1/namespaces/{namespace}/worker-deployments/{deployment_name}/{deployment_version}/stats"
+            }
+        };
+    }
+
     // Deletes records of (an old) Deployment. A deployment can only be deleted if
     // it has no Version in it.
     // Experimental. This API might significantly change or be removed in a future release.
@@ -889,7 +909,6 @@ service WorkflowService {
             }
         };
     }
-
 
     // Used for manual deletion of Versions. User can delete a Version only when all the
     // following conditions are met:
@@ -1194,5 +1213,4 @@ service WorkflowService {
             }
         };
     }
-
 }


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**

Added two new APIs:

* `GetWorkerDeploymentStats`
* `GetTaskQueueStats`

<!-- Tell your future self why have you made these changes -->
**Why?**

To return task queue stats to users for making scaling decisions.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**

No.

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**

https://github.com/temporalio/temporal/pull/7581 _(feature complete, but not yet production-ready)_