### PR TITLE
Add reset options to the ResetWorkflowExecution rpc

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -14377,11 +14377,6 @@
           "type": "string",
           "description": "Resets to the first workflow task processed by this build id.\nIf the workflow was not processed by the build id, or the workflow task can't be\ndetermined, no reset will be performed.\nNote that by default, this reset is allowed to be to a prior run in a chain of\ncontinue-as-new."
         },
-        "lastContinuedAsNew": {
-          "type": "object",
-          "properties": {},
-          "description": "Resets to the last workflow task completed in the previous run before the current run\nwas continued-as-new. This only works if the current workflow was continued from another\nworkflow (has a continued_execution_run_id). If the workflow was not continued from\nanother workflow, or the last workflow task can't be determined, no reset will be performed."
-        },
         "resetReapplyType": {
           "$ref": "#/definitions/v1ResetReapplyType",
           "title": "Deprecated. Use `options`.\nDefault: RESET_REAPPLY_TYPE_SIGNAL"

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -8936,6 +8936,10 @@
         "identity": {
           "type": "string",
           "title": "The identity of the worker/client"
+        },
+        "resetOptions": {
+          "$ref": "#/definitions/v1ResetOptions",
+          "description": "Describes where to reset to and how. If set, `workflow_task_finish_event_id` is ignored.\nThis allows specifying reset targets like first/last workflow task, build ID, or last continued-as-new\nwithout needing to know the exact event ID."
         }
       }
     },
