### PR TITLE
Add reset info to the activity heartbeat response

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -12220,10 +12220,6 @@
         "activityReset": {
           "type": "boolean",
           "description": "Will be set to true if the activity was reset.\nApplies only to the current run."
-        },
-        "heartbeatReset": {
-          "type": "boolean",
-          "description": "Will be set to true if the activity heartbeat was reset."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -12203,6 +12203,10 @@
         "activityPaused": {
           "type": "boolean",
           "description": "Will be set to true if the activity is paused."
+        },
+        "activityReset": {
+          "type": "boolean",
+          "description": "Will be set to true if the activity was reset.\nApplies only to the current run."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -12219,7 +12219,7 @@
         },
         "activityReset": {
           "type": "boolean",
-          "description": "Will be set to true if the activity was reset.\nApplyes only to the current run."
+          "description": "Will be set to true if the activity was reset.\nApplies only to the current run."
         },
         "heartbeatReset": {
           "type": "boolean",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -12216,6 +12216,14 @@
         "activityPaused": {
           "type": "boolean",
           "description": "Will be set to true if the activity is paused."
+        },
+        "activityReset": {
+          "type": "boolean",
+          "description": "Will be set to true if the activity was reset.\nApplyes only to the current run."
+        },
+        "heartbeatReset": {
+          "type": "boolean",
+          "description": "Will be set to true if the activity heartbeat was reset."
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9254,6 +9254,11 @@ components:
         activityPaused:
           type: boolean
           description: Will be set to true if the activity is paused.
+        activityReset:
+          type: boolean
+          description: |-
+            Will be set to true if the activity was reset.
+             Applies only to the current run.
     RecordActivityTaskHeartbeatRequest:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9286,9 +9286,6 @@ components:
           description: |-
             Will be set to true if the activity was reset.
              Applies only to the current run.
-        heartbeatReset:
-          type: boolean
-          description: Will be set to true if the activity heartbeat was reset.
     RegisterNamespaceRequest:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9285,7 +9285,7 @@ components:
           type: boolean
           description: |-
             Will be set to true if the activity was reset.
-             Applyes only to the current run.
+             Applies only to the current run.
         heartbeatReset:
           type: boolean
           description: Will be set to true if the activity heartbeat was reset.

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9281,6 +9281,14 @@ components:
         activityPaused:
           type: boolean
           description: Will be set to true if the activity is paused.
+        activityReset:
+          type: boolean
+          description: |-
+            Will be set to true if the activity was reset.
+             Applyes only to the current run.
+        heartbeatReset:
+          type: boolean
+          description: Will be set to true if the activity heartbeat was reset.
     RegisterNamespaceRequest:
       type: object
       properties:

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -557,6 +557,10 @@ message RecordActivityTaskHeartbeatByIdResponse {
 
     // Will be set to true if the activity is paused.
     bool activity_paused = 2;
+
+    // Will be set to true if the activity was reset.
+    // Applies only to the current run.
+    bool activity_reset = 3;
 }
 
 message RespondActivityTaskCompletedRequest {
@@ -1844,13 +1848,13 @@ message UpdateActivityOptionsRequest {
     // Controls which fields from `activity_options` will be applied
     google.protobuf.FieldMask update_mask = 5;
 
-    // either activity id or activity type must be provided
-    oneof activity {
-        // Only activity with this ID will be updated.
-        string id = 6;
-        // Update all running activities of this type.
-        string type = 7;
-    }
+        // either activity id or activity type must be provided
+        oneof activity {
+            // Only activity with this ID will be updated.
+            string id = 6;
+            // Update all running activities of this type.
+            string type = 7;
+        }
 }
 
 message UpdateActivityOptionsResponse {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -529,6 +529,13 @@ message RecordActivityTaskHeartbeatResponse {
 
     // Will be set to true if the activity is paused.
     bool activity_paused = 2;
+
+    // Will be set to true if the activity was reset.
+    // Applyes only to the current run.
+    bool activity_reset = 3;
+
+    // Will be set to true if the activity heartbeat was reset.
+    bool heartbeat_reset = 4;
 }
 
 message RecordActivityTaskHeartbeatByIdRequest {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -531,7 +531,7 @@ message RecordActivityTaskHeartbeatResponse {
     bool activity_paused = 2;
 
     // Will be set to true if the activity was reset.
-    // Applyes only to the current run.
+    // Applies only to the current run.
     bool activity_reset = 3;
 
     // Will be set to true if the activity heartbeat was reset.

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -533,9 +533,6 @@ message RecordActivityTaskHeartbeatResponse {
     // Will be set to true if the activity was reset.
     // Applies only to the current run.
     bool activity_reset = 3;
-
-    // Will be set to true if the activity heartbeat was reset.
-    bool heartbeat_reset = 4;
 }
 
 message RecordActivityTaskHeartbeatByIdRequest {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add two new flags to activity heartbeat response:
* reset_requested // indicates that reset happen while activity is still running
* reset_heartbeat //indicates that user asked to also reset heartbeats

<!-- Tell your future self why have you made these changes -->
**Why?**
Product request.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
No

Corresponding Server PR: https://github.com/temporalio/temporal/pull/7677