### PR TITLE
Add DescribeWorker API

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -2296,6 +2296,45 @@
         ]
       }
     },
+    "/api/v1/namespaces/{namespace}/workers/describe/{workerInstanceKey}": {
+      "get": {
+        "summary": "DescribeWorker returns information about the specified worker.",
+        "operationId": "DescribeWorker2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1DescribeWorkerResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "Namespace this worker belongs to.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "workerInstanceKey",
+            "description": "Worker instance key to describe.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
     "/api/v1/namespaces/{namespace}/workers/fetch-config": {
       "post": {
         "summary": "FetchWorkerConfig returns the worker configuration for a specific worker.",
@@ -6029,6 +6068,45 @@
             "description": "`query` in ListWorkers is used to filter workers based on worker status info.\nThe following worker status attributes are expected are supported as part of the query:\n* WorkerInstanceKey\n* WorkerIdentity\n* HostName\n* TaskQueue\n* DeploymentName\n* BuildId\n* SdkName\n* SdkVersion\n* StartTime\n* LastHeartbeatTime\n* Status\nCurrently metrics are not supported as a part of ListWorkers query.",
             "in": "query",
             "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/namespaces/{namespace}/workers/describe/{workerInstanceKey}": {
+      "get": {
+        "summary": "DescribeWorker returns information about the specified worker.",
+        "operationId": "DescribeWorker",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1DescribeWorkerResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "Namespace this worker belongs to.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "workerInstanceKey",
+            "description": "Worker instance key to describe.",
+            "in": "path",
+            "required": true,
             "type": "string"
           }
         ],
@@ -10872,6 +10950,14 @@
             "$ref": "#/definitions/DescribeWorkerDeploymentVersionResponseVersionTaskQueue"
           },
           "description": "All the Task Queues that have ever polled from this Deployment version."
+        }
+      }
+    },
+    "v1DescribeWorkerResponse": {
+      "type": "object",
+      "properties": {
+        "workerInfo": {
+          "$ref": "#/definitions/v1WorkerInfo"
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -2087,6 +2087,38 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/workers/describe/{workerInstanceKey}:
+    get:
+      tags:
+        - WorkflowService
+      description: DescribeWorker returns information about the specified worker.
+      operationId: DescribeWorker
+      parameters:
+        - name: namespace
+          in: path
+          description: Namespace this worker belongs to.
+          required: true
+          schema:
+            type: string
+        - name: workerInstanceKey
+          in: path
+          description: Worker instance key to describe.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DescribeWorkerResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
   /api/v1/namespaces/{namespace}/workers/fetch-config:
     post:
       tags:
@@ -5438,6 +5470,38 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/workers/describe/{workerInstanceKey}:
+    get:
+      tags:
+        - WorkflowService
+      description: DescribeWorker returns information about the specified worker.
+      operationId: DescribeWorker
+      parameters:
+        - name: namespace
+          in: path
+          description: Namespace this worker belongs to.
+          required: true
+          schema:
+            type: string
+        - name: workerInstanceKey
+          in: path
+          description: Worker instance key to describe.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DescribeWorkerResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
   /namespaces/{namespace}/workers/fetch-config:
     post:
       tags:
@@ -7921,6 +7985,11 @@ components:
              Only set if `report_task_queue_stats` is set to true in the request.
              (-- api-linter: core::0140::prepositions=disabled
                  aip.dev/not-precedent: "by" is used to clarify the key. --)
+    DescribeWorkerResponse:
+      type: object
+      properties:
+        workerInfo:
+          $ref: '#/components/schemas/WorkerInfo'
     DescribeWorkflowExecutionResponse:
       type: object
       properties:

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2539,3 +2539,15 @@ message UpdateWorkerConfigResponse {
         // Once we support sending update to a multiple workers - it will be converted into a batch job, and job id will be returned.
     }
 }
+
+message DescribeWorkerRequest {
+    // Namespace this worker belongs to.
+    string namespace = 1;
+
+    // Worker instance key to describe.
+    string worker_instance_key = 2;
+}
+
+message DescribeWorkerResponse {
+    temporal.api.worker.v1.WorkerInfo worker_info = 1;
+}

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -1235,4 +1235,14 @@ service WorkflowService {
             }
         };
     }
+
+    // DescribeWorker returns information about the specified worker.
+    rpc DescribeWorker (DescribeWorkerRequest) returns (DescribeWorkerResponse) {
+        option (google.api.http) = {
+            get: "/namespaces/{namespace}/workers/describe/{worker_instance_key}"
+            additional_bindings {
+                get: "/api/v1/namespaces/{namespace}/workers/describe/{worker_instance_key}"
+            }
+        };
+    }
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add DescribeWorker API.
Extracted from [this PR](https://github.com/temporalio/api/pull/622). 

<!-- Tell your future self why have you made these changes -->
DescribeWorker - will be needed to get all the heartbeat information from the worker.
Partially this can be covered by "ListWorkers" with query "WorkerInstanceKey = 'xxx'", but this is a dedicated API that doesn't require query processing.

Extracting into separate PR so that one is concentrated on worker payload only.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
Introduce new API

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
[Server PR](https://github.com/temporalio/temporal/pull/8094)