### PR TITLE
Allow fairness weight overrides via UpdateTaskQueueConfigApi

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -8940,6 +8940,14 @@
         "updateFairnessKeyRateLimitDefault": {
           "$ref": "#/definitions/UpdateTaskQueueConfigRequestRateLimitUpdate",
           "description": "Update to the default fairness key rate limit.\nIf not set, this configuration is unchanged.\nIf the `rate_limit` field in the `RateLimitUpdate` is missing, remove the existing rate limit."
+        },
+        "updateFairnessWeights": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number",
+            "format": "float"
+          },
+          "description": "If set, overrides the fairness weights for the fairness keys.\nSet as -1 to unset the fairness key."
         }
       }
     },
@@ -15145,6 +15153,14 @@
         "fairnessKeysRateLimitDefault": {
           "$ref": "#/definitions/v1RateLimitConfig",
           "description": "If set, each individual fairness key will be limited to this rate, scaled by the weight of the fairness key."
+        },
+        "fairnessWeights": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number",
+            "format": "float"
+          },
+          "description": "If set, overrides the fairness weights for the corresponding fairness keys."
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -12196,6 +12196,12 @@ components:
           allOf:
             - $ref: '#/components/schemas/RateLimitConfig'
           description: If set, each individual fairness key will be limited to this rate, scaled by the weight of the fairness key.
+        fairnessWeights:
+          type: object
+          additionalProperties:
+            type: number
+            format: float
+          description: If set, overrides the fairness weights for the corresponding fairness keys.
     TaskQueueReachability:
       type: object
       properties:
@@ -12776,6 +12782,14 @@ components:
             Update to the default fairness key rate limit.
              If not set, this configuration is unchanged.
              If the `rate_limit` field in the `RateLimitUpdate` is missing, remove the existing rate limit.
+        updateFairnessWeights:
+          type: object
+          additionalProperties:
+            type: number
+            format: float
+          description: |-
+            If set, overrides the fairness weights for the fairness keys.
+             Set as -1 to unset the fairness key.
     UpdateTaskQueueConfigRequest_RateLimitUpdate:
       type: object
       properties:

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -343,4 +343,6 @@ message TaskQueueConfig {
     RateLimitConfig queue_rate_limit = 1;
     // If set, each individual fairness key will be limited to this rate, scaled by the weight of the fairness key.
     RateLimitConfig fairness_keys_rate_limit_default = 2;
+    // If set, overrides the fairness weights for the corresponding fairness keys.
+    map<string, float> fairness_weights = 3;
 }

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2484,6 +2484,9 @@ message UpdateTaskQueueConfigRequest {
     // If not set, this configuration is unchanged.
     // If the `rate_limit` field in the `RateLimitUpdate` is missing, remove the existing rate limit.
     RateLimitUpdate update_fairness_key_rate_limit_default = 6;
+    // If set, overrides the fairness weights for the fairness keys.
+    // Set as -1 to unset the fairness key.
+    map<string, float> update_fairness_weights = 7;
 }
 
 message UpdateTaskQueueConfigResponse {


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
+ Added a update fairness weights map to the UpdateTaskQueueConfig api request.
+ Added a fairness_weights map in the taskQueueConfig message to enable persistence and return response.

<!-- Tell your future self why have you made these changes -->
**Why?**
+ Allow override of fairness weights for individual fairness keys via UpdateTaskQueueConfig api.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
+ No.

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
