### PR TITLE
Add Stats to DescribeTaskQueue

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -1489,18 +1489,6 @@
             "type": "string"
           },
           {
-            "name": "apiMode",
-            "description": "Deprecated. ENHANCED mode is also being deprecated.\nSelect the API mode to use for this request: DEFAULT mode (if unset) or ENHANCED mode.\nConsult the documentation for each field to understand which mode it is supported in.\n\n - DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED: Unspecified means legacy behavior.\n - DESCRIBE_TASK_QUEUE_MODE_ENHANCED: Enhanced mode reports aggregated results for all partitions, supports Build IDs, and reports richer info.",
-            "in": "query",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED",
-              "DESCRIBE_TASK_QUEUE_MODE_ENHANCED"
-            ],
-            "default": "DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED"
-          },
-          {
             "name": "taskQueue.kind",
             "description": "Default: TASK_QUEUE_KIND_NORMAL.\n\n - TASK_QUEUE_KIND_NORMAL: Tasks from a normal workflow task queue always include complete workflow history\n\nThe task queue specified by the user is always a normal task queue. There can be as many\nworkers as desired for a single normal task queue. All those workers may pick up tasks from\nthat queue.\n - TASK_QUEUE_KIND_STICKY: A sticky queue only includes new history since the last workflow task, and they are\nper-worker.\n\nSticky queues are created dynamically by each worker during their start up. They only exist\nfor the lifetime of the worker process. Tasks in a sticky task queue are only available to\nthe worker that created the sticky queue.\n\nSticky queues are only for workflow tasks. There are no sticky task queues for activities.",
             "in": "query",
@@ -1522,7 +1510,7 @@
           },
           {
             "name": "taskQueueType",
-            "description": "[DEFAULT MODE ONLY]\nIf unspecified (TASK_QUEUE_TYPE_UNSPECIFIED), then default value (TASK_QUEUE_TYPE_WORKFLOW) will be used.\nOnly supported in default mode (use `task_queue_types` in ENHANCED mode instead).\n\n - TASK_QUEUE_TYPE_WORKFLOW: Workflow type of task queue.\n - TASK_QUEUE_TYPE_ACTIVITY: Activity type of task queue.\n - TASK_QUEUE_TYPE_NEXUS: Task queue type for dispatching Nexus requests.",
+            "description": "If unspecified (TASK_QUEUE_TYPE_UNSPECIFIED), then default value (TASK_QUEUE_TYPE_WORKFLOW) will be used.\nOnly supported in default mode (use `task_queue_types` in ENHANCED mode instead).\n\n - TASK_QUEUE_TYPE_WORKFLOW: Workflow type of task queue.\n - TASK_QUEUE_TYPE_ACTIVITY: Activity type of task queue.\n - TASK_QUEUE_TYPE_NEXUS: Task queue type for dispatching Nexus requests.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -1536,10 +1524,29 @@
           },
           {
             "name": "includeTaskQueueStatus",
-            "description": "[DEFAULT MODE ONLY]\nDeprecated, use `report_stats` instead.\nIf true, the task queue status will be included in the response.",
+            "description": "Deprecated, use `report_stats` instead.\nIf true, the task queue status will be included in the response.",
             "in": "query",
             "required": false,
             "type": "boolean"
+          },
+          {
+            "name": "reportStats",
+            "description": "Report stats for the requested task queue type(s).",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "apiMode",
+            "description": "Deprecated. ENHANCED mode is also being deprecated.\nSelect the API mode to use for this request: DEFAULT mode (if unset) or ENHANCED mode.\nConsult the documentation for each field to understand which mode it is supported in.\n\n - DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED: Unspecified means legacy behavior.\n - DESCRIBE_TASK_QUEUE_MODE_ENHANCED: Enhanced mode reports aggregated results for all partitions, supports Build IDs, and reports richer info.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED",
+              "DESCRIBE_TASK_QUEUE_MODE_ENHANCED"
+            ],
+            "default": "DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED"
           },
           {
             "name": "versions.buildIds",
@@ -1568,7 +1575,7 @@
           },
           {
             "name": "taskQueueTypes",
-            "description": "[ENHANCED MODE ONLY]\nTask queue types to report info about. If not specified, all types are considered.\n\n - TASK_QUEUE_TYPE_WORKFLOW: Workflow type of task queue.\n - TASK_QUEUE_TYPE_ACTIVITY: Activity type of task queue.\n - TASK_QUEUE_TYPE_NEXUS: Task queue type for dispatching Nexus requests.",
+            "description": "Deprecated (as part of the ENHANCED mode deprecation).\nTask queue types to report info about. If not specified, all types are considered.\n\n - TASK_QUEUE_TYPE_WORKFLOW: Workflow type of task queue.\n - TASK_QUEUE_TYPE_ACTIVITY: Activity type of task queue.\n - TASK_QUEUE_TYPE_NEXUS: Task queue type for dispatching Nexus requests.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -1584,22 +1591,15 @@
             "collectionFormat": "multi"
           },
           {
-            "name": "reportStats",
-            "description": "[BOTH MODES]\nReport stats for the requested task queue type(s), and versions (only in ENHANCED mode).",
-            "in": "query",
-            "required": false,
-            "type": "boolean"
-          },
-          {
             "name": "reportPollers",
-            "description": "[ENHANCED MODE ONLY]\nDeprecated.\nReport list of pollers for requested task queue types and versions.",
+            "description": "Deprecated (as part of the ENHANCED mode deprecation).\nReport list of pollers for requested task queue types and versions.",
             "in": "query",
             "required": false,
             "type": "boolean"
           },
           {
             "name": "reportTaskReachability",
-            "description": "[ENHANCED MODE ONLY]\nDeprecated.\nReport task reachability for the requested versions and all task types (task reachability is not reported\nper task type).",
+            "description": "Deprecated (as part of the ENHANCED mode deprecation).\nReport task reachability for the requested versions and all task types (task reachability is not reported\nper task type).",
             "in": "query",
             "required": false,
             "type": "boolean"
@@ -5037,18 +5037,6 @@
             "type": "string"
           },
           {
-            "name": "apiMode",
-            "description": "Deprecated. ENHANCED mode is also being deprecated.\nSelect the API mode to use for this request: DEFAULT mode (if unset) or ENHANCED mode.\nConsult the documentation for each field to understand which mode it is supported in.\n\n - DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED: Unspecified means legacy behavior.\n - DESCRIBE_TASK_QUEUE_MODE_ENHANCED: Enhanced mode reports aggregated results for all partitions, supports Build IDs, and reports richer info.",
-            "in": "query",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED",
-              "DESCRIBE_TASK_QUEUE_MODE_ENHANCED"
-            ],
-            "default": "DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED"
-          },
-          {
             "name": "taskQueue.kind",
             "description": "Default: TASK_QUEUE_KIND_NORMAL.\n\n - TASK_QUEUE_KIND_NORMAL: Tasks from a normal workflow task queue always include complete workflow history\n\nThe task queue specified by the user is always a normal task queue. There can be as many\nworkers as desired for a single normal task queue. All those workers may pick up tasks from\nthat queue.\n - TASK_QUEUE_KIND_STICKY: A sticky queue only includes new history since the last workflow task, and they are\nper-worker.\n\nSticky queues are created dynamically by each worker during their start up. They only exist\nfor the lifetime of the worker process. Tasks in a sticky task queue are only available to\nthe worker that created the sticky queue.\n\nSticky queues are only for workflow tasks. There are no sticky task queues for activities.",
             "in": "query",
@@ -5070,7 +5058,7 @@
           },
           {
             "name": "taskQueueType",
-            "description": "[DEFAULT MODE ONLY]\nIf unspecified (TASK_QUEUE_TYPE_UNSPECIFIED), then default value (TASK_QUEUE_TYPE_WORKFLOW) will be used.\nOnly supported in default mode (use `task_queue_types` in ENHANCED mode instead).\n\n - TASK_QUEUE_TYPE_WORKFLOW: Workflow type of task queue.\n - TASK_QUEUE_TYPE_ACTIVITY: Activity type of task queue.\n - TASK_QUEUE_TYPE_NEXUS: Task queue type for dispatching Nexus requests.",
+            "description": "If unspecified (TASK_QUEUE_TYPE_UNSPECIFIED), then default value (TASK_QUEUE_TYPE_WORKFLOW) will be used.\nOnly supported in default mode (use `task_queue_types` in ENHANCED mode instead).\n\n - TASK_QUEUE_TYPE_WORKFLOW: Workflow type of task queue.\n - TASK_QUEUE_TYPE_ACTIVITY: Activity type of task queue.\n - TASK_QUEUE_TYPE_NEXUS: Task queue type for dispatching Nexus requests.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -5084,10 +5072,29 @@
           },
           {
             "name": "includeTaskQueueStatus",
-            "description": "[DEFAULT MODE ONLY]\nDeprecated, use `report_stats` instead.\nIf true, the task queue status will be included in the response.",
+            "description": "Deprecated, use `report_stats` instead.\nIf true, the task queue status will be included in the response.",
             "in": "query",
             "required": false,
             "type": "boolean"
+          },
+          {
+            "name": "reportStats",
+            "description": "Report stats for the requested task queue type(s).",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "apiMode",
+            "description": "Deprecated. ENHANCED mode is also being deprecated.\nSelect the API mode to use for this request: DEFAULT mode (if unset) or ENHANCED mode.\nConsult the documentation for each field to understand which mode it is supported in.\n\n - DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED: Unspecified means legacy behavior.\n - DESCRIBE_TASK_QUEUE_MODE_ENHANCED: Enhanced mode reports aggregated results for all partitions, supports Build IDs, and reports richer info.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED",
+              "DESCRIBE_TASK_QUEUE_MODE_ENHANCED"
+            ],
+            "default": "DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED"
           },
           {
             "name": "versions.buildIds",
@@ -5116,7 +5123,7 @@
           },
           {
             "name": "taskQueueTypes",
-            "description": "[ENHANCED MODE ONLY]\nTask queue types to report info about. If not specified, all types are considered.\n\n - TASK_QUEUE_TYPE_WORKFLOW: Workflow type of task queue.\n - TASK_QUEUE_TYPE_ACTIVITY: Activity type of task queue.\n - TASK_QUEUE_TYPE_NEXUS: Task queue type for dispatching Nexus requests.",
+            "description": "Deprecated (as part of the ENHANCED mode deprecation).\nTask queue types to report info about. If not specified, all types are considered.\n\n - TASK_QUEUE_TYPE_WORKFLOW: Workflow type of task queue.\n - TASK_QUEUE_TYPE_ACTIVITY: Activity type of task queue.\n - TASK_QUEUE_TYPE_NEXUS: Task queue type for dispatching Nexus requests.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -5132,22 +5139,15 @@
             "collectionFormat": "multi"
           },
           {
-            "name": "reportStats",
-            "description": "[BOTH MODES]\nReport stats for the requested task queue type(s), and versions (only in ENHANCED mode).",
-            "in": "query",
-            "required": false,
-            "type": "boolean"
-          },
-          {
             "name": "reportPollers",
-            "description": "[ENHANCED MODE ONLY]\nDeprecated.\nReport list of pollers for requested task queue types and versions.",
+            "description": "Deprecated (as part of the ENHANCED mode deprecation).\nReport list of pollers for requested task queue types and versions.",
             "in": "query",
             "required": false,
             "type": "boolean"
           },
           {
             "name": "reportTaskReachability",
-            "description": "[ENHANCED MODE ONLY]\nDeprecated.\nReport task reachability for the requested versions and all task types (task reachability is not reported\nper task type).",
+            "description": "Deprecated (as part of the ENHANCED mode deprecation).\nReport task reachability for the requested versions and all task types (task reachability is not reported\nper task type).",
             "in": "query",
             "required": false,
             "type": "boolean"
@@ -10081,27 +10081,26 @@
           "items": {
             "type": "object",
             "$ref": "#/definitions/v1PollerInfo"
-          },
-          "title": "[DEFAULT MODE ONLY]"
-        },
-        "taskQueueStatus": {
-          "$ref": "#/definitions/v1TaskQueueStatus",
-          "description": "[DEFAULT MODE ONLY]\nDeprecated.\nStatus of the task queue. Only populated when `include_task_queue_status` is set to true in the request."
+          }
         },
         "taskQueueStats": {
           "$ref": "#/definitions/v1TaskQueueStats",
-          "description": "[DEFAULT MODE ONLY]\nStatistics for the task queue. Only populated when `report_stats` is set to true in the request."
+          "description": "Statistics for the task queue. Only populated when `report_stats` is set to true in the request."
+        },
+        "versioningInfo": {
+          "$ref": "#/definitions/v1TaskQueueVersioningInfo",
+          "description": "Specifies which Worker Deployment Version(s) Server routes this Task Queue's tasks to.\nWhen not present, it means the tasks are routed to Unversioned workers (workers with\nUNVERSIONED or unspecified WorkerVersioningMode.)\nTask Queue Versioning info is updated indirectly by calling SetWorkerDeploymentCurrentVersion\nand SetWorkerDeploymentRampingVersion on Worker Deployments.\nNote: This information is not relevant to Pinned workflow executions and their activities as\nthey are always routed to their Pinned Deployment Version. However, new workflow executions\nare typically not Pinned until they complete their first task (unless they are started with\na Pinned VersioningOverride or are Child Workflows of a Pinned parent)."
+        },
+        "taskQueueStatus": {
+          "$ref": "#/definitions/v1TaskQueueStatus",
+          "description": "Deprecated.\nStatus of the task queue. Only populated when `include_task_queue_status` is set to true in the request."
         },
         "versionsInfo": {
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/v1TaskQueueVersionInfo"
           },
