### PR TITLE
add Manager field to WorkerDeployment, and SetWorkerDeploymentManager API

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -2130,6 +2130,51 @@
         ]
       }
     },
+    "/api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}/set-manager": {
+      "post": {
+        "summary": "Set/unset the Manager of a Worker Deployment.\nExperimental. This API might significantly change or be removed in a future release.",
+        "operationId": "SetWorkerDeploymentManager2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1SetWorkerDeploymentManagerResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceSetWorkerDeploymentManagerBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
     "/api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}/set-ramping-version": {
       "post": {
         "summary": "Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for\ngradual ramp to unversioned workers too.\nExperimental. This API might significantly change or be removed in a future release.",
@@ -5910,6 +5955,51 @@
         ]
       }
     },
+    "/namespaces/{namespace}/worker-deployments/{deploymentName}/set-manager": {
+      "post": {
+        "summary": "Set/unset the Manager of a Worker Deployment.\nExperimental. This API might significantly change or be removed in a future release.",
+        "operationId": "SetWorkerDeploymentManager",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1SetWorkerDeploymentManagerResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceSetWorkerDeploymentManagerBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
     "/namespaces/{namespace}/worker-deployments/{deploymentName}/set-ramping-version": {
       "post": {
         "summary": "Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for\ngradual ramp to unversioned workers too.\nExperimental. This API might significantly change or be removed in a future release.",
@@ -8395,6 +8485,25 @@
         }
       },
       "description": "Set/unset the Current Version of a Worker Deployment."
+    },
+    "WorkflowServiceSetWorkerDeploymentManagerBody": {
+      "type": "object",
+      "properties": {
+        "manager": {
+          "type": "string",
+          "description": "Optional. The string that you want to set as the Deployment's `manager`.\nEmpty string will set the `manager` field to an empty string."
+        },
+        "conflictToken": {
+          "type": "string",
+          "format": "byte",
+          "description": "Optional. This can be the value of conflict_token from a Describe, or another Worker\nDeployment API. Passing a non-nil conflict token will cause this request to fail if the\nDeployment's configuration has been modified between the API call that generated the\ntoken and this one."
+        },
+        "identity": {
+          "type": "string",
+          "description": "Optional. The identity of the client who initiated this request."
+        }
+      },
+      "description": "Set/unset the Manager of a Worker Deployment."
     },
     "WorkflowServiceSetWorkerDeploymentRampingVersionBody": {
       "type": "object",
@@ -14441,6 +14550,20 @@
         }
       }
     },
+    "v1SetWorkerDeploymentManagerResponse": {
+      "type": "object",
+      "properties": {
+        "conflictToken": {
+          "type": "string",
+          "format": "byte",
+          "description": "This value is returned so that it can be optionally passed to APIs\nthat write to the Worker Deployment state to ensure that the state\ndid not change between this API call and a future write."
+        },
+        "previousManager": {
+          "type": "string",
+          "description": "What the `manager` field was before this change."
+        }
+      }
+    },
     "v1SetWorkerDeploymentRampingVersionResponse": {
       "type": "object",
       "properties": {
@@ -15910,6 +16033,10 @@
         "lastModifierIdentity": {
           "type": "string",
           "description": "Identity of the last client who modified the configuration of this Deployment. Set to the\n`identity` value sent by APIs such as `SetWorkerDeploymentCurrentVersion` and\n`SetWorkerDeploymentRampingVersion`."
+        },
+        "manager": {
+          "type": "string",
+          "description": "Indicates what client is currently expected to make writes to this Worker Deployment, if any.\nLike `last_modifier_identity`, on each write to the Deployment's `routing_config`, this is set\nto the identity of the client that did the write.\nUnlike `last_modifier_identity`, `manager` can be set to an arbitrary string, including the empty\nstring, by the `SetWorkerDeploymentManager` API. Clients can choose to behave differently in response\nto different `manager` values, such as by refusing to do writes unless the `manager` value indicates\nthat they can do so without overwriting another client's changes."
         }
       },
       "description": "A Worker Deployment (Deployment, for short) represents all workers serving \na shared set of Task Queues. Typically, a Deployment represents one service or \napplication.\nA Deployment contains multiple Deployment Versions, each representing a different \nversion of workers. (see documentation of WorkerDeploymentVersionInfo)\nDeployment records are created in Temporal server automatically when their\nfirst poller arrives to the server.\nExperimental. Worker Deployments are experimental and might significantly change in the future."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -1914,6 +1914,44 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}/set-manager:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        Set/unset the Manager of a Worker Deployment.
