### PR TITLE
Add indentity/description to the rule, propagate then in PauseInfo

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -13,6 +13,8 @@ breaking:
     - WIRE_JSON
   ignore:
     - google
+    # TODO (yuri) remove this
+    - temporal/api/workflow/v1/message.proto
 lint:
   use:
     - DEFAULT

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -6801,10 +6801,6 @@
           "$ref": "#/definitions/PauseInfoManual",
           "title": "activity was paused by the manual intervention"
         },
-        "ruleId": {
-          "type": "string",
-          "title": "Id of the rule that paused the activity.\nDeprecated, replaced by Rule"
-        },
         "rule": {
           "$ref": "#/definitions/PauseInfoRule",
           "title": "activity was paused by the rule"

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -6772,6 +6772,23 @@
         }
       }
     },
+    "PauseInfoRule": {
+      "type": "object",
+      "properties": {
+        "ruleId": {
+          "type": "string",
+          "description": "The rule that paused the activity."
+        },
+        "identity": {
+          "type": "string",
+          "description": "The identity of the actor that created the rule."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Reason why rule was created. Populated from rule description."
+        }
+      }
+    },
     "PendingActivityInfoPauseInfo": {
       "type": "object",
       "properties": {
@@ -6786,7 +6803,11 @@
         },
         "ruleId": {
           "type": "string",
-          "description": "Id of the rule that paused the activity."
+          "title": "Id of the rule that paused the activity.\nDeprecated, replaced by Rule"
+        },
+        "rule": {
+          "$ref": "#/definitions/PauseInfoRule",
+          "title": "activity was paused by the rule"
         }
       }
     },
@@ -7046,6 +7067,14 @@
         "requestId": {
           "type": "string",
           "description": "Used to de-dupe requests. Typically should be UUID."
+        },
+        "identity": {
+          "type": "string",
+          "description": "Identity of the actor who created the rule. Will be stored with the rule."
+        },
+        "description": {
+          "type": "string",
+          "description": "Rule description.Will be stored with the rule."
         }
       }
     },
@@ -15493,6 +15522,14 @@
         "spec": {
           "$ref": "#/definitions/v1WorkflowRuleSpec",
           "title": "Rule specification"
+        },
+        "identity": {
+          "type": "string",
+          "title": "Indentity of the actor that created the rule"
+        },
+        "description": {
+          "type": "string",
+          "description": "Rule description."
         }
       },
       "description": "WorkflowRule describes a rule that can be applied to any workflow in this namespace."

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -15525,7 +15525,7 @@
         },
         "identity": {
           "type": "string",
-          "title": "Indentity of the actor that created the rule"
+          "title": "Identity of the actor that created the rule"
         },
         "description": {
           "type": "string",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -15519,7 +15519,7 @@
           "$ref": "#/definitions/v1WorkflowRuleSpec",
           "title": "Rule specification"
         },
-        "identity": {
+        "createdBy": {
           "type": "string",
           "title": "Identity of the actor that created the rule"
         },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -15519,7 +15519,7 @@
           "$ref": "#/definitions/v1WorkflowRuleSpec",
           "title": "Rule specification"
         },