-          "description": "[ENHANCED MODE ONLY]\nDeprecated.\nThis map contains Task Queue information for each Build ID. Empty string as key value means unversioned."
-        },
-        "versioningInfo": {
-          "$ref": "#/definitions/v1TaskQueueVersioningInfo",
-          "description": "[DEFAULT MODE ONLY]\nSpecifies which Worker Deployment Version(s) Server routes this Task Queue's tasks to.\nWhen not present, it means the tasks are routed to Unversioned workers (workers with\nUNVERSIONED or unspecified WorkerVersioningMode.)\nTask Queue Versioning info is updated indirectly by calling SetWorkerDeploymentCurrentVersion\nand SetWorkerDeploymentRampingVersion on Worker Deployments.\nNote: This information is not relevant to Pinned workflow executions and their activities as\nthey are always routed to their Pinned Deployment Version. However, new workflow executions\nare typically not Pinned until they complete their first task (unless they are started with\na Pinned VersioningOverride or are Child Workflows of a Pinned parent)."
+          "description": "Deprecated.\nOnly returned in ENHANCED mode.\nThis map contains Task Queue information for each Build ID. Empty string as key value means unversioned."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -1536,7 +1536,7 @@
           },
           {
             "name": "includeTaskQueueStatus",
-            "description": "[DEFAULT MODE ONLY]\nIf true, the task queue status will be included in the response.\nIn ENHANCED mode, use `report_stats` instead.",
+            "description": "[DEFAULT MODE ONLY]\nDeprecated.\nIf true, the task queue status will be included in the response.\nIn ENHANCED mode, use `report_stats` instead.",
             "in": "query",
             "required": false,
             "type": "boolean"
@@ -5084,7 +5084,7 @@
           },
           {
             "name": "includeTaskQueueStatus",
-            "description": "[DEFAULT MODE ONLY]\nIf true, the task queue status will be included in the response.\nIn ENHANCED mode, use `report_stats` instead.",
+            "description": "[DEFAULT MODE ONLY]\nDeprecated.\nIf true, the task queue status will be included in the response.\nIn ENHANCED mode, use `report_stats` instead.",
             "in": "query",
             "required": false,
             "type": "boolean"
@@ -10101,7 +10101,7 @@
         },
         "versioningInfo": {
           "$ref": "#/definitions/v1TaskQueueVersioningInfo",
-          "description": "[ENHANCED MODE ONLY]\nSpecifies which Worker Deployment Version(s) Server routes this Task Queue's tasks to.\nWhen not present, it means the tasks are routed to Unversioned workers (workers with\nUNVERSIONED or unspecified WorkerVersioningMode.)\nTask Queue Versioning info is updated indirectly by calling SetWorkerDeploymentCurrentVersion\nand SetWorkerDeploymentRampingVersion on Worker Deployments.\nNote: This information is not relevant to Pinned workflow executions and their activities as\nthey are always routed to their Pinned Deployment Version. However, new workflow executions\nare typically not Pinned until they complete their first task (unless they are started with\na Pinned VersioningOverride or are Child Workflows of a Pinned parent)."
+          "description": "[DEFAULT MODE ONLY]\nSpecifies which Worker Deployment Version(s) Server routes this Task Queue's tasks to.\nWhen not present, it means the tasks are routed to Unversioned workers (workers with\nUNVERSIONED or unspecified WorkerVersioningMode.)\nTask Queue Versioning info is updated indirectly by calling SetWorkerDeploymentCurrentVersion\nand SetWorkerDeploymentRampingVersion on Worker Deployments.\nNote: This information is not relevant to Pinned workflow executions and their activities as\nthey are always routed to their Pinned Deployment Version. However, new workflow executions\nare typically not Pinned until they complete their first task (unless they are started with\na Pinned VersioningOverride or are Child Workflows of a Pinned parent)."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -1523,15 +1523,15 @@
             "default": "TASK_QUEUE_TYPE_UNSPECIFIED"
           },
           {
-            "name": "includeTaskQueueStatus",
-            "description": "Deprecated, use `report_stats` instead.\nIf true, the task queue status will be included in the response.",
+            "name": "reportStats",
+            "description": "Report stats for the requested task queue type(s).",
             "in": "query",
             "required": false,
             "type": "boolean"
           },
           {
-            "name": "reportStats",
-            "description": "Report stats for the requested task queue type(s).",
+            "name": "includeTaskQueueStatus",
+            "description": "Deprecated, use `report_stats` instead.\nIf true, the task queue status will be included in the response.",
             "in": "query",
             "required": false,
             "type": "boolean"
@@ -5071,15 +5071,15 @@
             "default": "TASK_QUEUE_TYPE_UNSPECIFIED"
           },
           {
-            "name": "includeTaskQueueStatus",
-            "description": "Deprecated, use `report_stats` instead.\nIf true, the task queue status will be included in the response.",
+            "name": "reportStats",
+            "description": "Report stats for the requested task queue type(s).",
             "in": "query",
             "required": false,
             "type": "boolean"
           },
           {
-            "name": "reportStats",
-            "description": "Report stats for the requested task queue type(s).",
+            "name": "includeTaskQueueStatus",
+            "description": "Deprecated, use `report_stats` instead.\nIf true, the task queue status will be included in the response.",
             "in": "query",
             "required": false,
             "type": "boolean"
@@ -10083,7 +10083,7 @@
             "$ref": "#/definitions/v1PollerInfo"
           }
         },
