### PR TITLE
Add `status` to StartWorkflowExecutionResponse

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -13785,7 +13785,7 @@
         },
         "status": {
           "$ref": "#/definitions/v1WorkflowExecutionStatus",
-          "description": "Status of the workflow. Note that it will be WORKFLOW_EXECUTION_STATUS_RUNNING unless used within an\n`ExecuteMultiOperation` (see more details there)."
+          "description": "Current execution status of the workflow. Typically remains WORKFLOW_EXECUTION_STATUS_RUNNING\nunless a de-dupe occurs or in specific scenarios handled within the ExecuteMultiOperation (refer to its docs)."
         },
         "eagerWorkflowTask": {
           "$ref": "#/definitions/v1PollWorkflowTaskQueueResponse",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -10084,7 +10084,7 @@
           }
         }
       },
-      "description": "IMPORTANT: For [StartWorkflow, UpdateWorkflow] combination (\"Update-with-Start\") when both\n  1. the workflow update for the requested update ID has already completed, and\n  2. the workflow for the requested workflow ID has already been closed,\nthen you'll receive\n  - a successful update response containing the update's outcome, and\n  - a start response with a `status` field that reflects the workflow's current state."
+      "description": "IMPORTANT: For [StartWorkflow, UpdateWorkflow] combination (\"Update-with-Start\") when both\n  1. the workflow update for the requested update ID has already completed, and\n  2. the workflow for the requested workflow ID has already been closed,\nthen you'll receive\n  - an update response containing the update's outcome, and\n  - a start response with a `status` field that reflects the workflow's current state."
     },
     "v1ExecuteMultiOperationResponseResponse": {
       "type": "object",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -10089,7 +10089,8 @@
       "type": "object",
       "properties": {
         "startWorkflow": {
-          "$ref": "#/definitions/v1StartWorkflowExecutionResponse"
+          "$ref": "#/definitions/v1StartWorkflowExecutionResponse",
+          "description": "Note that for the combination [StartWorkflow, UpdateWorkflow], aka Update-with-Start, when the Update's\noutcome for the requested Update ID is available but the workflow has already been closed, the\nStartWorkflowExecutionResponse will set `running` to `false`."
         },
         "updateWorkflow": {
           "$ref": "#/definitions/v1UpdateWorkflowExecutionResponse"
@@ -13781,6 +13782,10 @@
         "started": {
           "type": "boolean",
           "description": "If true, a new workflow was started."
+        },
+        "running": {
+          "type": "boolean",
+          "description": "If true, the workflow is running."
         },
         "eagerWorkflowTask": {
           "$ref": "#/definitions/v1PollWorkflowTaskQueueResponse",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -10083,14 +10083,14 @@
             "$ref": "#/definitions/v1ExecuteMultiOperationResponseResponse"
           }
         }
-      }
+      },
+      "description": "IMPORTANT: For [StartWorkflow, UpdateWorkflow] combination (\"Update-with-Start\") when both\n  1. the workflow update for the requested update ID has already completed, and\n  2. the workflow for the requested workflow ID has already been closed,\nthen you'll receive\n  - a successful update response containing the update's outcome, and\n  - a start response with a `status` field that reflects the workflow's current state."
     },
     "v1ExecuteMultiOperationResponseResponse": {
       "type": "object",
       "properties": {
         "startWorkflow": {
-          "$ref": "#/definitions/v1StartWorkflowExecutionResponse",
-          "description": "Note that for the combination [StartWorkflow, UpdateWorkflow], aka Update-with-Start, when the Update's\noutcome for the requested Update ID is available but the workflow has already been closed, the\nStartWorkflowExecutionResponse will set `running` to `false`."
+          "$ref": "#/definitions/v1StartWorkflowExecutionResponse"
         },
         "updateWorkflow": {
           "$ref": "#/definitions/v1UpdateWorkflowExecutionResponse"
@@ -13783,9 +13783,9 @@
           "type": "boolean",
           "description": "If true, a new workflow was started."
         },
-        "running": {
-          "type": "boolean",
-          "description": "If true, the workflow is running."
+        "status": {
+          "$ref": "#/definitions/v1WorkflowExecutionStatus",
+          "description": "Status of the workflow. Note that it will be WORKFLOW_EXECUTION_STATUS_RUNNING unless used within an\n`ExecuteMultiOperation` (see more details there)."
         },
         "eagerWorkflowTask": {
           "$ref": "#/definitions/v1PollWorkflowTaskQueueResponse",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -7385,7 +7385,7 @@ components:
            1. the workflow update for the requested update ID has already completed, and
            2. the workflow for the requested workflow ID has already been closed,
          then you'll receive
-           - a successful update response containing the update's outcome, and
+           - an update response containing the update's outcome, and
            - a start response with a `status` field that reflects the workflow's current state.
     ExecuteMultiOperationResponse_Response:
       type: object

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -7384,7 +7384,12 @@ components:
       type: object
       properties:
         startWorkflow:
-          $ref: '#/components/schemas/StartWorkflowExecutionResponse'
+          allOf:
+            - $ref: '#/components/schemas/StartWorkflowExecutionResponse'
+          description: |-
+            Note that for the combination [StartWorkflow, UpdateWorkflow], aka Update-with-Start, when the Update's
+             outcome for the requested Update ID is available but the workflow has already been closed, the
+             StartWorkflowExecutionResponse will set `running` to `false`.
         updateWorkflow:
           $ref: '#/components/schemas/UpdateWorkflowExecutionResponse'
     ExternalWorkflowExecutionCancelRequestedEventAttributes:
@@ -11011,6 +11016,9 @@ components:
         started:
           type: boolean
           description: If true, a new workflow was started.
+        running:
+          type: boolean
+          description: If true, the workflow is running.
         eagerWorkflowTask:
           allOf:
             - $ref: '#/components/schemas/PollWorkflowTaskQueueResponse'

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -7380,16 +7380,18 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ExecuteMultiOperationResponse_Response'
+      description: |-
+        IMPORTANT: For [StartWorkflow, UpdateWorkflow] combination ("Update-with-Start") when both
+           1. the workflow update for the requested update ID has already completed, and
+           2. the workflow for the requested workflow ID has already been closed,
+         then you'll receive
+           - a successful update response containing the update's outcome, and
+           - a start response with a `status` field that reflects the workflow's current state.
     ExecuteMultiOperationResponse_Response:
       type: object
       properties:
         startWorkflow:
-          allOf:
-            - $ref: '#/components/schemas/StartWorkflowExecutionResponse'
-          description: |-
-            Note that for the combination [StartWorkflow, UpdateWorkflow], aka Update-with-Start, when the Update's
-             outcome for the requested Update ID is available but the workflow has already been closed, the
-             StartWorkflowExecutionResponse will set `running` to `false`.
+          $ref: '#/components/schemas/StartWorkflowExecutionResponse'
         updateWorkflow:
           $ref: '#/components/schemas/UpdateWorkflowExecutionResponse'
     ExternalWorkflowExecutionCancelRequestedEventAttributes:
@@ -11016,9 +11018,21 @@ components:
         started:
           type: boolean
           description: If true, a new workflow was started.
-        running:
-          type: boolean
-          description: If true, the workflow is running.
+        status:
+          enum:
+            - WORKFLOW_EXECUTION_STATUS_UNSPECIFIED
+            - WORKFLOW_EXECUTION_STATUS_RUNNING
+            - WORKFLOW_EXECUTION_STATUS_COMPLETED
+            - WORKFLOW_EXECUTION_STATUS_FAILED
+            - WORKFLOW_EXECUTION_STATUS_CANCELED
+            - WORKFLOW_EXECUTION_STATUS_TERMINATED
+            - WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW
+            - WORKFLOW_EXECUTION_STATUS_TIMED_OUT
+          type: string
+          description: |-
+            Status of the workflow. Note that it will be WORKFLOW_EXECUTION_STATUS_RUNNING unless used within an
+             `ExecuteMultiOperation` (see more details there).
+          format: enum
         eagerWorkflowTask:
           allOf:
             - $ref: '#/components/schemas/PollWorkflowTaskQueueResponse'

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -11030,8 +11030,8 @@ components:
             - WORKFLOW_EXECUTION_STATUS_TIMED_OUT
           type: string
           description: |-
-            Status of the workflow. Note that it will be WORKFLOW_EXECUTION_STATUS_RUNNING unless used within an
-             `ExecuteMultiOperation` (see more details there).
+            Current execution status of the workflow. Typically remains WORKFLOW_EXECUTION_STATUS_RUNNING
+             unless a de-dupe occurs or in specific scenarios handled within the ExecuteMultiOperation (refer to its docs).
           format: enum
         eagerWorkflowTask:
           allOf:

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -221,6 +221,8 @@ message StartWorkflowExecutionResponse {
     string run_id = 1;
     // If true, a new workflow was started.
     bool started = 3;
+    // If true, the workflow is running.
+    bool running = 5;
     // When `request_eager_execution` is set on the `StartWorkflowExecutionRequest`, the server - if supported - will
     // return the first workflow task to be eagerly executed.
     // The caller is expected to have a worker available to process the task.
@@ -1810,6 +1812,9 @@ message ExecuteMultiOperationResponse {
 
     message Response {
         oneof response {
+            // Note that for the combination [StartWorkflow, UpdateWorkflow], aka Update-with-Start, when the Update's
+            // outcome for the requested Update ID is available but the workflow has already been closed, the
+            // StartWorkflowExecutionResponse will set `running` to `false`.
             StartWorkflowExecutionResponse start_workflow = 1;
             UpdateWorkflowExecutionResponse update_workflow = 2;
         }

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -221,8 +221,9 @@ message StartWorkflowExecutionResponse {
     string run_id = 1;
     // If true, a new workflow was started.
     bool started = 3;
-    // If true, the workflow is running.
-    bool running = 5;
+    // Status of the workflow. Note that it will be WORKFLOW_EXECUTION_STATUS_RUNNING unless used within an
+    // `ExecuteMultiOperation` (see more details there).
+    temporal.api.enums.v1.WorkflowExecutionStatus status = 5;
     // When `request_eager_execution` is set on the `StartWorkflowExecutionRequest`, the server - if supported - will
     // return the first workflow task to be eagerly executed.
     // The caller is expected to have a worker available to process the task.
@@ -1807,14 +1808,17 @@ message ExecuteMultiOperationRequest {
     }
 }
 
+// IMPORTANT: For [StartWorkflow, UpdateWorkflow] combination ("Update-with-Start") when both
+//   1. the workflow update for the requested update ID has already completed, and
+//   2. the workflow for the requested workflow ID has already been closed,
+// then you'll receive
+//   - a successful update response containing the update's outcome, and
+//   - a start response with a `status` field that reflects the workflow's current state.
 message ExecuteMultiOperationResponse {
     repeated Response responses = 1;
 
     message Response {
         oneof response {
-            // Note that for the combination [StartWorkflow, UpdateWorkflow], aka Update-with-Start, when the Update's
-            // outcome for the requested Update ID is available but the workflow has already been closed, the
-            // StartWorkflowExecutionResponse will set `running` to `false`.
             StartWorkflowExecutionResponse start_workflow = 1;
             UpdateWorkflowExecutionResponse update_workflow = 2;
         }

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1812,7 +1812,7 @@ message ExecuteMultiOperationRequest {
 //   1. the workflow update for the requested update ID has already completed, and
 //   2. the workflow for the requested workflow ID has already been closed,
 // then you'll receive
-//   - a successful update response containing the update's outcome, and
+//   - an update response containing the update's outcome, and
 //   - a start response with a `status` field that reflects the workflow's current state.
 message ExecuteMultiOperationResponse {
     repeated Response responses = 1;

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -221,8 +221,8 @@ message StartWorkflowExecutionResponse {
     string run_id = 1;
     // If true, a new workflow was started.
     bool started = 3;
-    // Status of the workflow. Note that it will be WORKFLOW_EXECUTION_STATUS_RUNNING unless used within an
-    // `ExecuteMultiOperation` (see more details there).
+    // Current execution status of the workflow. Typically remains WORKFLOW_EXECUTION_STATUS_RUNNING
+    // unless a de-dupe occurs or in specific scenarios handled within the ExecuteMultiOperation (refer to its docs).
     temporal.api.enums.v1.WorkflowExecutionStatus status = 5;
     // When `request_eager_execution` is set on the `StartWorkflowExecutionRequest`, the server - if supported - will
     // return the first workflow task to be eagerly executed.


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**

Added field `WorkflowExecutionStatus status` to `StartWorkflowExecutionResponse`.

<!-- Tell your future self why have you made these changes -->
**Why?**

To align Update-with-Start's behavior with a regular Update. A regular Update returns its outcome from a closed Workflow, to make Update-with-Start do the same thing, it needs to returns a successful response in that case. But that would tell the user that a running Workflow exists. To help the user distinguish whether UwS operated on a closed or running workflow, this field is introduced.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**

No.

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**

https://github.com/temporalio/temporal/pull/7656