### PR TITLE
Add RESOURCE_EXHAUSTED_CAUSE_GRPC_MESSAGE_TOO_LARGE

### DIFF
--- a/temporal/api/enums/v1/failed_cause.proto
+++ b/temporal/api/enums/v1/failed_cause.proto
@@ -123,6 +123,8 @@ enum ResourceExhaustedCause {
     RESOURCE_EXHAUSTED_CAUSE_CIRCUIT_BREAKER_OPEN = 8;
     // Namespace exceeds operations rate limit.
     RESOURCE_EXHAUSTED_CAUSE_OPS_LIMIT = 9;
+    // GRPC message was too large.
+    RESOURCE_EXHAUSTED_CAUSE_GRPC_MESSAGE_TOO_LARGE = 10;
 }
 
 enum ResourceExhaustedScope {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added `RESOURCE_EXHAUSTED_CAUSE_GRPC_MESSAGE_TOO_LARGE` enum value to `ResourceExhaustedCause`.

<!-- Tell your future self why have you made these changes -->
**Why?**
Go SDK recently merged PR for not retrying gRPC-message-too-large errors: https://github.com/temporalio/sdk-go/pull/2026

The implementation detects this error situation and sets the details of the gRPC status object to an instance of `ResourceExhaustedFailure` with `cause` set to a specific value so that the information is preserved by the error converter. However, no existing `ResourceExhaustedCause` value was appropriate here, so a new one was added, currently as a non-standard extension.

This PR upstreams the new enum value so that the non-standard extension in Go SDK can be removed.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
No
