### PR TITLE
Add process key, make heartbeats repeatable field

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -13,8 +13,8 @@ breaking:
     - WIRE_JSON
   ignore:
     - google
-    # TODO (yuri) remove this
-    - temporal/api/workflow/v1/message.proto
+    # TODO (yuri) remove this. Added for "heartbeat" change (add
+    - temporal/api/workflowservice/v1/request_response.proto
 lint:
   use:
     - DEFAULT

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -15416,11 +15416,11 @@
         },
         "processKey": {
           "type": "string",
-          "title": "Worker process identifier, should be unique across the fleet.\nIt is to disambiguate processed with the same id.\nUsed to build worker command task queue name:\nf\"temporal-sys/worker-commands/{process_key}\""
+          "title": "Worker process identifier. This id should be unique for all _processes_\nrunning workers in the namespace, and should be shared by all workers\nin the same process.\nThis will be used to build the worker command nexus task queue name:\n\"temporal-sys/worker-commands/{process_key}\""
         },
         "processId": {
           "type": "string",
-          "description": "Worker process identifier, should be unique for the host."
+          "description": "Worker process identifier. Unlike process_key, this id only needs to be unique\nwithin one host (so using e.g. a unix pid would be appropriate)."
         },
         "currentHostCpuUsage": {
           "type": "number",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -7605,7 +7605,7 @@
           "type": "string",
           "description": "The identity of the client who initiated this request."
         },
-        "workerHeartbeats": {
+        "workerHeartbeat": {
           "type": "array",
           "items": {
             "type": "object",
@@ -15416,7 +15416,7 @@
         },
         "processKey": {
           "type": "string",
-          "title": "Worker process identifier, should be unique across the fleet.\nIt is to disambiguate processed with the same id.\nUsed to build worker command task queue name:\nf\"sys/worker/command/{process_key}/\""
+          "title": "Worker process identifier, should be unique across the fleet.\nIt is to disambiguate processed with the same id.\nUsed to build worker command task queue name:\nf\"temporal-sys/worker-commands/{process_key}\""
         },
         "processId": {
           "type": "string",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -7605,8 +7605,12 @@
           "type": "string",
           "description": "The identity of the client who initiated this request."
         },
-        "workerHeartbeat": {
-          "$ref": "#/definitions/v1WorkerHeartbeat"
+        "workerHeartbeats": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1WorkerHeartbeat"
+          }
         }
       }
     },
