### PR TITLE
Add activity options to the pending activity info

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -11771,6 +11771,10 @@
         },
         "pauseInfo": {
           "$ref": "#/definitions/PendingActivityInfoPauseInfo"
+        },
+        "activityOptions": {
+          "$ref": "#/definitions/v1ActivityOptions",
+          "description": "current activity options. May be different from the one used to start the activity."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -11774,7 +11774,7 @@
         },
         "activityOptions": {
           "$ref": "#/definitions/v1ActivityOptions",
-          "description": "current activity options. May be different from the one used to start the activity."
+          "description": "Current activity options. May be different from the one used to start the activity."
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -8859,6 +8859,10 @@ components:
           description: Priority metadata
         pauseInfo:
           $ref: '#/components/schemas/PendingActivityInfo_PauseInfo'
+        activityOptions:
+          allOf:
+            - $ref: '#/components/schemas/ActivityOptions'
+          description: current activity options. May be different from the one used to start the activity.
     PendingActivityInfo_PauseInfo:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -8862,7 +8862,7 @@ components:
         activityOptions:
           allOf:
             - $ref: '#/components/schemas/ActivityOptions'
-          description: current activity options. May be different from the one used to start the activity.
+          description: Current activity options. May be different from the one used to start the activity.
     PendingActivityInfo_PauseInfo:
       type: object
       properties:

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -14,6 +14,7 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/field_mask.proto";
 
+import "temporal/api/activity/v1/message.proto";
 import "temporal/api/enums/v1/common.proto";
 import "temporal/api/enums/v1/event_type.proto";
 import "temporal/api/enums/v1/workflow.proto";
@@ -322,6 +323,9 @@ message PendingActivityInfo {
     }
 
     PauseInfo pause_info = 23;
+
+    // current activity options. May be different from the one used to start the activity.
+    temporal.api.activity.v1.ActivityOptions activity_options = 24;
 }
 
 message PendingChildExecutionInfo {

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -324,7 +324,7 @@ message PendingActivityInfo {
 
     PauseInfo pause_info = 23;
 
-    // current activity options. May be different from the one used to start the activity.
+    // Current activity options. May be different from the one used to start the activity.
     temporal.api.activity.v1.ActivityOptions activity_options = 24;
 }
 


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
Add activity options to the pending activity info

<!-- Tell your future self why have you made these changes -->
**Why?**
If activity options where changed - there is no "official" way to users to know what are the current options.
UI should display current options, so we will provide them as a part of DescribeWorfklow response. 
Thus we add activity options to the pending activity info, which will be a part of DescribeWorfklow response. 

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
No