@@ -14372,6 +14376,11 @@
         "buildId": {
           "type": "string",
           "description": "Resets to the first workflow task processed by this build id.\nIf the workflow was not processed by the build id, or the workflow task can't be\ndetermined, no reset will be performed.\nNote that by default, this reset is allowed to be to a prior run in a chain of\ncontinue-as-new."
+        },
+        "lastContinuedAsNew": {
+          "type": "object",
+          "properties": {},
+          "description": "Resets to the last workflow task completed in the previous run before the current run\nwas continued-as-new. This only works if the current workflow was continued from another\nworkflow (has a continued_execution_run_id). If the workflow was not continued from\nanother workflow, or the last workflow task can't be determined, no reset will be performed."
         },
         "resetReapplyType": {
           "$ref": "#/definitions/v1ResetReapplyType",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -8939,7 +8939,7 @@
         },
         "resetOptions": {
           "$ref": "#/definitions/v1ResetOptions",
-          "description": "Describes where to reset to and how. If set, `workflow_task_finish_event_id` is ignored.\nThis allows specifying reset targets like first/last workflow task, build ID, or last continued-as-new\nwithout needing to know the exact event ID."
+          "description": "Describes where to reset to and how. If set, `workflow_task_finish_event_id` is ignored."
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -11901,10 +11901,7 @@ components:
         resetOptions:
           allOf:
             - $ref: '#/components/schemas/ResetOptions'
-          description: |-
-            Describes where to reset to and how. If set, `workflow_task_finish_event_id` is ignored.
-             This allows specifying reset targets like first/last workflow task, build ID, or last continued-as-new
-             without needing to know the exact event ID.
+          description: Describes where to reset to and how. If set, `workflow_task_finish_event_id` is ignored.
     ResetWorkflowExecutionResponse:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -11898,6 +11898,13 @@ components:
         identity:
           type: string
           description: The identity of the worker/client
+        resetOptions:
+          allOf:
+            - $ref: '#/components/schemas/ResetOptions'
+          description: |-
+            Describes where to reset to and how. If set, `workflow_task_finish_event_id` is ignored.
+             This allows specifying reset targets like first/last workflow task, build ID, or last continued-as-new
+             without needing to know the exact event ID.
     ResetWorkflowExecutionResponse:
       type: object
       properties:

--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -160,11 +160,6 @@ message ResetOptions {
         // Note that by default, this reset is allowed to be to a prior run in a chain of
         // continue-as-new.
         string build_id = 4;
-        // Resets to the last workflow task completed in the previous run before the current run
-        // was continued-as-new. This only works if the current workflow was continued from another
-        // workflow (has a continued_execution_run_id). If the workflow was not continued from
-        // another workflow, or the last workflow task can't be determined, no reset will be performed.
-        google.protobuf.Empty last_continued_as_new = 5;
     }
 
     // Deprecated. Use `options`.

--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -160,6 +160,11 @@ message ResetOptions {
         // Note that by default, this reset is allowed to be to a prior run in a chain of
         // continue-as-new.
         string build_id = 4;
+        // Resets to the last workflow task completed in the previous run before the current run
+        // was continued-as-new. This only works if the current workflow was continued from another
+        // workflow (has a continued_execution_run_id). If the workflow was not continued from
+        // another workflow, or the last workflow task can't be determined, no reset will be performed.
+        google.protobuf.Empty last_continued_as_new = 5;
     }
 
     // Deprecated. Use `options`.

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -831,8 +831,6 @@ message ResetWorkflowExecutionRequest {
     // The identity of the worker/client
     string identity = 9;
     // Describes where to reset to and how. If set, `workflow_task_finish_event_id` is ignored.
-    // This allows specifying reset targets like first/last workflow task, build ID, or last continued-as-new
-    // without needing to know the exact event ID.
     temporal.api.common.v1.ResetOptions reset_options = 10;
 }
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -830,6 +830,10 @@ message ResetWorkflowExecutionRequest {
     repeated temporal.api.workflow.v1.PostResetOperation post_reset_operations = 8;
     // The identity of the worker/client
     string identity = 9;
+    // Describes where to reset to and how. If set, `workflow_task_finish_event_id` is ignored.
+    // This allows specifying reset targets like first/last workflow task, build ID, or last continued-as-new
+    // without needing to know the exact event ID.
+    temporal.api.common.v1.ResetOptions reset_options = 10;
 }
 
 message ResetWorkflowExecutionResponse {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Per https://github.com/temporalio/temporal/issues/1338:
> The ResetWorkflowExecution gRPC API accepts only workflow_task_finish_event_id. So all the logic of finding reset point resides in the tctl. This makes the logic not reusable when SDKs invoke reset operation directly.

Originally, I planned on addressing this by adding the `reset_type` described in that ticket and [utilized in the CLI](https://github.com/temporalio/cli/blob/aa925d353b8e50f13d749086b471c0a1ae513b1b/internal/temporalcli/commands.gen.go#L3656). However, after starting implementation, I found the batch operations already uses `ResetOptions` (see [BatchOperationReset](https://github.com/temporalio/api/blob/4130a80613796f56a2c6be9fc22da9023929c645/temporal/api/batch/v1/message.proto#L81-L82)), which provides a more flexible and extensible solution.

If applied, this PR will add a `reset_options` field to `ResetWorkflowExecutionRequest` - This allows callers to specify reset targets (first/last workflow task, build ID, etc.) without needing to compute exact event IDs, bringing the same capabilities to single-workflow resets that batch operations already have.

<!-- Tell your future self why have you made these changes -->
**Why?**
This moves the reset point determination logic from the CLI into the service, enabling SDKs to perform user-friendly reset operations like "reset to the first workflow task" without implementing their own history traversal logic.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
 Fully backwards compatible.
  - The existing `workflow_task_finish_event_id` field remains unchanged and functional
  - When `reset_options` is set, it takes precedence over `workflow_task_finish_event_id`
  - Old clients continue to work without modification
  - Follows the same pattern as `BatchOperationReset`, which has both options and deprecated legacy fields


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
As I understand it, this does not break the Server. However, if reset options are supplied in the modified gRPC request, they will be ignored.

**Next steps**
Server-side implementation will need to handle the new `reset_options` field by:
  1. Checking if `reset_options` is set and using it to determine the reset point
  2. Falling back to `workflow_task_finish_event_id` if `reset_options` is not set
  3. Implementing the target resolution logic
    a. I haven't confirmed this, but I'd imagine I could copy the logic from the batch operations.