### PR TITLE
Add Stats to DescribeWorkerDeploymentVersion

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -1780,7 +1780,7 @@
           },
           {
             "name": "reportTaskQueueStats",
-            "description": "Report stats for version's task queues.",
+            "description": "Report stats for task queues which have been polled by this version.",
             "in": "query",
             "required": false,
             "type": "boolean"
@@ -5388,7 +5388,7 @@
           },
           {
             "name": "reportTaskQueueStats",
-            "description": "Report stats for version's task queues.",
+            "description": "Report stats for task queues which have been polled by this version.",
             "in": "query",
             "required": false,
             "type": "boolean"

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -6918,6 +6918,20 @@
         }
       }
     },
+    "DescribeWorkerDeploymentVersionResponseVersionTaskQueue": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/v1TaskQueueType"
+        },
+        "stats": {
+          "$ref": "#/definitions/v1TaskQueueStats"
+        }
+      }
+    },
     "EndpointTargetExternal": {
       "type": "object",
       "properties": {
@@ -10326,6 +10340,14 @@
       "properties": {
         "workerDeploymentVersionInfo": {
           "$ref": "#/definitions/v1WorkerDeploymentVersionInfo"
+        },
+        "versionTaskQueues": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/DescribeWorkerDeploymentVersionResponseVersionTaskQueue"
+          },
+          "description": "All the Task Queues that have ever polled from this Deployment version."
         }
       }
     },
@@ -15252,7 +15274,7 @@
             "type": "object",
             "$ref": "#/definitions/WorkerDeploymentVersionInfoVersionTaskQueueInfo"
           },