+         Experimental. This API might significantly change or be removed in a future release.
+      operationId: SetWorkerDeploymentManager
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: deploymentName
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetWorkerDeploymentManagerRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SetWorkerDeploymentManagerResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
   /api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}/set-ramping-version:
     post:
       tags:
@@ -5291,6 +5329,44 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SetWorkerDeploymentCurrentVersionResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/worker-deployments/{deploymentName}/set-manager:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        Set/unset the Manager of a Worker Deployment.
+         Experimental. This API might significantly change or be removed in a future release.
+      operationId: SetWorkerDeploymentManager
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: deploymentName
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetWorkerDeploymentManagerRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SetWorkerDeploymentManagerResponse'
         default:
           description: Default error response
           content:
@@ -11441,6 +11517,43 @@ components:
           allOf:
             - $ref: '#/components/schemas/WorkerDeploymentVersion'
           description: The version that was current before executing this operation.
+    SetWorkerDeploymentManagerRequest:
+      type: object
+      properties:
+        namespace:
+          type: string
+        deploymentName:
+          type: string
+        manager:
+          type: string
+          description: |-
+            Optional. The string that you want to set as the Deployment's `manager`.
+             Empty string will set the `manager` field to an empty string.
+        conflictToken:
+          type: string
+          description: |-
+            Optional. This can be the value of conflict_token from a Describe, or another Worker
+             Deployment API. Passing a non-nil conflict token will cause this request to fail if the
+             Deployment's configuration has been modified between the API call that generated the
+             token and this one.
+          format: bytes
+        identity:
+          type: string
+          description: Optional. The identity of the client who initiated this request.
+      description: Set/unset the Manager of a Worker Deployment.
+    SetWorkerDeploymentManagerResponse:
+      type: object
+      properties:
+        conflictToken:
+          type: string
+          description: |-
+            This value is returned so that it can be optionally passed to APIs
+             that write to the Worker Deployment state to ensure that the state
+             did not change between this API call and a future write.
+          format: bytes
+        previousManager:
+          type: string
+          description: What the `manager` field was before this change.
     SetWorkerDeploymentRampingVersionRequest:
       type: object
       properties:
@@ -13172,6 +13285,16 @@ components:
             Identity of the last client who modified the configuration of this Deployment. Set to the
              `identity` value sent by APIs such as `SetWorkerDeploymentCurrentVersion` and
              `SetWorkerDeploymentRampingVersion`.
+        manager:
+          type: string
+          description: |-
+            Indicates what client is currently expected to make writes to this Worker Deployment, if any.
+             Like `last_modifier_identity`, on each write to the Deployment's `routing_config`, this is set
+             to the identity of the client that did the write.
+             Unlike `last_modifier_identity`, `manager` can be set to an arbitrary string, including the empty
+             string, by the `SetWorkerDeploymentManager` API. Clients can choose to behave differently in response
+             to different `manager` values, such as by refusing to do writes unless the `manager` value indicates
+             that they can do so without overwriting another client's changes.
       description: "A Worker Deployment (Deployment, for short) represents all workers serving \n a shared set of Task Queues. Typically, a Deployment represents one service or \n application.\n A Deployment contains multiple Deployment Versions, each representing a different \n version of workers. (see documentation of WorkerDeploymentVersionInfo)\n Deployment records are created in Temporal server automatically when their\n first poller arrives to the server.\n Experimental. Worker Deployments are experimental and might significantly change in the future."
     WorkerDeploymentInfo_WorkerDeploymentVersionSummary:
       type: object

