### PR TITLE
Worker heartbeat: Remove heartbeat from non-nexus polling

### DIFF
--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -267,9 +267,6 @@ message PollWorkflowTaskQueueRequest {
     // Worker deployment options that user has set in the worker.
     // Experimental. Worker Deployments are experimental and might significantly change in the future.
     temporal.api.deployment.v1.WorkerDeploymentOptions deployment_options = 6;
-
-    // Worker info to be sent to the server.
-    temporal.api.worker.v1.WorkerHeartbeat worker_heartbeat = 7;
 }
 
 message PollWorkflowTaskQueueResponse {
@@ -441,10 +438,6 @@ message PollActivityTaskQueueRequest {
     temporal.api.common.v1.WorkerVersionCapabilities worker_version_capabilities = 5 [deprecated = true];
     // Worker deployment options that user has set in the worker.
     temporal.api.deployment.v1.WorkerDeploymentOptions deployment_options = 6;
-
-    // Worker info to be sent to the server.
-    temporal.api.worker.v1.WorkerHeartbeat worker_heartbeat = 7;
-
 }
 
 message PollActivityTaskQueueResponse {
@@ -1007,8 +1000,6 @@ message ShutdownWorkerRequest {
     string sticky_task_queue = 2;
     string identity = 3;
     string reason = 4;
-
-    temporal.api.worker.v1.WorkerHeartbeat worker_heartbeat = 5;
 }
 
 message ShutdownWorkerResponse {


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
Removed the `worker_heartbeat` field from non-nexus calls

<!-- Tell your future self why have you made these changes -->
**Why?**
We only want `worker_heartbeat` info sent on nexus polls and dedicated worker heartbeat requests.


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
Breaking change for a WIP feature, should have no effect. Also tried grepping for this field in server and didn't find it used anywhere.

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