-          "description": "All the Task Queues that have ever polled from this Deployment version."
+          "description": "All the Task Queues that have ever polled from this Deployment version.\nDeprecated. Use `version_task_queues` in DescribeWorkerDeploymentVersionResponse instead."
         },
         "drainageInfo": {
           "$ref": "#/definitions/v1VersionDrainageInfo",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -1777,6 +1777,13 @@
             "in": "query",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "reportTaskQueueStats",
+            "description": "Report stats for version's task queues.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "tags": [
@@ -5378,6 +5385,13 @@
             "in": "query",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "reportTaskQueueStats",
+            "description": "Report stats for version's task queues.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "tags": [
@@ -6928,7 +6942,8 @@
           "$ref": "#/definitions/v1TaskQueueType"
         },
         "stats": {
-          "$ref": "#/definitions/v1TaskQueueStats"
+          "$ref": "#/definitions/v1TaskQueueStats",
+          "description": "Only set if `report_task_queue_stats` is set on the request."
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -1590,6 +1590,11 @@ paths:
           description: Identifies the Worker Deployment this Version is part of.
           schema:
             type: string
+        - name: reportTaskQueueStats
+          in: query
+          description: Report stats for version's task queues.
+          schema:
+            type: boolean
       responses:
         "200":
           description: OK
@@ -4823,6 +4828,11 @@ paths:
           description: Identifies the Worker Deployment this Version is part of.
           schema:
             type: string
+        - name: reportTaskQueueStats
+          in: query
+          description: Report stats for version's task queues.
+          schema:
+            type: boolean
       responses:
         "200":
           description: OK
@@ -7555,7 +7565,9 @@ components:
           type: string
           format: enum
         stats:
-          $ref: '#/components/schemas/TaskQueueStats'
+          allOf:
+            - $ref: '#/components/schemas/TaskQueueStats'
+          description: Only set if `report_task_queue_stats` is set on the request.
     DescribeWorkflowExecutionResponse:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -1592,7 +1592,7 @@ paths:
             type: string
         - name: reportTaskQueueStats
           in: query
-          description: Report stats for version's task queues.
+          description: Report stats for task queues which have been polled by this version.
           schema:
             type: boolean
       responses:
@@ -4830,7 +4830,7 @@ paths:
             type: string
         - name: reportTaskQueueStats
           in: query
-          description: Report stats for version's task queues.
+          description: Report stats for task queues which have been polled by this version.
           schema:
             type: boolean
       responses:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -7536,6 +7536,26 @@ components:
       properties:
         workerDeploymentVersionInfo:
           $ref: '#/components/schemas/WorkerDeploymentVersionInfo'
+        versionTaskQueues:
+          type: array
+          items:
+            $ref: '#/components/schemas/DescribeWorkerDeploymentVersionResponse_VersionTaskQueue'
+          description: All the Task Queues that have ever polled from this Deployment version.
+    DescribeWorkerDeploymentVersionResponse_VersionTaskQueue:
+      type: object
+      properties:
+        name:
+          type: string
+        type:
+          enum:
+            - TASK_QUEUE_TYPE_UNSPECIFIED
+            - TASK_QUEUE_TYPE_WORKFLOW
+            - TASK_QUEUE_TYPE_ACTIVITY
+            - TASK_QUEUE_TYPE_NEXUS
+          type: string
+          format: enum
+        stats:
+          $ref: '#/components/schemas/TaskQueueStats'
     DescribeWorkflowExecutionResponse:
       type: object
       properties:
@@ -12637,7 +12657,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/WorkerDeploymentVersionInfo_VersionTaskQueueInfo'
-          description: All the Task Queues that have ever polled from this Deployment version.
+          description: |-
+            All the Task Queues that have ever polled from this Deployment version.
+             Deprecated. Use `version_task_queues` in DescribeWorkerDeploymentVersionResponse instead.
         drainageInfo:
           allOf:
             - $ref: '#/components/schemas/VersionDrainageInfo'

--- a/temporal/api/deployment/v1/message.proto
+++ b/temporal/api/deployment/v1/message.proto
@@ -128,6 +128,7 @@ message WorkerDeploymentVersionInfo {
     float ramp_percentage = 7;
 
     // All the Task Queues that have ever polled from this Deployment version.
+    // Deprecated. Use `version_task_queues` in DescribeWorkerDeploymentVersionResponse instead.
     repeated VersionTaskQueueInfo task_queue_infos = 8;
     message VersionTaskQueueInfo {
         string name = 1;

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2030,6 +2030,15 @@ message DescribeWorkerDeploymentVersionRequest {
 
 message DescribeWorkerDeploymentVersionResponse {
     temporal.api.deployment.v1.WorkerDeploymentVersionInfo worker_deployment_version_info = 1;
+
+    // All the Task Queues that have ever polled from this Deployment version.
+    repeated VersionTaskQueue version_task_queues = 2;
+    // (-- api-linter: core::0123::resource-annotation=disabled --)
+    message VersionTaskQueue {
+        string name = 1;
+        temporal.api.enums.v1.TaskQueueType type = 2;
+        temporal.api.taskqueue.v1.TaskQueueStats stats = 3;
+    }
 }
 
 message DescribeWorkerDeploymentRequest {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2026,7 +2026,7 @@ message DescribeWorkerDeploymentVersionRequest {
     string version = 2 [deprecated = true];
     // Required.
     temporal.api.deployment.v1.WorkerDeploymentVersion deployment_version = 3;
-    // Report stats for version's task queues.
+    // Report stats for task queues which have been polled by this version.
     bool report_task_queue_stats = 4;
 }
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2026,6 +2026,8 @@ message DescribeWorkerDeploymentVersionRequest {
     string version = 2 [deprecated = true];
     // Required.
     temporal.api.deployment.v1.WorkerDeploymentVersion deployment_version = 3;
+    // Report stats for version's task queues.
+    bool report_task_queue_stats = 4;
 }
 
 message DescribeWorkerDeploymentVersionResponse {
@@ -2037,6 +2039,7 @@ message DescribeWorkerDeploymentVersionResponse {
     message VersionTaskQueue {
         string name = 1;
         temporal.api.enums.v1.TaskQueueType type = 2;
+        // Only set if `report_task_queue_stats` is set on the request.
         temporal.api.taskqueue.v1.TaskQueueStats stats = 3;
     }
 }


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**

(1) Deprecated `task_queue_infos` in `deployment.WorkerDeploymentVersionInfo`.
(2) Added `version_task_queues` to `DescribeWorkerDeploymentVersionResponse`.

<!-- Tell your future self why have you made these changes -->
**Why?**

We want to report task queue stats for each task queue that is part of a worker deployment version.

The challenge is that the `taskqueue` package depends on the `deployment` package. So adding `TaskQueueStats` to `deployment.WorkerDeploymentVersionInfo` causes a cycle import error.

Weighing our options, we decided to effectively _move_ the task queue-related data from within the deployment package into the response message.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**

Not yet; but in subsequent releases the deprecated field `task_queue_infos` will be removed.

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**

https://github.com/temporalio/temporal/pull/7959 (draft)