### PR TITLE
bug: add timestamp to TriggerImmediatelyRequest

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -14748,6 +14748,11 @@
         "overlapPolicy": {
           "$ref": "#/definitions/v1ScheduleOverlapPolicy",
           "description": "If set, override overlap policy for this one request."
+        },
+        "triggerTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp for when this request should be triggered."
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -11907,6 +11907,10 @@ components:
           type: string
           description: If set, override overlap policy for this one request.
           format: enum
+        triggerTime:
+          type: string
+          description: Timestamp for when this request should be triggered.
+          format: date-time
     TriggerWorkflowRuleRequest:
       type: object
       properties:

--- a/temporal/api/schedule/v1/message.proto
+++ b/temporal/api/schedule/v1/message.proto
@@ -278,6 +278,9 @@ message ScheduleState {
 message TriggerImmediatelyRequest {
     // If set, override overlap policy for this one request.
     temporal.api.enums.v1.ScheduleOverlapPolicy overlap_policy = 1;
+    
+    // Timestamp for when this request should be triggered.
+    google.protobuf.Timestamp trigger_time = 2;
 }
 
 message BackfillRequest {


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
adding a timestamp to `TriggerImmediatelyRequest` message

<!-- Tell your future self why have you made these changes -->
We can make the wft “more idempotent”: put the desired trigger time in the trigger immediately request itself, so it goes in the signal payload, so all wfts attempt to start the target with the same id.


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
[**Server PR**](https://github.com/temporalio/temporal/pull/7968)
