### PR TITLE
add client identity to update-metadata request

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -8275,6 +8275,10 @@
             "type": "string"
           },
           "description": "List of keys to remove from the metadata."
+        },
+        "identity": {
+          "type": "string",
+          "description": "Optional. The identity of the client who initiated this request."
         }
       },
       "description": "Used to update the user-defined metadata of a Worker Deployment Version."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -11944,6 +11944,9 @@ components:
           items:
             type: string
           description: List of keys to remove from the metadata.
+        identity:
+          type: string
+          description: Optional. The identity of the client who initiated this request.
       description: Used to update the user-defined metadata of a Worker Deployment Version.
     UpdateWorkerDeploymentVersionMetadataResponse:
       type: object

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2212,6 +2212,8 @@ message UpdateWorkerDeploymentVersionMetadataRequest {
     map<string, temporal.api.common.v1.Payload> upsert_entries = 3;
     // List of keys to remove from the metadata.
     repeated string remove_entries = 4;
+    // Optional. The identity of the client who initiated this request.
+    string identity = 6;
 }
 
 message UpdateWorkerDeploymentVersionMetadataResponse {


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
add client identity to update-metadata request

<!-- Tell your future self why have you made these changes -->
on the server side we generate a uuid identity. would be nice to allow user to specify it instead

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