-        "createdBy": {
+        "createdByIdentity": {
           "type": "string",
           "title": "Identity of the actor that created the rule"
         },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -13027,7 +13027,7 @@ components:
           description: Rule specification
         identity:
           type: string
-          description: Indentity of the actor that created the rule
+          description: Identity of the actor that created the rule
         description:
           type: string
           description: Rule description.

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -13020,9 +13020,14 @@ components:
           allOf:
             - $ref: '#/components/schemas/WorkflowRuleSpec'
           description: Rule specification
-        identity:
+        createdBy:
           type: string
-          description: Identity of the actor that created the rule
+          description: |-
+            Identity of the actor that created the rule
+             (-- api-linter: core::0140::prepositions=disabled
+                 aip.dev/not-precedent: It is better reflect the intent this way, we will also have updated_by. --)
+             (-- api-linter: core::0142::time-field-names=disabled
+                 aip.dev/not-precedent: Same as above. All other options sounds clumsy --)
         description:
           type: string
           description: Rule description.

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -6914,6 +6914,12 @@ components:
         requestId:
           type: string
           description: Used to de-dupe requests. Typically should be UUID.
+        identity:
+          type: string
+          description: Identity of the actor who created the rule. Will be stored with the rule.
+        description:
+          type: string
+          description: Rule description.Will be stored with the rule.
     CreateWorkflowRuleResponse:
       type: object
       properties:
@@ -8715,6 +8721,18 @@ components:
         reason:
           type: string
           description: Reason for pausing the activity.
+    PauseInfo_Rule:
+      type: object
+      properties:
+        ruleId:
+          type: string
+          description: The rule that paused the activity.
+        identity:
+          type: string
+          description: The identity of the actor that created the rule.
+        reason:
+          type: string
+          description: Reason why rule was created. Populated from rule description.
     Payload:
       description: |-
         Represents some binary (byte array) data (ex: activity input parameters or workflow result) with
@@ -8832,7 +8850,13 @@ components:
           description: activity was paused by the manual intervention
         ruleId:
           type: string
-          description: Id of the rule that paused the activity.
+          description: |-
+            Id of the rule that paused the activity.
+             Deprecated, replaced by Rule
+        rule:
+          allOf:
+            - $ref: '#/components/schemas/PauseInfo_Rule'
+          description: activity was paused by the rule
     PendingChildExecutionInfo:
       type: object
       properties:
@@ -13001,6 +13025,12 @@ components:
           allOf:
             - $ref: '#/components/schemas/WorkflowRuleSpec'
           description: Rule specification
+        identity:
+          type: string
+          description: Indentity of the actor that created the rule
+        description:
+          type: string
+          description: Rule description.
       description: WorkflowRule describes a rule that can be applied to any workflow in this namespace.
     WorkflowRuleAction:
       type: object

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -13020,7 +13020,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/WorkflowRuleSpec'
           description: Rule specification
-        createdBy:
+        createdByIdentity:
           type: string
           description: |-
             Identity of the actor that created the rule

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -8848,11 +8848,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/PauseInfo_Manual'
           description: activity was paused by the manual intervention
-        ruleId:
-          type: string
-          description: |-
-            Id of the rule that paused the activity.
-             Deprecated, replaced by Rule
         rule:
           allOf:
             - $ref: '#/components/schemas/PauseInfo_Rule'

--- a/temporal/api/rules/v1/message.proto
+++ b/temporal/api/rules/v1/message.proto
@@ -105,7 +105,7 @@ message WorkflowRule {
   //     aip.dev/not-precedent: It is better reflect the intent this way, we will also have updated_by. --)
   // (-- api-linter: core::0142::time-field-names=disabled
   //     aip.dev/not-precedent: Same as above. All other options sounds clumsy --)
-  string created_by = 3;
+  string created_by_identity = 3;
 
   // Rule description.
   string description = 4;

--- a/temporal/api/rules/v1/message.proto
+++ b/temporal/api/rules/v1/message.proto
@@ -100,7 +100,7 @@ message WorkflowRule {
   // Rule specification
   WorkflowRuleSpec spec = 2;
 
-  // Indentity of the actor that created the rule
+  // Identity of the actor that created the rule
   string identity = 3;
 
   // Rule description.

--- a/temporal/api/rules/v1/message.proto
+++ b/temporal/api/rules/v1/message.proto
@@ -99,4 +99,10 @@ message WorkflowRule {
 
   // Rule specification
   WorkflowRuleSpec spec = 2;
+
+  // Indentity of the actor that created the rule
+  string identity = 3;
+
+  // Rule description.
+  string description = 4;
 }

--- a/temporal/api/rules/v1/message.proto
+++ b/temporal/api/rules/v1/message.proto
@@ -101,7 +101,11 @@ message WorkflowRule {
   WorkflowRuleSpec spec = 2;
 
   // Identity of the actor that created the rule
-  string identity = 3;
+  // (-- api-linter: core::0140::prepositions=disabled
+  //     aip.dev/not-precedent: It is better reflect the intent this way, we will also have updated_by. --)
+  // (-- api-linter: core::0142::time-field-names=disabled
+  //     aip.dev/not-precedent: Same as above. All other options sounds clumsy --)
+  string created_by = 3;
 
   // Rule description.
   string description = 4;

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -336,9 +336,6 @@ message PendingActivityInfo {
             // activity was paused by the manual intervention
             Manual manual = 2;
 
-            // Id of the rule that paused the activity.
-            // Deprecated, replaced by Rule
-            string rule_id = 3;
 
             // activity was paused by the rule
             Rule rule = 4;

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -322,12 +322,26 @@ message PendingActivityInfo {
             // Reason for pausing the activity.
             string reason = 2;
         }
+
+        message Rule {
+            // The rule that paused the activity.
+            string rule_id = 1;
+            // The identity of the actor that created the rule.
+            string identity = 2;
+            // Reason why rule was created. Populated from rule description.
+            string reason = 3;
+        }
+
         oneof paused_by {
             // activity was paused by the manual intervention
             Manual manual = 2;
 
             // Id of the rule that paused the activity.
+            // Deprecated, replaced by Rule
             string rule_id = 3;
+
+            // activity was paused by the rule
+            Rule rule = 4;
         }
     }
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2220,6 +2220,12 @@ message CreateWorkflowRuleRequest {
 
     // Used to de-dupe requests. Typically should be UUID.
     string request_id = 4;
+
+    // Identity of the actor who created the rule. Will be stored with the rule.
+    string identity = 5;
+
+    // Rule description.Will be stored with the rule.
+    string description = 6;
 }
 
 message CreateWorkflowRuleResponse {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
1. Add identity/description to the rules.
2. Add new message with "rule_id, identity, reason" to the PauseInfo


<!-- Tell your future self why have you made these changes -->
**Why?**
Product request - identity/reason should be always populated, for both manual/rule.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
Not really. But old "rule_id" in oneof is effectively deprecated.