@@ -15409,6 +15413,10 @@
         "hostName": {
           "type": "string",
           "description": "Worker host identifier."
+        },
+        "processKey": {
+          "type": "string",
+          "title": "Worker process identifier, should be unique across the fleet.\nIt is to disambiguate processed with the same id.\nUsed to build worker command task queue name:\nf\"sys/worker/command/{process_key}/\""
         },
         "processId": {
           "type": "string",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9722,7 +9722,7 @@ components:
         identity:
           type: string
           description: The identity of the client who initiated this request.
-        workerHeartbeats:
+        workerHeartbeat:
           type: array
           items:
             $ref: '#/components/schemas/WorkerHeartbeat'
@@ -12805,7 +12805,7 @@ components:
             Worker process identifier, should be unique across the fleet.
              It is to disambiguate processed with the same id.
              Used to build worker command task queue name:
-             f"sys/worker/command/{process_key}/"
+             f"temporal-sys/worker-commands/{process_key}"
         processId:
           type: string
           description: Worker process identifier, should be unique for the host.

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9722,8 +9722,10 @@ components:
         identity:
           type: string
           description: The identity of the client who initiated this request.
-        workerHeartbeat:
-          $ref: '#/components/schemas/WorkerHeartbeat'
+        workerHeartbeats:
+          type: array
+          items:
+            $ref: '#/components/schemas/WorkerHeartbeat'
     RecordWorkerHeartbeatResponse:
       type: object
       properties: {}
@@ -12797,6 +12799,13 @@ components:
         hostName:
           type: string
           description: Worker host identifier.
+        processKey:
+          type: string
+          description: |-
+            Worker process identifier, should be unique across the fleet.
+             It is to disambiguate processed with the same id.
+             Used to build worker command task queue name:
+             f"sys/worker/command/{process_key}/"
         processId:
           type: string
           description: Worker process identifier, should be unique for the host.

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -12802,13 +12802,16 @@ components:
         processKey:
           type: string
           description: |-
-            Worker process identifier, should be unique across the fleet.
-             It is to disambiguate processed with the same id.
-             Used to build worker command task queue name:
-             f"temporal-sys/worker-commands/{process_key}"
+            Worker process identifier. This id should be unique for all _processes_
+             running workers in the namespace, and should be shared by all workers
+             in the same process.
+             This will be used to build the worker command nexus task queue name:
+             "temporal-sys/worker-commands/{process_key}"
         processId:
           type: string
-          description: Worker process identifier, should be unique for the host.
+          description: |-
+            Worker process identifier. Unlike process_key, this id only needs to be unique
+             within one host (so using e.g. a unix pid would be appropriate).
         currentHostCpuUsage:
           type: number
           description: |-

--- a/temporal/api/worker/v1/message.proto
+++ b/temporal/api/worker/v1/message.proto
@@ -54,13 +54,16 @@ message WorkerHostInfo {
   // Worker host identifier.
   string host_name = 1;
 
-  // Worker process identifier, should be unique across the fleet.
-  // It is to disambiguate processed with the same id.
-  // Used to build worker command task queue name:
-  // f"temporal-sys/worker-commands/{process_key}"
+
+  // Worker process identifier. This id should be unique for all _processes_
+  // running workers in the namespace, and should be shared by all workers
+  // in the same process.
+  // This will be used to build the worker command nexus task queue name:
+  // "temporal-sys/worker-commands/{process_key}"
   string process_key = 5;
 
-  // Worker process identifier, should be unique for the host.
+  // Worker process identifier. Unlike process_key, this id only needs to be unique
+  // within one host (so using e.g. a unix pid would be appropriate).
   string process_id = 2;
 
   // System used CPU as a float in the range [0.0, 1.0] where 1.0 is defined as all

--- a/temporal/api/worker/v1/message.proto
+++ b/temporal/api/worker/v1/message.proto
@@ -57,7 +57,7 @@ message WorkerHostInfo {
   // Worker process identifier, should be unique across the fleet.
   // It is to disambiguate processed with the same id.
   // Used to build worker command task queue name:
-  // f"sys/worker/command/{process_key}/"
+  // f"temporal-sys/worker-commands/{process_key}"
   string process_key = 5;
 
   // Worker process identifier, should be unique for the host.

--- a/temporal/api/worker/v1/message.proto
+++ b/temporal/api/worker/v1/message.proto
@@ -54,6 +54,12 @@ message WorkerHostInfo {
   // Worker host identifier.
   string host_name = 1;
 
+  // Worker process identifier, should be unique across the fleet.
+  // It is to disambiguate processed with the same id.
+  // Used to build worker command task queue name:
+  // f"sys/worker/command/{process_key}/"
+  string process_key = 5;
+
   // Worker process identifier, should be unique for the host.
   string process_id = 2;
 
@@ -77,7 +83,6 @@ message WorkerHeartbeat {
   // Worker identity, set by the client, may not be unique.
   // Usually host_name+(user group name)+process_id, but can be overwritten by the user.
   string worker_identity = 2;
-
 
   // Worker host information.
   WorkerHostInfo host_info = 3;

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1772,9 +1772,7 @@ message PollNexusTaskQueueRequest {
     temporal.api.deployment.v1.WorkerDeploymentOptions deployment_options = 6;
 
     // Worker info to be sent to the server.
-    reserved 7;
-    reserved "worker_heartbeat";
-    repeated temporal.api.worker.v1.WorkerHeartbeat worker_heartbeats = 8;
+    repeated temporal.api.worker.v1.WorkerHeartbeat worker_heartbeat = 7;
 }
 
 message PollNexusTaskQueueResponse {
@@ -2386,9 +2384,7 @@ message RecordWorkerHeartbeatRequest {
     // The identity of the client who initiated this request.
     string identity = 2;
 
-    reserved 3;
-    reserved "worker_heartbeat";
-    repeated temporal.api.worker.v1.WorkerHeartbeat worker_heartbeats = 4;
+    repeated temporal.api.worker.v1.WorkerHeartbeat worker_heartbeat = 3;
 }
 
 message RecordWorkerHeartbeatResponse {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1772,7 +1772,9 @@ message PollNexusTaskQueueRequest {
     temporal.api.deployment.v1.WorkerDeploymentOptions deployment_options = 6;
 
     // Worker info to be sent to the server.
-    temporal.api.worker.v1.WorkerHeartbeat worker_heartbeat = 7;
+    reserved 7;
+    reserved "worker_heartbeat";
+    repeated temporal.api.worker.v1.WorkerHeartbeat worker_heartbeats = 8;
 }
 
 message PollNexusTaskQueueResponse {
@@ -2384,7 +2386,9 @@ message RecordWorkerHeartbeatRequest {
     // The identity of the client who initiated this request.
     string identity = 2;
 
-    temporal.api.worker.v1.WorkerHeartbeat worker_heartbeat = 3;
+    reserved 3;
+    reserved "worker_heartbeat";
+    repeated temporal.api.worker.v1.WorkerHeartbeat worker_heartbeats = 4;
 }
 
 message RecordWorkerHeartbeatResponse {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Add "process_key" to the worker host info.
Make "worker_heartbeat" repeatable in "PollNexus" and "RecordHeartbeat" APIs.

<!-- Tell your future self why have you made these changes -->
**Why?**

We decide to have a single Q per process. Thus we need a way to agree on task queue name, and for that we need this information to be:
* available as a part of heartbeat
* unique across at least namespace
Process ID is not unique.

Since we send all heartbeats at once - we make them repeated.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
Not yet.