-        "taskQueueStats": {
+        "stats": {
           "$ref": "#/definitions/v1TaskQueueStats",
           "description": "Statistics for the task queue. Only populated when `report_stats` is set to true in the request."
         },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -1489,6 +1489,18 @@
             "type": "string"
           },
           {
+            "name": "apiMode",
+            "description": "Select the API mode to use for this request: DEFAULT mode (if unset) or ENHANCED mode.\nConsult the documentation for each field to understand which mode it is supported in.\n\n - DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED: Unspecified means legacy behavior.\n - DESCRIBE_TASK_QUEUE_MODE_ENHANCED: Enhanced mode reports aggregated results for all partitions, supports Build IDs, and reports richer info.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED",
+              "DESCRIBE_TASK_QUEUE_MODE_ENHANCED"
+            ],
+            "default": "DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED"
+          },
+          {
             "name": "taskQueue.kind",
             "description": "Default: TASK_QUEUE_KIND_NORMAL.\n\n - TASK_QUEUE_KIND_NORMAL: Tasks from a normal workflow task queue always include complete workflow history\n\nThe task queue specified by the user is always a normal task queue. There can be as many\nworkers as desired for a single normal task queue. All those workers may pick up tasks from\nthat queue.\n - TASK_QUEUE_KIND_STICKY: A sticky queue only includes new history since the last workflow task, and they are\nper-worker.\n\nSticky queues are created dynamically by each worker during their start up. They only exist\nfor the lifetime of the worker process. Tasks in a sticky task queue are only available to\nthe worker that created the sticky queue.\n\nSticky queues are only for workflow tasks. There are no sticky task queues for activities.",
             "in": "query",
@@ -1510,7 +1522,7 @@
           },
           {
             "name": "taskQueueType",
-            "description": "Deprecated. Use `ENHANCED` mode with `task_queue_types`. Ignored in `ENHANCED` mode.\nIf unspecified (TASK_QUEUE_TYPE_UNSPECIFIED), then default value (TASK_QUEUE_TYPE_WORKFLOW) will be used.\n\n - TASK_QUEUE_TYPE_WORKFLOW: Workflow type of task queue.\n - TASK_QUEUE_TYPE_ACTIVITY: Activity type of task queue.\n - TASK_QUEUE_TYPE_NEXUS: Task queue type for dispatching Nexus requests.",
+            "description": "[DEFAULT MODE ONLY]\nIf unspecified (TASK_QUEUE_TYPE_UNSPECIFIED), then default value (TASK_QUEUE_TYPE_WORKFLOW) will be used.\nOnly supported in default mode (use `task_queue_types` in ENHANCED mode instead).\n\n - TASK_QUEUE_TYPE_WORKFLOW: Workflow type of task queue.\n - TASK_QUEUE_TYPE_ACTIVITY: Activity type of task queue.\n - TASK_QUEUE_TYPE_NEXUS: Task queue type for dispatching Nexus requests.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -1524,22 +1536,10 @@
           },
           {
             "name": "includeTaskQueueStatus",
-            "description": "Deprecated. Ignored in `ENHANCED` mode.",
+            "description": "[DEFAULT MODE ONLY]\nIf true, the task queue status will be included in the response.\nIn ENHANCED mode, use `report_stats` instead.",
             "in": "query",
             "required": false,
             "type": "boolean"
-          },
-          {
-            "name": "apiMode",
-            "description": "All options except `task_queue_type` and `include_task_queue_status` are only available in the `ENHANCED` mode.\n\n - DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED: Unspecified means legacy behavior.\n - DESCRIBE_TASK_QUEUE_MODE_ENHANCED: Enhanced mode reports aggregated results for all partitions, supports Build IDs, and reports richer info.",
-            "in": "query",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED",
-              "DESCRIBE_TASK_QUEUE_MODE_ENHANCED"
-            ],
-            "default": "DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED"
           },
           {
             "name": "versions.buildIds",
@@ -1568,7 +1568,7 @@
           },
           {
             "name": "taskQueueTypes",
-            "description": "Task queue types to report info about. If not specified, all types are considered.\n\n - TASK_QUEUE_TYPE_WORKFLOW: Workflow type of task queue.\n - TASK_QUEUE_TYPE_ACTIVITY: Activity type of task queue.\n - TASK_QUEUE_TYPE_NEXUS: Task queue type for dispatching Nexus requests.",
+            "description": "[ENHANCED MODE ONLY]\nTask queue types to report info about. If not specified, all types are considered.\n\n - TASK_QUEUE_TYPE_WORKFLOW: Workflow type of task queue.\n - TASK_QUEUE_TYPE_ACTIVITY: Activity type of task queue.\n - TASK_QUEUE_TYPE_NEXUS: Task queue type for dispatching Nexus requests.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -1585,21 +1585,21 @@
           },
           {
             "name": "reportStats",
-            "description": "Report stats for the requested task queue types and versions",
+            "description": "[BOTH MODES]\nReport stats for the requested task queue type(s), and versions (only in ENHANCED mode).",
             "in": "query",
             "required": false,
             "type": "boolean"
           },
           {
             "name": "reportPollers",
-            "description": "Report list of pollers for requested task queue types and versions",
+            "description": "[ENHANCED MODE ONLY]\nReport list of pollers for requested task queue types and versions.",
             "in": "query",
             "required": false,
             "type": "boolean"
           },
           {
             "name": "reportTaskReachability",
-            "description": "Report task reachability for the requested versions and all task types (task reachability is not reported\nper task type).",
+            "description": "[ENHANCED MODE ONLY]\nReport task reachability for the requested versions and all task types (task reachability is not reported\nper task type).",
             "in": "query",
             "required": false,
             "type": "boolean"
@@ -5037,6 +5037,18 @@
             "type": "string"
           },
           {
+            "name": "apiMode",
+            "description": "Select the API mode to use for this request: DEFAULT mode (if unset) or ENHANCED mode.\nConsult the documentation for each field to understand which mode it is supported in.\n\n - DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED: Unspecified means legacy behavior.\n - DESCRIBE_TASK_QUEUE_MODE_ENHANCED: Enhanced mode reports aggregated results for all partitions, supports Build IDs, and reports richer info.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED",
+              "DESCRIBE_TASK_QUEUE_MODE_ENHANCED"
+            ],
+            "default": "DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED"
+          },
+          {
             "name": "taskQueue.kind",
             "description": "Default: TASK_QUEUE_KIND_NORMAL.\n\n - TASK_QUEUE_KIND_NORMAL: Tasks from a normal workflow task queue always include complete workflow history\n\nThe task queue specified by the user is always a normal task queue. There can be as many\nworkers as desired for a single normal task queue. All those workers may pick up tasks from\nthat queue.\n - TASK_QUEUE_KIND_STICKY: A sticky queue only includes new history since the last workflow task, and they are\nper-worker.\n\nSticky queues are created dynamically by each worker during their start up. They only exist\nfor the lifetime of the worker process. Tasks in a sticky task queue are only available to\nthe worker that created the sticky queue.\n\nSticky queues are only for workflow tasks. There are no sticky task queues for activities.",
             "in": "query",
@@ -5058,7 +5070,7 @@
           },
           {
             "name": "taskQueueType",
-            "description": "Deprecated. Use `ENHANCED` mode with `task_queue_types`. Ignored in `ENHANCED` mode.\nIf unspecified (TASK_QUEUE_TYPE_UNSPECIFIED), then default value (TASK_QUEUE_TYPE_WORKFLOW) will be used.\n\n - TASK_QUEUE_TYPE_WORKFLOW: Workflow type of task queue.\n - TASK_QUEUE_TYPE_ACTIVITY: Activity type of task queue.\n - TASK_QUEUE_TYPE_NEXUS: Task queue type for dispatching Nexus requests.",
+            "description": "[DEFAULT MODE ONLY]\nIf unspecified (TASK_QUEUE_TYPE_UNSPECIFIED), then default value (TASK_QUEUE_TYPE_WORKFLOW) will be used.\nOnly supported in default mode (use `task_queue_types` in ENHANCED mode instead).\n\n - TASK_QUEUE_TYPE_WORKFLOW: Workflow type of task queue.\n - TASK_QUEUE_TYPE_ACTIVITY: Activity type of task queue.\n - TASK_QUEUE_TYPE_NEXUS: Task queue type for dispatching Nexus requests.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -5072,22 +5084,10 @@
           },
           {
             "name": "includeTaskQueueStatus",
-            "description": "Deprecated. Ignored in `ENHANCED` mode.",
+            "description": "[DEFAULT MODE ONLY]\nIf true, the task queue status will be included in the response.\nIn ENHANCED mode, use `report_stats` instead.",
             "in": "query",
             "required": false,
             "type": "boolean"
-          },
-          {
-            "name": "apiMode",
-            "description": "All options except `task_queue_type` and `include_task_queue_status` are only available in the `ENHANCED` mode.\n\n - DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED: Unspecified means legacy behavior.\n - DESCRIBE_TASK_QUEUE_MODE_ENHANCED: Enhanced mode reports aggregated results for all partitions, supports Build IDs, and reports richer info.",
-            "in": "query",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED",
-              "DESCRIBE_TASK_QUEUE_MODE_ENHANCED"
-            ],
-            "default": "DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED"
           },
           {
             "name": "versions.buildIds",
@@ -5116,7 +5116,7 @@
           },
           {
             "name": "taskQueueTypes",
-            "description": "Task queue types to report info about. If not specified, all types are considered.\n\n - TASK_QUEUE_TYPE_WORKFLOW: Workflow type of task queue.\n - TASK_QUEUE_TYPE_ACTIVITY: Activity type of task queue.\n - TASK_QUEUE_TYPE_NEXUS: Task queue type for dispatching Nexus requests.",
+            "description": "[ENHANCED MODE ONLY]\nTask queue types to report info about. If not specified, all types are considered.\n\n - TASK_QUEUE_TYPE_WORKFLOW: Workflow type of task queue.\n - TASK_QUEUE_TYPE_ACTIVITY: Activity type of task queue.\n - TASK_QUEUE_TYPE_NEXUS: Task queue type for dispatching Nexus requests.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -5133,21 +5133,21 @@
           },
           {
             "name": "reportStats",
-            "description": "Report stats for the requested task queue types and versions",
+            "description": "[BOTH MODES]\nReport stats for the requested task queue type(s), and versions (only in ENHANCED mode).",
             "in": "query",
             "required": false,
             "type": "boolean"
           },
           {
             "name": "reportPollers",
-            "description": "Report list of pollers for requested task queue types and versions",
+            "description": "[ENHANCED MODE ONLY]\nReport list of pollers for requested task queue types and versions.",
             "in": "query",
             "required": false,
             "type": "boolean"
           },
           {
             "name": "reportTaskReachability",
-            "description": "Report task reachability for the requested versions and all task types (task reachability is not reported\nper task type).",
+            "description": "[ENHANCED MODE ONLY]\nReport task reachability for the requested versions and all task types (task reachability is not reported\nper task type).",
             "in": "query",
             "required": false,
             "type": "boolean"
@@ -10082,22 +10082,26 @@
             "type": "object",
             "$ref": "#/definitions/v1PollerInfo"
           },
