### PR TITLE
Update description of Visibility Scan API

### DIFF
--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -458,7 +458,8 @@ service WorkflowService {
         };
     }
 
-    // ScanWorkflowExecutions is a visibility API to list large amount of workflow executions in a specific namespace without order.
+    // ScanWorkflowExecutions _was_ a visibility API to list large amount of workflow executions in a specific namespace without order.
+    // It has since been deprecated in favor of `ListWorkflowExecutions` and rewritten to use `ListWorkflowExecutions` internally.
     //
     // Deprecated: Replaced with `ListWorkflowExecutions`.
     // (-- api-linter: core::0127::http-annotation=disabled


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
Update description of Visibility Scan API

<!-- Tell your future self why have you made these changes -->
**Why?**
Visibility Scan API has been marked as deprecated since Temporal v1.27.0.
Temporal Server is changing to simply call the `List` API, so updating the description so it is clear.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
https://github.com/temporalio/temporal/pull/8328