--- a/temporal/api/deployment/v1/message.proto
+++ b/temporal/api/deployment/v1/message.proto
@@ -195,6 +195,15 @@ message WorkerDeploymentInfo {
     // `SetWorkerDeploymentRampingVersion`.
     string last_modifier_identity = 5;
 
+    // Indicates what client is currently expected to make writes to this Worker Deployment, if any.
+    // Like `last_modifier_identity`, on each write to the Deployment's `routing_config`, this is set
+    // to the identity of the client that did the write.
+    // Unlike `last_modifier_identity`, `manager` can be set to an arbitrary string, including the empty
+    // string, by the `SetWorkerDeploymentManager` API. Clients can choose to behave differently in response
+    // to different `manager` values, such as by refusing to do writes unless the `manager` value indicates
+    // that they can do so without overwriting another client's changes.
+    string manager = 6;
+
     message WorkerDeploymentVersionSummary {
         // Deprecated. Use `deployment_version`.
         string version = 1 [deprecated = true];

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2311,6 +2311,34 @@ message UpdateWorkerDeploymentVersionMetadataResponse {
     temporal.api.deployment.v1.VersionMetadata metadata = 1;
 }
 
+// Set/unset the Manager of a Worker Deployment.
+message SetWorkerDeploymentManagerRequest {
+    string namespace = 1;
+    string deployment_name = 2;
+
+    // Optional. The string that you want to set as the Deployment's `manager`.
+    // Empty string will set the `manager` field to an empty string.
+    string manager = 3;
+
+    // Optional. This can be the value of conflict_token from a Describe, or another Worker
+    // Deployment API. Passing a non-nil conflict token will cause this request to fail if the
+    // Deployment's configuration has been modified between the API call that generated the
+    // token and this one.
+    bytes conflict_token = 4;
+
+    // Optional. The identity of the client who initiated this request.
+    string identity = 5;
+}
+
+message SetWorkerDeploymentManagerResponse {
+    // This value is returned so that it can be optionally passed to APIs
+    // that write to the Worker Deployment state to ensure that the state
+    // did not change between this API call and a future write.
+    bytes conflict_token = 1;
+
+    // What the `manager` field was before this change.
+    string previous_manager = 2;
+}
 
 // Returns the Current Deployment of a deployment series.
 // [cleanup-wv-pre-release] Pre-release deployment APIs, clean up later

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -923,6 +923,19 @@ service WorkflowService {
         };
     }
 
+    // Set/unset the Manager of a Worker Deployment.
+    // Experimental. This API might significantly change or be removed in a future release.
+    rpc SetWorkerDeploymentManager (SetWorkerDeploymentManagerRequest) returns (SetWorkerDeploymentManagerResponse) {
+        option (google.api.http) = {
+            post: "/namespaces/{namespace}/worker-deployments/{deployment_name}/set-manager"
+            body: "*"
+            additional_bindings {
+                post: "/api/v1/namespaces/{namespace}/worker-deployments/{deployment_name}/set-manager"
+                body: "*"
+            }
+        };
+    }
+
     // Invokes the specified Update function on user Workflow code.
     rpc UpdateWorkflowExecution(UpdateWorkflowExecutionRequest) returns (UpdateWorkflowExecutionResponse) {
         option (google.api.http) = {


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
add Manager field to WorkerDeployment, and SetWorkerDeploymentManager API


<!-- Tell your future self why have you made these changes -->
I want the Worker Controller to stop making changes to a Worker Deployment if it detects that another client has written to the same Worker Deployment. This is so that, if a user calls `SetCurrentVersion` or `SetRampingVersion` from the CLI during an incident, the Controller does not overwrite that change.

`LastModifiedBy` is not enough for this feature, because we need a way for the "other client" (likely user CLI in most cases, maybe UI if we allow such changes through the UI some day) to indicate to the controller that manual changes are no longer needed and the controller can safely take ownership over writing to this Worker Deployment again.

I thought about doing this via a `Metadata` on the Deployment, similar to WorkerDeploymentVersion Metadata, but I can't think of any other use cases for Deployment-level metadata, and I think this is load-bearing enough to deserve it's own field, where we can clearly document semantics.


<!-- Are there any breaking changes on binary or code level? -->
No


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
Not implemented in server yet because this is just a proposal
