### PR TITLE
Add ScheduledEventID to NexusOperationCancelRequest[Completed|Failed]

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -11189,6 +11189,11 @@
           "type": "string",
           "format": "int64",
           "description": "The `WORKFLOW_TASK_COMPLETED` event that the corresponding RequestCancelNexusOperation command was reported\nwith."
+        },
+        "scheduledEventId": {
+          "type": "string",
+          "format": "int64",
+          "description": "The id of the `NEXUS_OPERATION_SCHEDULED` event this cancel request corresponds to."
         }
       }
     },
@@ -11208,6 +11213,11 @@
         "failure": {
           "$ref": "#/definitions/apifailurev1Failure",
           "description": "Failure details. A NexusOperationFailureInfo wrapping a CanceledFailureInfo."
+        },
+        "scheduledEventId": {
+          "type": "string",
+          "format": "int64",
+          "description": "The id of the `NEXUS_OPERATION_SCHEDULED` event this cancel request corresponds to."
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -8397,6 +8397,9 @@ components:
           description: |-
             The `WORKFLOW_TASK_COMPLETED` event that the corresponding RequestCancelNexusOperation command was reported
              with.
+        scheduledEventId:
+          type: string
+          description: The id of the `NEXUS_OPERATION_SCHEDULED` event this cancel request corresponds to.
     NexusOperationCancelRequestFailedEventAttributes:
       type: object
       properties:
@@ -8412,6 +8415,9 @@ components:
           allOf:
             - $ref: '#/components/schemas/Failure'
           description: Failure details. A NexusOperationFailureInfo wrapping a CanceledFailureInfo.
+        scheduledEventId:
+          type: string
+          description: The id of the `NEXUS_OPERATION_SCHEDULED` event this cancel request corresponds to.
     NexusOperationCancelRequestedEventAttributes:
       type: object
       properties:

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -960,6 +960,8 @@ message NexusOperationCancelRequestCompletedEventAttributes {
     // The `WORKFLOW_TASK_COMPLETED` event that the corresponding RequestCancelNexusOperation command was reported
     // with.
     int64 workflow_task_completed_event_id = 2;
+    // The id of the `NEXUS_OPERATION_SCHEDULED` event this cancel request corresponds to.
+    int64 scheduled_event_id = 3;
 }
 
 message NexusOperationCancelRequestFailedEventAttributes {
@@ -970,6 +972,8 @@ message NexusOperationCancelRequestFailedEventAttributes {
     int64 workflow_task_completed_event_id = 2;
     // Failure details. A NexusOperationFailureInfo wrapping a CanceledFailureInfo.
     temporal.api.failure.v1.Failure failure = 3;
+    // The id of the `NEXUS_OPERATION_SCHEDULED` event this cancel request corresponds to.
+    int64 scheduled_event_id = 4;
 }
 
 // History events are the method by which Temporal SDKs advance (or recreate) workflow state.


### PR DESCRIPTION
**What changed?**
Added ScheduledEventID of the Nexus operation to the new NexusOperationCancelRequestCompleted and NexusOperationCancelRequestFailed events

**Why?**
For efficient lookups. Go SDK stores cancellation state machines keyed on scheduled event ID.

**Server PR**
https://github.com/temporalio/temporal/pull/7612