-          "description": "Deprecated. Use `versions_info.types_info.pollers` with `ENHANCED` mode instead.\nNot set in `ENHANCED` mode."
+          "title": "[DEFAULT MODE ONLY]"
         },
         "taskQueueStatus": {
           "$ref": "#/definitions/v1TaskQueueStatus",
-          "description": "Deprecated. Not set in `ENHANCED` mode."
+          "description": "[DEFAULT MODE ONLY]\nDeprecated.\nStatus of the task queue. Only populated when `include_task_queue_status` is set to true in the request."
+        },
+        "taskQueueStats": {
+          "$ref": "#/definitions/v1TaskQueueStats",
+          "description": "[DEFAULT MODE ONLY]\nStatistics for the task queue. Only populated when `report_stats` is set to true in the request."
         },
         "versionsInfo": {
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/v1TaskQueueVersionInfo"
           },
-          "description": "This map contains Task Queue information for each Build ID. Empty string as key value means unversioned.\nOnly set in `ENHANCED` mode."
+          "description": "[ENHANCED MODE ONLY]\nThis map contains Task Queue information for each Build ID. Empty string as key value means unversioned."
         },
         "versioningInfo": {
           "$ref": "#/definitions/v1TaskQueueVersioningInfo",
-          "description": "Specifies which Worker Deployment Version(s) Server routes this Task Queue's tasks to.\nWhen not present, it means the tasks are routed to Unversioned workers (workers with\nUNVERSIONED or unspecified WorkerVersioningMode.)\nTask Queue Versioning info is updated indirectly by calling SetWorkerDeploymentCurrentVersion\nand SetWorkerDeploymentRampingVersion on Worker Deployments.\nNote: This information is not relevant to Pinned workflow executions and their activities as\nthey are always routed to their Pinned Deployment Version. However, new workflow executions\nare typically not Pinned until they complete their first task (unless they are started with\na Pinned VersioningOverride or are Child Workflows of a Pinned parent)."
+          "description": "[ENHANCED MODE ONLY]\nSpecifies which Worker Deployment Version(s) Server routes this Task Queue's tasks to.\nWhen not present, it means the tasks are routed to Unversioned workers (workers with\nUNVERSIONED or unspecified WorkerVersioningMode.)\nTask Queue Versioning info is updated indirectly by calling SetWorkerDeploymentCurrentVersion\nand SetWorkerDeploymentRampingVersion on Worker Deployments.\nNote: This information is not relevant to Pinned workflow executions and their activities as\nthey are always routed to their Pinned Deployment Version. However, new workflow executions\nare typically not Pinned until they complete their first task (unless they are started with\na Pinned VersioningOverride or are Child Workflows of a Pinned parent)."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -1490,7 +1490,7 @@
           },
           {
             "name": "apiMode",
-            "description": "Select the API mode to use for this request: DEFAULT mode (if unset) or ENHANCED mode.\nConsult the documentation for each field to understand which mode it is supported in.\n\n - DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED: Unspecified means legacy behavior.\n - DESCRIBE_TASK_QUEUE_MODE_ENHANCED: Enhanced mode reports aggregated results for all partitions, supports Build IDs, and reports richer info.",
+            "description": "Deprecated. ENHANCED mode is also being deprecated.\nSelect the API mode to use for this request: DEFAULT mode (if unset) or ENHANCED mode.\nConsult the documentation for each field to understand which mode it is supported in.\n\n - DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED: Unspecified means legacy behavior.\n - DESCRIBE_TASK_QUEUE_MODE_ENHANCED: Enhanced mode reports aggregated results for all partitions, supports Build IDs, and reports richer info.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -1536,7 +1536,7 @@
           },
           {
             "name": "includeTaskQueueStatus",
-            "description": "[DEFAULT MODE ONLY]\nDeprecated.\nIf true, the task queue status will be included in the response.\nIn ENHANCED mode, use `report_stats` instead.",
+            "description": "[DEFAULT MODE ONLY]\nDeprecated, use `report_stats` instead.\nIf true, the task queue status will be included in the response.",
             "in": "query",
             "required": false,
             "type": "boolean"
@@ -1592,14 +1592,14 @@
           },
           {
             "name": "reportPollers",
-            "description": "[ENHANCED MODE ONLY]\nReport list of pollers for requested task queue types and versions.",
+            "description": "[ENHANCED MODE ONLY]\nDeprecated.\nReport list of pollers for requested task queue types and versions.",
             "in": "query",
             "required": false,
             "type": "boolean"
           },
           {
             "name": "reportTaskReachability",
-            "description": "[ENHANCED MODE ONLY]\nReport task reachability for the requested versions and all task types (task reachability is not reported\nper task type).",
+            "description": "[ENHANCED MODE ONLY]\nDeprecated.\nReport task reachability for the requested versions and all task types (task reachability is not reported\nper task type).",
             "in": "query",
             "required": false,
             "type": "boolean"
@@ -5038,7 +5038,7 @@
           },
           {
             "name": "apiMode",
-            "description": "Select the API mode to use for this request: DEFAULT mode (if unset) or ENHANCED mode.\nConsult the documentation for each field to understand which mode it is supported in.\n\n - DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED: Unspecified means legacy behavior.\n - DESCRIBE_TASK_QUEUE_MODE_ENHANCED: Enhanced mode reports aggregated results for all partitions, supports Build IDs, and reports richer info.",
+            "description": "Deprecated. ENHANCED mode is also being deprecated.\nSelect the API mode to use for this request: DEFAULT mode (if unset) or ENHANCED mode.\nConsult the documentation for each field to understand which mode it is supported in.\n\n - DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED: Unspecified means legacy behavior.\n - DESCRIBE_TASK_QUEUE_MODE_ENHANCED: Enhanced mode reports aggregated results for all partitions, supports Build IDs, and reports richer info.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -5084,7 +5084,7 @@
           },
           {
             "name": "includeTaskQueueStatus",
-            "description": "[DEFAULT MODE ONLY]\nDeprecated.\nIf true, the task queue status will be included in the response.\nIn ENHANCED mode, use `report_stats` instead.",
+            "description": "[DEFAULT MODE ONLY]\nDeprecated, use `report_stats` instead.\nIf true, the task queue status will be included in the response.",
             "in": "query",
             "required": false,
             "type": "boolean"
@@ -5140,14 +5140,14 @@
           },
           {
             "name": "reportPollers",
-            "description": "[ENHANCED MODE ONLY]\nReport list of pollers for requested task queue types and versions.",
+            "description": "[ENHANCED MODE ONLY]\nDeprecated.\nReport list of pollers for requested task queue types and versions.",
             "in": "query",
             "required": false,
             "type": "boolean"
           },
           {
             "name": "reportTaskReachability",
-            "description": "[ENHANCED MODE ONLY]\nReport task reachability for the requested versions and all task types (task reachability is not reported\nper task type).",
+            "description": "[ENHANCED MODE ONLY]\nDeprecated.\nReport task reachability for the requested versions and all task types (task reachability is not reported\nper task type).",
             "in": "query",
             "required": false,
             "type": "boolean"
@@ -10097,7 +10097,7 @@
           "additionalProperties": {
             "$ref": "#/definitions/v1TaskQueueVersionInfo"
           },
-          "description": "[ENHANCED MODE ONLY]\nThis map contains Task Queue information for each Build ID. Empty string as key value means unversioned."
+          "description": "[ENHANCED MODE ONLY]\nDeprecated.\nThis map contains Task Queue information for each Build ID. Empty string as key value means unversioned."
         },
         "versioningInfo": {
           "$ref": "#/definitions/v1TaskQueueVersioningInfo",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -1394,18 +1394,6 @@ paths:
           required: true
           schema:
             type: string
-        - name: apiMode
-          in: query
-          description: |-
-            Deprecated. ENHANCED mode is also being deprecated.
-             Select the API mode to use for this request: DEFAULT mode (if unset) or ENHANCED mode.
-             Consult the documentation for each field to understand which mode it is supported in.
-          schema:
-            enum:
-              - DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED
-              - DESCRIBE_TASK_QUEUE_MODE_ENHANCED
-            type: string
-            format: enum
         - name: taskQueue.name
           in: query
           schema:
@@ -1430,8 +1418,7 @@ paths:
         - name: taskQueueType
           in: query
           description: |-
-            [DEFAULT MODE ONLY]
-             If unspecified (TASK_QUEUE_TYPE_UNSPECIFIED), then default value (TASK_QUEUE_TYPE_WORKFLOW) will be used.
+            If unspecified (TASK_QUEUE_TYPE_UNSPECIFIED), then default value (TASK_QUEUE_TYPE_WORKFLOW) will be used.
              Only supported in default mode (use `task_queue_types` in ENHANCED mode instead).
           schema:
             enum:
@@ -1444,11 +1431,27 @@ paths:
         - name: includeTaskQueueStatus
           in: query
           description: |-
-            [DEFAULT MODE ONLY]
-             Deprecated, use `report_stats` instead.
+            Deprecated, use `report_stats` instead.
              If true, the task queue status will be included in the response.
           schema:
             type: boolean
+        - name: reportStats
+          in: query
+          description: Report stats for the requested task queue type(s).
+          schema:
+            type: boolean
+        - name: apiMode
+          in: query
+          description: |-
+            Deprecated. ENHANCED mode is also being deprecated.
+             Select the API mode to use for this request: DEFAULT mode (if unset) or ENHANCED mode.
+             Consult the documentation for each field to understand which mode it is supported in.
+          schema:
+            enum:
+              - DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED
+              - DESCRIBE_TASK_QUEUE_MODE_ENHANCED
+            type: string
+            format: enum
         - name: versions.buildIds
           in: query
           description: Include specific Build IDs.
@@ -1471,7 +1474,7 @@ paths:
         - name: taskQueueTypes
           in: query
           description: |-
-            [ENHANCED MODE ONLY]
+            Deprecated (as part of the ENHANCED mode deprecation).
              Task queue types to report info about. If not specified, all types are considered.
           schema:
             type: array
@@ -1483,26 +1486,17 @@ paths:
                 - TASK_QUEUE_TYPE_NEXUS
               type: string
               format: enum
-        - name: reportStats
-          in: query
-          description: |-
-            [BOTH MODES]
-             Report stats for the requested task queue type(s), and versions (only in ENHANCED mode).
-          schema:
-            type: boolean
         - name: reportPollers
           in: query
           description: |-
-            [ENHANCED MODE ONLY]
-             Deprecated.
+            Deprecated (as part of the ENHANCED mode deprecation).
              Report list of pollers for requested task queue types and versions.
           schema:
             type: boolean
         - name: reportTaskReachability
           in: query
           description: |-
-            [ENHANCED MODE ONLY]
-             Deprecated.
+            Deprecated (as part of the ENHANCED mode deprecation).
              Report task reachability for the requested versions and all task types (task reachability is not reported
              per task type).
           schema:
@@ -4580,18 +4574,6 @@ paths:
           required: true
           schema:
             type: string
-        - name: apiMode
-          in: query
-          description: |-
-            Deprecated. ENHANCED mode is also being deprecated.
-             Select the API mode to use for this request: DEFAULT mode (if unset) or ENHANCED mode.
-             Consult the documentation for each field to understand which mode it is supported in.
-          schema:
-            enum:
-              - DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED
-              - DESCRIBE_TASK_QUEUE_MODE_ENHANCED
-            type: string
-            format: enum
         - name: taskQueue.name
           in: query
           schema:
@@ -4616,8 +4598,7 @@ paths:
         - name: taskQueueType
           in: query
           description: |-
-            [DEFAULT MODE ONLY]
-             If unspecified (TASK_QUEUE_TYPE_UNSPECIFIED), then default value (TASK_QUEUE_TYPE_WORKFLOW) will be used.
+            If unspecified (TASK_QUEUE_TYPE_UNSPECIFIED), then default value (TASK_QUEUE_TYPE_WORKFLOW) will be used.
              Only supported in default mode (use `task_queue_types` in ENHANCED mode instead).
           schema:
             enum:
@@ -4630,11 +4611,27 @@ paths:
         - name: includeTaskQueueStatus
           in: query
           description: |-
-            [DEFAULT MODE ONLY]
-             Deprecated, use `report_stats` instead.
+            Deprecated, use `report_stats` instead.
              If true, the task queue status will be included in the response.
           schema:
             type: boolean
+        - name: reportStats
+          in: query
+          description: Report stats for the requested task queue type(s).
+          schema:
+            type: boolean
+        - name: apiMode
+          in: query
+          description: |-
+            Deprecated. ENHANCED mode is also being deprecated.
+             Select the API mode to use for this request: DEFAULT mode (if unset) or ENHANCED mode.
+             Consult the documentation for each field to understand which mode it is supported in.
+          schema:
+            enum:
+              - DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED
+              - DESCRIBE_TASK_QUEUE_MODE_ENHANCED
+            type: string
+            format: enum
         - name: versions.buildIds
           in: query
           description: Include specific Build IDs.
@@ -4657,7 +4654,7 @@ paths:
         - name: taskQueueTypes
           in: query
           description: |-
-            [ENHANCED MODE ONLY]
+            Deprecated (as part of the ENHANCED mode deprecation).
              Task queue types to report info about. If not specified, all types are considered.
           schema:
             type: array
@@ -4669,26 +4666,17 @@ paths:
                 - TASK_QUEUE_TYPE_NEXUS
               type: string
               format: enum
-        - name: reportStats
-          in: query
-          description: |-
-            [BOTH MODES]
-             Report stats for the requested task queue type(s), and versions (only in ENHANCED mode).
-          schema:
-            type: boolean
         - name: reportPollers
           in: query
           description: |-
-            [ENHANCED MODE ONLY]
-             Deprecated.
+            Deprecated (as part of the ENHANCED mode deprecation).
              Report list of pollers for requested task queue types and versions.
           schema:
             type: boolean
         - name: reportTaskReachability
           in: query
           description: |-
-            [ENHANCED MODE ONLY]
-             Deprecated.
+            Deprecated (as part of the ENHANCED mode deprecation).
              Report task reachability for the requested versions and all task types (task reachability is not reported
              per task type).
           schema:
@@ -7328,34 +7316,15 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PollerInfo'
-          description: '[DEFAULT MODE ONLY]'
-        taskQueueStatus:
-          allOf:
-            - $ref: '#/components/schemas/TaskQueueStatus'
-          description: |-
-            [DEFAULT MODE ONLY]
-             Deprecated.
-             Status of the task queue. Only populated when `include_task_queue_status` is set to true in the request.
         taskQueueStats:
           allOf:
             - $ref: '#/components/schemas/TaskQueueStats'
-          description: |-
-            [DEFAULT MODE ONLY]
-             Statistics for the task queue. Only populated when `report_stats` is set to true in the request.
-        versionsInfo:
-          type: object
-          additionalProperties:
-            $ref: '#/components/schemas/TaskQueueVersionInfo'
-          description: |-
-            [ENHANCED MODE ONLY]
-             Deprecated.
-             This map contains Task Queue information for each Build ID. Empty string as key value means unversioned.
+          description: Statistics for the task queue. Only populated when `report_stats` is set to true in the request.
         versioningInfo:
           allOf:
             - $ref: '#/components/schemas/TaskQueueVersioningInfo'
           description: |-
-            [DEFAULT MODE ONLY]
-             Specifies which Worker Deployment Version(s) Server routes this Task Queue's tasks to.
+            Specifies which Worker Deployment Version(s) Server routes this Task Queue's tasks to.
              When not present, it means the tasks are routed to Unversioned workers (workers with
              UNVERSIONED or unspecified WorkerVersioningMode.)
              Task Queue Versioning info is updated indirectly by calling SetWorkerDeploymentCurrentVersion
@@ -7364,6 +7333,20 @@ components:
              they are always routed to their Pinned Deployment Version. However, new workflow executions
              are typically not Pinned until they complete their first task (unless they are started with
              a Pinned VersioningOverride or are Child Workflows of a Pinned parent).
+        taskQueueStatus:
+          allOf:
+            - $ref: '#/components/schemas/TaskQueueStatus'
+          description: |-
+            Deprecated.
+             Status of the task queue. Only populated when `include_task_queue_status` is set to true in the request.
+        versionsInfo:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/TaskQueueVersionInfo'
+          description: |-
+            Deprecated.
+             Only returned in ENHANCED mode.
+             This map contains Task Queue information for each Build ID. Empty string as key value means unversioned.
     DescribeWorkerDeploymentResponse:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -1397,7 +1397,8 @@ paths:
         - name: apiMode
           in: query
           description: |-
-            Select the API mode to use for this request: DEFAULT mode (if unset) or ENHANCED mode.
+            Deprecated. ENHANCED mode is also being deprecated.
+             Select the API mode to use for this request: DEFAULT mode (if unset) or ENHANCED mode.
              Consult the documentation for each field to understand which mode it is supported in.
           schema:
             enum:
@@ -1444,9 +1445,8 @@ paths:
           in: query
           description: |-
             [DEFAULT MODE ONLY]
-             Deprecated.
+             Deprecated, use `report_stats` instead.
              If true, the task queue status will be included in the response.
-             In ENHANCED mode, use `report_stats` instead.
           schema:
             type: boolean
         - name: versions.buildIds
@@ -1494,6 +1494,7 @@ paths:
           in: query
           description: |-
             [ENHANCED MODE ONLY]
+             Deprecated.
              Report list of pollers for requested task queue types and versions.
           schema:
             type: boolean
@@ -1501,6 +1502,7 @@ paths:
           in: query
           description: |-
             [ENHANCED MODE ONLY]
+             Deprecated.
              Report task reachability for the requested versions and all task types (task reachability is not reported
              per task type).
           schema:
@@ -4581,7 +4583,8 @@ paths:
         - name: apiMode
           in: query
           description: |-
-            Select the API mode to use for this request: DEFAULT mode (if unset) or ENHANCED mode.
+            Deprecated. ENHANCED mode is also being deprecated.
+             Select the API mode to use for this request: DEFAULT mode (if unset) or ENHANCED mode.
              Consult the documentation for each field to understand which mode it is supported in.
           schema:
             enum:
@@ -4628,9 +4631,8 @@ paths:
           in: query
           description: |-
             [DEFAULT MODE ONLY]
-             Deprecated.
+             Deprecated, use `report_stats` instead.
              If true, the task queue status will be included in the response.
-             In ENHANCED mode, use `report_stats` instead.
           schema:
             type: boolean
         - name: versions.buildIds
@@ -4678,6 +4680,7 @@ paths:
           in: query
           description: |-
             [ENHANCED MODE ONLY]
+             Deprecated.
              Report list of pollers for requested task queue types and versions.
           schema:
             type: boolean
@@ -4685,6 +4688,7 @@ paths:
           in: query
           description: |-
             [ENHANCED MODE ONLY]
+             Deprecated.
              Report task reachability for the requested versions and all task types (task reachability is not reported
              per task type).
           schema:
@@ -7344,6 +7348,7 @@ components:
             $ref: '#/components/schemas/TaskQueueVersionInfo'
           description: |-
             [ENHANCED MODE ONLY]
+             Deprecated.
              This map contains Task Queue information for each Build ID. Empty string as key value means unversioned.
         versioningInfo:
           allOf:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -1394,6 +1394,17 @@ paths:
           required: true
           schema:
             type: string
+        - name: apiMode
+          in: query
+          description: |-
+            Select the API mode to use for this request: DEFAULT mode (if unset) or ENHANCED mode.
+             Consult the documentation for each field to understand which mode it is supported in.
+          schema:
+            enum:
+              - DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED
+              - DESCRIBE_TASK_QUEUE_MODE_ENHANCED
+            type: string
+            format: enum
         - name: taskQueue.name
           in: query
           schema:
@@ -1418,8 +1429,9 @@ paths:
         - name: taskQueueType
           in: query
           description: |-
-            Deprecated. Use `ENHANCED` mode with `task_queue_types`. Ignored in `ENHANCED` mode.
+            [DEFAULT MODE ONLY]
              If unspecified (TASK_QUEUE_TYPE_UNSPECIFIED), then default value (TASK_QUEUE_TYPE_WORKFLOW) will be used.
+             Only supported in default mode (use `task_queue_types` in ENHANCED mode instead).
           schema:
             enum:
               - TASK_QUEUE_TYPE_UNSPECIFIED
@@ -1430,18 +1442,12 @@ paths:
             format: enum
         - name: includeTaskQueueStatus
           in: query
-          description: Deprecated. Ignored in `ENHANCED` mode.
+          description: |-
+            [DEFAULT MODE ONLY]
+             If true, the task queue status will be included in the response.
+             In ENHANCED mode, use `report_stats` instead.
           schema:
             type: boolean
-        - name: apiMode
-          in: query
-          description: All options except `task_queue_type` and `include_task_queue_status` are only available in the `ENHANCED` mode.
-          schema:
-            enum:
-              - DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED
-              - DESCRIBE_TASK_QUEUE_MODE_ENHANCED
-            type: string
-            format: enum
         - name: versions.buildIds
           in: query
           description: Include specific Build IDs.
@@ -1463,7 +1469,9 @@ paths:
             type: boolean
         - name: taskQueueTypes
           in: query
-          description: Task queue types to report info about. If not specified, all types are considered.
+          description: |-
+            [ENHANCED MODE ONLY]
+             Task queue types to report info about. If not specified, all types are considered.
           schema:
             type: array
             items:
@@ -1476,18 +1484,23 @@ paths:
               format: enum
         - name: reportStats
           in: query
-          description: Report stats for the requested task queue types and versions
+          description: |-
+            [BOTH MODES]
+             Report stats for the requested task queue type(s), and versions (only in ENHANCED mode).
           schema:
             type: boolean
         - name: reportPollers
           in: query
-          description: Report list of pollers for requested task queue types and versions
+          description: |-
+            [ENHANCED MODE ONLY]
+             Report list of pollers for requested task queue types and versions.
           schema:
             type: boolean
         - name: reportTaskReachability
           in: query
           description: |-
-            Report task reachability for the requested versions and all task types (task reachability is not reported
+            [ENHANCED MODE ONLY]
+             Report task reachability for the requested versions and all task types (task reachability is not reported
              per task type).
           schema:
             type: boolean
@@ -4564,6 +4577,17 @@ paths:
           required: true
           schema:
             type: string
+        - name: apiMode
+          in: query
+          description: |-
+            Select the API mode to use for this request: DEFAULT mode (if unset) or ENHANCED mode.
+             Consult the documentation for each field to understand which mode it is supported in.
+          schema:
+            enum:
+              - DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED
+              - DESCRIBE_TASK_QUEUE_MODE_ENHANCED
+            type: string
+            format: enum
         - name: taskQueue.name
           in: query
           schema:
@@ -4588,8 +4612,9 @@ paths:
         - name: taskQueueType
           in: query
           description: |-
-            Deprecated. Use `ENHANCED` mode with `task_queue_types`. Ignored in `ENHANCED` mode.
+            [DEFAULT MODE ONLY]
              If unspecified (TASK_QUEUE_TYPE_UNSPECIFIED), then default value (TASK_QUEUE_TYPE_WORKFLOW) will be used.
+             Only supported in default mode (use `task_queue_types` in ENHANCED mode instead).
           schema:
             enum:
               - TASK_QUEUE_TYPE_UNSPECIFIED
@@ -4600,18 +4625,12 @@ paths:
             format: enum
         - name: includeTaskQueueStatus
           in: query
-          description: Deprecated. Ignored in `ENHANCED` mode.
+          description: |-
+            [DEFAULT MODE ONLY]
+             If true, the task queue status will be included in the response.
+             In ENHANCED mode, use `report_stats` instead.
           schema:
             type: boolean
-        - name: apiMode
-          in: query
-          description: All options except `task_queue_type` and `include_task_queue_status` are only available in the `ENHANCED` mode.
-          schema:
-            enum:
-              - DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED
-              - DESCRIBE_TASK_QUEUE_MODE_ENHANCED
-            type: string
-            format: enum
         - name: versions.buildIds
           in: query
           description: Include specific Build IDs.
@@ -4633,7 +4652,9 @@ paths:
             type: boolean
         - name: taskQueueTypes
           in: query
-          description: Task queue types to report info about. If not specified, all types are considered.
+          description: |-
+            [ENHANCED MODE ONLY]
+             Task queue types to report info about. If not specified, all types are considered.
           schema:
             type: array
             items:
@@ -4646,18 +4667,23 @@ paths:
               format: enum
         - name: reportStats
           in: query
-          description: Report stats for the requested task queue types and versions
+          description: |-
+            [BOTH MODES]
+             Report stats for the requested task queue type(s), and versions (only in ENHANCED mode).
           schema:
             type: boolean
         - name: reportPollers
           in: query
-          description: Report list of pollers for requested task queue types and versions
+          description: |-
+            [ENHANCED MODE ONLY]
+             Report list of pollers for requested task queue types and versions.
           schema:
             type: boolean
         - name: reportTaskReachability
           in: query
           description: |-
-            Report task reachability for the requested versions and all task types (task reachability is not reported
+            [ENHANCED MODE ONLY]
+             Report task reachability for the requested versions and all task types (task reachability is not reported
              per task type).
           schema:
             type: boolean
@@ -7296,25 +7322,33 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PollerInfo'
-          description: |-
-            Deprecated. Use `versions_info.types_info.pollers` with `ENHANCED` mode instead.
-             Not set in `ENHANCED` mode.
+          description: '[DEFAULT MODE ONLY]'
         taskQueueStatus:
           allOf:
             - $ref: '#/components/schemas/TaskQueueStatus'
-          description: Deprecated. Not set in `ENHANCED` mode.
+          description: |-
+            [DEFAULT MODE ONLY]
+             Deprecated.
+             Status of the task queue. Only populated when `include_task_queue_status` is set to true in the request.
+        taskQueueStats:
+          allOf:
+            - $ref: '#/components/schemas/TaskQueueStats'
+          description: |-
+            [DEFAULT MODE ONLY]
+             Statistics for the task queue. Only populated when `report_stats` is set to true in the request.
         versionsInfo:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/TaskQueueVersionInfo'
           description: |-
-            This map contains Task Queue information for each Build ID. Empty string as key value means unversioned.
-             Only set in `ENHANCED` mode.
+            [ENHANCED MODE ONLY]
+             This map contains Task Queue information for each Build ID. Empty string as key value means unversioned.
         versioningInfo:
           allOf:
             - $ref: '#/components/schemas/TaskQueueVersioningInfo'
           description: |-
-            Specifies which Worker Deployment Version(s) Server routes this Task Queue's tasks to.
+            [ENHANCED MODE ONLY]
+             Specifies which Worker Deployment Version(s) Server routes this Task Queue's tasks to.
              When not present, it means the tasks are routed to Unversioned workers (workers with
              UNVERSIONED or unspecified WorkerVersioningMode.)
              Task Queue Versioning info is updated indirectly by calling SetWorkerDeploymentCurrentVersion

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -1444,6 +1444,7 @@ paths:
           in: query
           description: |-
             [DEFAULT MODE ONLY]
+             Deprecated.
              If true, the task queue status will be included in the response.
              In ENHANCED mode, use `report_stats` instead.
           schema:
@@ -4627,6 +4628,7 @@ paths:
           in: query
           description: |-
             [DEFAULT MODE ONLY]
+             Deprecated.
              If true, the task queue status will be included in the response.
              In ENHANCED mode, use `report_stats` instead.
           schema:
@@ -7347,7 +7349,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/TaskQueueVersioningInfo'
           description: |-
-            [ENHANCED MODE ONLY]
+            [DEFAULT MODE ONLY]
              Specifies which Worker Deployment Version(s) Server routes this Task Queue's tasks to.
              When not present, it means the tasks are routed to Unversioned workers (workers with
              UNVERSIONED or unspecified WorkerVersioningMode.)

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -1428,16 +1428,16 @@ paths:
               - TASK_QUEUE_TYPE_NEXUS
             type: string
             format: enum
+        - name: reportStats
+          in: query
+          description: Report stats for the requested task queue type(s).
+          schema:
+            type: boolean
         - name: includeTaskQueueStatus
           in: query
           description: |-
             Deprecated, use `report_stats` instead.
              If true, the task queue status will be included in the response.
-          schema:
-            type: boolean
-        - name: reportStats
-          in: query
-          description: Report stats for the requested task queue type(s).
           schema:
             type: boolean
         - name: apiMode
@@ -4608,16 +4608,16 @@ paths:
               - TASK_QUEUE_TYPE_NEXUS
             type: string
             format: enum
+        - name: reportStats
+          in: query
+          description: Report stats for the requested task queue type(s).
+          schema:
+            type: boolean
         - name: includeTaskQueueStatus
           in: query
           description: |-
             Deprecated, use `report_stats` instead.
              If true, the task queue status will be included in the response.
-          schema:
-            type: boolean
-        - name: reportStats
-          in: query
-          description: Report stats for the requested task queue type(s).
           schema:
             type: boolean
         - name: apiMode
@@ -7316,7 +7316,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PollerInfo'
-        taskQueueStats:
+        stats:
           allOf:
             - $ref: '#/components/schemas/TaskQueueStats'
           description: Statistics for the task queue. Only populated when `report_stats` is set to true in the request.

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1033,7 +1033,7 @@ message DescribeWorkflowExecutionResponse {
 message DescribeTaskQueueRequest {
     string namespace = 1;
 
-    // However, sticky queues are not supported in ENHANCED mode.
+    // Sticky queues are not supported in deprecated ENHANCED mode.
     temporal.api.taskqueue.v1.TaskQueue task_queue = 2;
 
     // If unspecified (TASK_QUEUE_TYPE_UNSPECIFIED), then default value (TASK_QUEUE_TYPE_WORKFLOW) will be used.

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1032,45 +1032,68 @@ message DescribeWorkflowExecutionResponse {
 //     aip.dev/not-precedent: field_behavior annotation not available in our gogo fork --)
 message DescribeTaskQueueRequest {
     string namespace = 1;
-    // Sticky queues are not supported in `ENHANCED` mode.
-    temporal.api.taskqueue.v1.TaskQueue task_queue = 2;
-    // Deprecated. Use `ENHANCED` mode with `task_queue_types`. Ignored in `ENHANCED` mode.
-    // If unspecified (TASK_QUEUE_TYPE_UNSPECIFIED), then default value (TASK_QUEUE_TYPE_WORKFLOW) will be used.
-    temporal.api.enums.v1.TaskQueueType task_queue_type = 3 [deprecated = true];
-    // Deprecated. Ignored in `ENHANCED` mode.
-    bool include_task_queue_status = 4 [deprecated = true];
 
-    // All options except `task_queue_type` and `include_task_queue_status` are only available in the `ENHANCED` mode.
+    // Select the API mode to use for this request: DEFAULT mode (if unset) or ENHANCED mode.
+    // Consult the documentation for each field to understand which mode it is supported in.
     temporal.api.enums.v1.DescribeTaskQueueMode api_mode = 5;
 
+    // [BOTH MODES]
+    // However, sticky queues are not supported in ENHANCED mode.
+    temporal.api.taskqueue.v1.TaskQueue task_queue = 2;
+
+    // [DEFAULT MODE ONLY]
+    // If unspecified (TASK_QUEUE_TYPE_UNSPECIFIED), then default value (TASK_QUEUE_TYPE_WORKFLOW) will be used.
+    // Only supported in default mode (use `task_queue_types` in ENHANCED mode instead).
+    temporal.api.enums.v1.TaskQueueType task_queue_type = 3;
+
+    // [DEFAULT MODE ONLY]
+    // If true, the task queue status will be included in the response.
+    // In ENHANCED mode, use `report_stats` instead.
+    bool include_task_queue_status = 4;
+
+    // [ENHANCED MODE ONLY]
     // Optional. If not provided, the result for the default Build ID will be returned. The default Build ID is the one
     // mentioned in the first unconditional Assignment Rule. If there is no default Build ID, the result for the
     // unversioned queue will be returned.
     // (-- api-linter: core::0140::prepositions --)
     temporal.api.taskqueue.v1.TaskQueueVersionSelection versions = 6;
 
+    // [ENHANCED MODE ONLY]
     // Task queue types to report info about. If not specified, all types are considered.
     repeated temporal.api.enums.v1.TaskQueueType task_queue_types = 7;
-    // Report stats for the requested task queue types and versions
+
+    // [BOTH MODES]
+    // Report stats for the requested task queue type(s), and versions (only in ENHANCED mode).
     bool report_stats = 8;
-    // Report list of pollers for requested task queue types and versions
+
+    // [ENHANCED MODE ONLY]
+    // Report list of pollers for requested task queue types and versions.
     bool report_pollers = 9;
+
+    // [ENHANCED MODE ONLY]
     // Report task reachability for the requested versions and all task types (task reachability is not reported
     // per task type).
     bool report_task_reachability = 10;
 }
 
 message DescribeTaskQueueResponse {
-    // Deprecated. Use `versions_info.types_info.pollers` with `ENHANCED` mode instead.
-    // Not set in `ENHANCED` mode.
-    repeated temporal.api.taskqueue.v1.PollerInfo pollers = 1 [deprecated = true];
-    // Deprecated. Not set in `ENHANCED` mode.
+    // [DEFAULT MODE ONLY]
+    repeated temporal.api.taskqueue.v1.PollerInfo pollers = 1;
+
+    // [DEFAULT MODE ONLY]
+    // Deprecated.
+    // Status of the task queue. Only populated when `include_task_queue_status` is set to true in the request.
     temporal.api.taskqueue.v1.TaskQueueStatus task_queue_status = 2 [deprecated = true];
 
+    // [DEFAULT MODE ONLY]
+    // Statistics for the task queue. Only populated when `report_stats` is set to true in the request.
+    temporal.api.taskqueue.v1.TaskQueueStats task_queue_stats = 5;
+
+    // [ENHANCED MODE ONLY]
     // This map contains Task Queue information for each Build ID. Empty string as key value means unversioned.
-    // Only set in `ENHANCED` mode.
     map<string, temporal.api.taskqueue.v1.TaskQueueVersionInfo> versions_info = 3;
 
+    // [ENHANCED MODE ONLY]
     // Specifies which Worker Deployment Version(s) Server routes this Task Queue's tasks to.
     // When not present, it means the tasks are routed to Unversioned workers (workers with
     // UNVERSIONED or unspecified WorkerVersioningMode.)

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1094,7 +1094,7 @@ message DescribeTaskQueueResponse {
     // This map contains Task Queue information for each Build ID. Empty string as key value means unversioned.
     map<string, temporal.api.taskqueue.v1.TaskQueueVersionInfo> versions_info = 3;
 
-    // [ENHANCED MODE ONLY]
+    // [DEFAULT MODE ONLY]
     // Specifies which Worker Deployment Version(s) Server routes this Task Queue's tasks to.
     // When not present, it means the tasks are routed to Unversioned workers (workers with
     // UNVERSIONED or unspecified WorkerVersioningMode.)

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1077,7 +1077,7 @@ message DescribeTaskQueueResponse {
     repeated temporal.api.taskqueue.v1.PollerInfo pollers = 1;
 
     // Statistics for the task queue. Only populated when `report_stats` is set to true in the request.
-    temporal.api.taskqueue.v1.TaskQueueStats task_queue_stats = 5;
+    temporal.api.taskqueue.v1.TaskQueueStats stats = 5;
 
     // Specifies which Worker Deployment Version(s) Server routes this Task Queue's tasks to.
     // When not present, it means the tasks are routed to Unversioned workers (workers with

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1036,7 +1036,7 @@ message DescribeTaskQueueRequest {
     // Deprecated. ENHANCED mode is also being deprecated.
     // Select the API mode to use for this request: DEFAULT mode (if unset) or ENHANCED mode.
     // Consult the documentation for each field to understand which mode it is supported in.
-    temporal.api.enums.v1.DescribeTaskQueueMode api_mode = 5 [deprecated = true];;
+    temporal.api.enums.v1.DescribeTaskQueueMode api_mode = 5 [deprecated = true];
 
     // [BOTH MODES]
     // However, sticky queues are not supported in ENHANCED mode.

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1047,9 +1047,10 @@ message DescribeTaskQueueRequest {
     temporal.api.enums.v1.TaskQueueType task_queue_type = 3;
 
     // [DEFAULT MODE ONLY]
+    // Deprecated.
     // If true, the task queue status will be included in the response.
     // In ENHANCED mode, use `report_stats` instead.
-    bool include_task_queue_status = 4;
+    bool include_task_queue_status = 4 [deprecated = true];
 
     // [ENHANCED MODE ONLY]
     // Optional. If not provided, the result for the default Build ID will be returned. The default Build ID is the one

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1033,9 +1033,10 @@ message DescribeWorkflowExecutionResponse {
 message DescribeTaskQueueRequest {
     string namespace = 1;
 
+    // Deprecated. ENHANCED mode is also being deprecated.
     // Select the API mode to use for this request: DEFAULT mode (if unset) or ENHANCED mode.
     // Consult the documentation for each field to understand which mode it is supported in.
-    temporal.api.enums.v1.DescribeTaskQueueMode api_mode = 5;
+    temporal.api.enums.v1.DescribeTaskQueueMode api_mode = 5 [deprecated = true];;
 
     // [BOTH MODES]
     // However, sticky queues are not supported in ENHANCED mode.
@@ -1047,34 +1048,36 @@ message DescribeTaskQueueRequest {
     temporal.api.enums.v1.TaskQueueType task_queue_type = 3;
 
     // [DEFAULT MODE ONLY]
-    // Deprecated.
+    // Deprecated, use `report_stats` instead.
     // If true, the task queue status will be included in the response.
-    // In ENHANCED mode, use `report_stats` instead.
     bool include_task_queue_status = 4 [deprecated = true];
 
     // [ENHANCED MODE ONLY]
+    // Deprecated.
     // Optional. If not provided, the result for the default Build ID will be returned. The default Build ID is the one
     // mentioned in the first unconditional Assignment Rule. If there is no default Build ID, the result for the
     // unversioned queue will be returned.
     // (-- api-linter: core::0140::prepositions --)
-    temporal.api.taskqueue.v1.TaskQueueVersionSelection versions = 6;
+    temporal.api.taskqueue.v1.TaskQueueVersionSelection versions = 6 [deprecated = true];
 
     // [ENHANCED MODE ONLY]
     // Task queue types to report info about. If not specified, all types are considered.
-    repeated temporal.api.enums.v1.TaskQueueType task_queue_types = 7;
+    repeated temporal.api.enums.v1.TaskQueueType task_queue_types = 7 [deprecated = true];
 
     // [BOTH MODES]
     // Report stats for the requested task queue type(s), and versions (only in ENHANCED mode).
     bool report_stats = 8;
 
     // [ENHANCED MODE ONLY]
+    // Deprecated.
     // Report list of pollers for requested task queue types and versions.
-    bool report_pollers = 9;
+    bool report_pollers = 9 [deprecated = true];
 
     // [ENHANCED MODE ONLY]
+    // Deprecated.
     // Report task reachability for the requested versions and all task types (task reachability is not reported
     // per task type).
-    bool report_task_reachability = 10;
+    bool report_task_reachability = 10 [deprecated = true];
 }
 
 message DescribeTaskQueueResponse {
@@ -1091,8 +1094,9 @@ message DescribeTaskQueueResponse {
     temporal.api.taskqueue.v1.TaskQueueStats task_queue_stats = 5;
 
     // [ENHANCED MODE ONLY]
+    // Deprecated.
     // This map contains Task Queue information for each Build ID. Empty string as key value means unversioned.
-    map<string, temporal.api.taskqueue.v1.TaskQueueVersionInfo> versions_info = 3;
+    map<string, temporal.api.taskqueue.v1.TaskQueueVersionInfo> versions_info = 3 [deprecated = true];
 
     // [DEFAULT MODE ONLY]
     // Specifies which Worker Deployment Version(s) Server routes this Task Queue's tasks to.

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1033,72 +1033,52 @@ message DescribeWorkflowExecutionResponse {
 message DescribeTaskQueueRequest {
     string namespace = 1;
 
+    // However, sticky queues are not supported in ENHANCED mode.
+    temporal.api.taskqueue.v1.TaskQueue task_queue = 2;
+
+    // If unspecified (TASK_QUEUE_TYPE_UNSPECIFIED), then default value (TASK_QUEUE_TYPE_WORKFLOW) will be used.
+    // Only supported in default mode (use `task_queue_types` in ENHANCED mode instead).
+    temporal.api.enums.v1.TaskQueueType task_queue_type = 3;
+
+    // Deprecated, use `report_stats` instead.
+    // If true, the task queue status will be included in the response.
+    bool include_task_queue_status = 4 [deprecated = true];
+
+    // Report stats for the requested task queue type(s).
+    bool report_stats = 8;
+
     // Deprecated. ENHANCED mode is also being deprecated.
     // Select the API mode to use for this request: DEFAULT mode (if unset) or ENHANCED mode.
     // Consult the documentation for each field to understand which mode it is supported in.
     temporal.api.enums.v1.DescribeTaskQueueMode api_mode = 5 [deprecated = true];
 
-    // [BOTH MODES]
-    // However, sticky queues are not supported in ENHANCED mode.
-    temporal.api.taskqueue.v1.TaskQueue task_queue = 2;
-
-    // [DEFAULT MODE ONLY]
-    // If unspecified (TASK_QUEUE_TYPE_UNSPECIFIED), then default value (TASK_QUEUE_TYPE_WORKFLOW) will be used.
-    // Only supported in default mode (use `task_queue_types` in ENHANCED mode instead).
-    temporal.api.enums.v1.TaskQueueType task_queue_type = 3;
-
-    // [DEFAULT MODE ONLY]
-    // Deprecated, use `report_stats` instead.
-    // If true, the task queue status will be included in the response.
-    bool include_task_queue_status = 4 [deprecated = true];
-
-    // [ENHANCED MODE ONLY]
-    // Deprecated.
+    // Deprecated (as part of the ENHANCED mode deprecation).
     // Optional. If not provided, the result for the default Build ID will be returned. The default Build ID is the one
     // mentioned in the first unconditional Assignment Rule. If there is no default Build ID, the result for the
     // unversioned queue will be returned.
     // (-- api-linter: core::0140::prepositions --)
     temporal.api.taskqueue.v1.TaskQueueVersionSelection versions = 6 [deprecated = true];
 
-    // [ENHANCED MODE ONLY]
+    // Deprecated (as part of the ENHANCED mode deprecation).
     // Task queue types to report info about. If not specified, all types are considered.
     repeated temporal.api.enums.v1.TaskQueueType task_queue_types = 7 [deprecated = true];
 
-    // [BOTH MODES]
-    // Report stats for the requested task queue type(s), and versions (only in ENHANCED mode).
-    bool report_stats = 8;
-
-    // [ENHANCED MODE ONLY]
-    // Deprecated.
+    // Deprecated (as part of the ENHANCED mode deprecation).
     // Report list of pollers for requested task queue types and versions.
     bool report_pollers = 9 [deprecated = true];
 
-    // [ENHANCED MODE ONLY]
-    // Deprecated.
+    // Deprecated (as part of the ENHANCED mode deprecation).
     // Report task reachability for the requested versions and all task types (task reachability is not reported
     // per task type).
     bool report_task_reachability = 10 [deprecated = true];
 }
 
 message DescribeTaskQueueResponse {
-    // [DEFAULT MODE ONLY]
     repeated temporal.api.taskqueue.v1.PollerInfo pollers = 1;
 
-    // [DEFAULT MODE ONLY]
-    // Deprecated.
-    // Status of the task queue. Only populated when `include_task_queue_status` is set to true in the request.
-    temporal.api.taskqueue.v1.TaskQueueStatus task_queue_status = 2 [deprecated = true];
-
-    // [DEFAULT MODE ONLY]
     // Statistics for the task queue. Only populated when `report_stats` is set to true in the request.
     temporal.api.taskqueue.v1.TaskQueueStats task_queue_stats = 5;
 
-    // [ENHANCED MODE ONLY]
-    // Deprecated.
-    // This map contains Task Queue information for each Build ID. Empty string as key value means unversioned.
-    map<string, temporal.api.taskqueue.v1.TaskQueueVersionInfo> versions_info = 3 [deprecated = true];
-
-    // [DEFAULT MODE ONLY]
     // Specifies which Worker Deployment Version(s) Server routes this Task Queue's tasks to.
     // When not present, it means the tasks are routed to Unversioned workers (workers with
     // UNVERSIONED or unspecified WorkerVersioningMode.)
@@ -1109,6 +1089,15 @@ message DescribeTaskQueueResponse {
     // are typically not Pinned until they complete their first task (unless they are started with
     // a Pinned VersioningOverride or are Child Workflows of a Pinned parent).
     temporal.api.taskqueue.v1.TaskQueueVersioningInfo versioning_info = 4;
+
+    // Deprecated.
+    // Status of the task queue. Only populated when `include_task_queue_status` is set to true in the request.
+    temporal.api.taskqueue.v1.TaskQueueStatus task_queue_status = 2 [deprecated = true];
+
+    // Deprecated.
+    // Only returned in ENHANCED mode.
+    // This map contains Task Queue information for each Build ID. Empty string as key value means unversioned.
+    map<string, temporal.api.taskqueue.v1.TaskQueueVersionInfo> versions_info = 3 [deprecated = true];
 }
 
 message GetClusterInfoRequest {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1040,12 +1040,12 @@ message DescribeTaskQueueRequest {
     // Only supported in default mode (use `task_queue_types` in ENHANCED mode instead).
     temporal.api.enums.v1.TaskQueueType task_queue_type = 3;
 
+    // Report stats for the requested task queue type(s).
+    bool report_stats = 8;
+
     // Deprecated, use `report_stats` instead.
     // If true, the task queue status will be included in the response.
     bool include_task_queue_status = 4 [deprecated = true];
-
-    // Report stats for the requested task queue type(s).
-    bool report_stats = 8;
 
     // Deprecated. ENHANCED mode is also being deprecated.
     // Select the API mode to use for this request: DEFAULT mode (if unset) or ENHANCED mode.


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**

Added `TaskQueueStats` field to `DescribeTaskQueueResponse`.

<!-- Tell your future self why have you made these changes -->
**Why?**

To provide non-versioning users with relevant task queue stats.

PS: The long-term plan is to deprecate the ENHANCED mod fields.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**

N/A

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**

https://github.com/temporalio/temporal/pull/7816