### PR TITLE
Add request_id to CallbackInfo

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -9623,6 +9623,10 @@
         "blockedReason": {
           "type": "string",
           "description": "If the state is BLOCKED, blocked reason provides additional information."
+        },
+        "requestId": {
+          "type": "string",
+          "description": "RequestId of the request that attached the callback to the workflow."
         }
       },
       "description": "CallbackInfo contains the state of an attached workflow callback."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -6966,6 +6966,9 @@ components:
         blockedReason:
           type: string
           description: If the state is BLOCKED, blocked reason provides additional information.
+        requestId:
+          type: string
+          description: RequestId of the request that attached the callback to the workflow.
       description: CallbackInfo contains the state of an attached workflow callback.
     CallbackInfo_Trigger:
       type: object

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -452,6 +452,8 @@ message CallbackInfo {
 
     // If the state is BLOCKED, blocked reason provides additional information.
     string blocked_reason = 9;
+    // RequestId of the request that attached the callback to the workflow.
+    string request_id = 10;
 }
 
 // PendingNexusOperationInfo contains the state of a pending Nexus operation.


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
Add `request_id` to `CallbackInfo`

<!-- Tell your future self why have you made these changes -->
**Why?**
Be able to correlate the callback to the history event that added the callback.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
