### PR TITLE
add degraded workflow visibility into NamespaceInfo.Capabilities

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -12386,6 +12386,10 @@
         "workerHeartbeats": {
           "type": "boolean",
           "title": "True if the namespace supports worker heartbeats"
+        },
+        "degradedWorkflowVisibility": {
+          "type": "boolean",
+          "title": "True if the namespace supports degraded workflow visibility"
         }
       },
       "description": "Namespace capability details. Should contain what features are enabled in a namespace."

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -12387,9 +12387,9 @@
           "type": "boolean",
           "title": "True if the namespace supports worker heartbeats"
         },
-        "degradedWorkflowVisibility": {
+        "reportedProblemsSearchAttribute": {
           "type": "boolean",
-          "title": "True if the namespace supports degraded workflow visibility"
+          "title": "True if the namespace supports reported problems search attribute"
         }
       },
       "description": "Namespace capability details. Should contain what features are enabled in a namespace."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9213,9 +9213,9 @@ components:
         workerHeartbeats:
           type: boolean
           description: True if the namespace supports worker heartbeats
-        degradedWorkflowVisibility:
+        reportedProblemsSearchAttribute:
           type: boolean
-          description: True if the namespace supports degraded workflow visibility
+          description: True if the namespace supports reported problems search attribute
       description: Namespace capability details. Should contain what features are enabled in a namespace.
     NamespaceReplicationConfig:
       type: object

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9213,6 +9213,9 @@ components:
         workerHeartbeats:
           type: boolean
           description: True if the namespace supports worker heartbeats
+        degradedWorkflowVisibility:
+          type: boolean
+          description: True if the namespace supports degraded workflow visibility
       description: Namespace capability details. Should contain what features are enabled in a namespace.
     NamespaceReplicationConfig:
       type: object

--- a/temporal/api/namespace/v1/message.proto
+++ b/temporal/api/namespace/v1/message.proto
@@ -36,6 +36,8 @@ message NamespaceInfo {
         bool async_update = 3;
         // True if the namespace supports worker heartbeats
         bool worker_heartbeats = 4;
+        // True if the namespace supports degraded workflow visibility
+        bool degraded_workflow_visibility = 5;
     }
 
     // Whether scheduled workflows are supported on this namespace. This is only needed

--- a/temporal/api/namespace/v1/message.proto
+++ b/temporal/api/namespace/v1/message.proto
@@ -36,8 +36,8 @@ message NamespaceInfo {
         bool async_update = 3;
         // True if the namespace supports worker heartbeats
         bool worker_heartbeats = 4;
-        // True if the namespace supports degraded workflow visibility
-        bool degraded_workflow_visibility = 5;
+        // True if the namespace supports reported problems search attribute
+        bool reported_problems_search_attribute = 5;
     }
 
     // Whether scheduled workflows are supported on this namespace. This is only needed


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
Adding `degraded_workflow_visibility` to `NamespaceInfo.Capabilities`.

<!-- Tell your future self why have you made these changes -->
This will allow us to programmatically turn on the saved query for degraded workflow visibility.

**Breaking changes**
No