### PR TITLE
[NO NOT MERGE] Direct Nexus calls

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -1462,6 +1462,128 @@
         ]
       }
     },
+    "/api/v1/namespaces/{namespace}/nexus-requests/endpoints/{endpoint}/services/{service}/operations/{operation}": {
+      "post": {
+        "summary": "StartNexusOperation starts a Nexus operation on an endpoint, communicating directly with the\nendpoint using the caller's namespace credentials.\nThe response follows the Nexus RPC spec semantics: synchronous completion, asynchronous start,\nor operation error.\nHandler errors (e.g., NOT_FOUND, BAD_REQUEST) are returned as gRPC errors.",
+        "operationId": "StartNexusOperation2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1StartNexusOperationResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "The namespace to authenticate to. This may be different from the target namespace of the specified endpoint.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "endpoint",
+            "description": "Endpoint name, resolved via the Temporal service's endpoint registry.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "service",
+            "description": "Nexus service name.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "operation",
+            "description": "Nexus operation name.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceStartNexusOperationBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/api/v1/namespaces/{namespace}/nexus-requests/endpoints/{endpoint}/services/{service}/operations/{operation}/cancel": {
+      "post": {
+        "summary": "CancelNexusOperation requests cancellation of a previously started asynchronous Nexus operation.\nCancellation is cooperative: this forwards a cancel request to the handler, but the operation\nwill only transition to canceled if the handler processes it.",
+        "operationId": "CancelNexusOperation2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1CancelNexusOperationResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "The namespace to authenticate to. This may be different from the target namespace of the specified endpoint.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "endpoint",
+            "description": "Endpoint name, resolved via the Temporal service's endpoint registry.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "service",
+            "description": "Nexus service name.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "operation",
+            "description": "Nexus operation name.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceCancelNexusOperationBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
     "/api/v1/namespaces/{namespace}/schedule-count": {
       "get": {
         "summary": "CountSchedules is a visibility API to count schedules in a specific namespace.",
@@ -6032,6 +6154,128 @@
         ]
       }
     },
+    "/namespaces/{namespace}/nexus-requests/endpoints/{endpoint}/services/{service}/operations/{operation}": {
+      "post": {
+        "summary": "StartNexusOperation starts a Nexus operation on an endpoint, communicating directly with the\nendpoint using the caller's namespace credentials.\nThe response follows the Nexus RPC spec semantics: synchronous completion, asynchronous start,\nor operation error.\nHandler errors (e.g., NOT_FOUND, BAD_REQUEST) are returned as gRPC errors.",
+        "operationId": "StartNexusOperation",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1StartNexusOperationResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "The namespace to authenticate to. This may be different from the target namespace of the specified endpoint.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "endpoint",
+            "description": "Endpoint name, resolved via the Temporal service's endpoint registry.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "service",
+            "description": "Nexus service name.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "operation",
+            "description": "Nexus operation name.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceStartNexusOperationBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/namespaces/{namespace}/nexus-requests/endpoints/{endpoint}/services/{service}/operations/{operation}/cancel": {
+      "post": {
+        "summary": "CancelNexusOperation requests cancellation of a previously started asynchronous Nexus operation.\nCancellation is cooperative: this forwards a cancel request to the handler, but the operation\nwill only transition to canceled if the handler processes it.",
+        "operationId": "CancelNexusOperation",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1CancelNexusOperationResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "The namespace to authenticate to. This may be different from the target namespace of the specified endpoint.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "endpoint",
+            "description": "Endpoint name, resolved via the Temporal service's endpoint registry.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "service",
+            "description": "Nexus service name.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "operation",
+            "description": "Nexus operation name.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceCancelNexusOperationBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
     "/namespaces/{namespace}/schedule-count": {
       "get": {
         "summary": "CountSchedules is a visibility API to count schedules in a specific namespace.",
@@ -8923,7 +9167,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/v1Link"
+            "$ref": "#/definitions/apiCommonV1Link"
           },
           "description": "Links to be associated with the WorkflowExecutionSignaled event."
         }
@@ -8943,6 +9187,33 @@
         }
       },
       "description": "UpdateWorkflowOptions represents updating workflow execution options after a workflow reset.\nKeep the parameters in sync with temporal.api.workflowservice.v1.UpdateWorkflowExecutionOptionsRequest."
+    },
+    "StartNexusOperationResponseAsyncSuccess": {
+      "type": "object",
+      "properties": {
+        "operationToken": {
+          "type": "string"
+        }
+      },
+      "description": "An operation was started asynchronously. The token can be used for cancellation."
+    },
+    "StartNexusOperationResponseOperationFailure": {
+      "type": "object",
+      "properties": {
+        "failure": {
+          "$ref": "#/definitions/v1Failure"
+        }
+      },
+      "description": "The operation completed unsuccessfully.\nThe operation is considered canceled if the failure has a CanceledFailureInfo object attached."
+    },
+    "StartNexusOperationResponseSyncSuccess": {
+      "type": "object",
+      "properties": {
+        "payload": {
+          "$ref": "#/definitions/v1Payload"
+        }
+      },
+      "description": "An operation completed successfully and synchronously."
     },
     "UpdateTaskQueueConfigRequestRateLimitUpdate": {
       "type": "object",
@@ -9115,6 +9386,19 @@
         }
       },
       "description": "Activity trigger will be triggered when an activity is about to start."
+    },
+    "WorkflowServiceCancelNexusOperationBody": {
+      "type": "object",
+      "properties": {
+        "identity": {
+          "type": "string",
+          "description": "The identity of the client who initiated this request."
+        },
+        "operationToken": {
+          "type": "string",
+          "description": "Operation token from StartNexusOperationResponse.AsyncSuccess."
+        }
+      }
     },
     "WorkflowServiceCreateScheduleBody": {
       "type": "object",
@@ -10007,6 +10291,31 @@
         }
       }
     },
+    "WorkflowServiceStartNexusOperationBody": {
+      "type": "object",
+      "properties": {
+        "identity": {
+          "type": "string",
+          "description": "The identity of the client who initiated this request."
+        },
+        "requestId": {
+          "type": "string",
+          "description": "A unique identifier for this request, used as an idempotency key."
+        },
+        "input": {
+          "$ref": "#/definitions/v1Payload",
+          "description": "Serialized input to the operation."
+        },
+        "links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apiCommonV1Link"
+          },
+          "description": "Links for associating the caller with the operation."
+        }
+      }
+    },
     "WorkflowServiceStartWorkflowExecutionBody": {
       "type": "object",
       "properties": {
@@ -10523,6 +10832,30 @@
         }
       },
       "description": "Keep the parameters in sync with:\n  - temporal.api.batch.v1.BatchOperationUpdateWorkflowExecutionOptions.\n  - temporal.api.workflow.v1.PostResetOperation.UpdateWorkflowOptions."
+    },
+    "apiCommonV1Link": {
+      "type": "object",
+      "properties": {
+        "workflowEvent": {
+          "$ref": "#/definitions/LinkWorkflowEvent"
+        },
+        "batchJob": {
+          "$ref": "#/definitions/LinkBatchJob"
+        }
+      },
+      "description": "Link can be associated with history events. It might contain information about an external entity\nrelated to the history event. For example, workflow A makes a Nexus call that starts workflow B:\nin this case, a history event in workflow A could contain a Link to the workflow started event in\nworkflow B, and vice-versa."
+    },
+    "apiNexusV1Link": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "See https://github.com/nexus-rpc/api/blob/main/SPEC.md#links."
+        },
+        "type": {
+          "type": "string"
+        }
+      }
     },
     "protobufAny": {
       "type": "object",
@@ -11525,7 +11858,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/v1Link"
+            "$ref": "#/definitions/apiCommonV1Link"
           },
           "description": "Links associated with the callback. It can be used to link to underlying resources of the\ncallback."
         }
@@ -11599,6 +11932,9 @@
         "CANCEL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_NAMESPACE_NOT_FOUND"
       ],
       "default": "CANCEL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_UNSPECIFIED"
+    },
+    "v1CancelNexusOperationResponse": {
+      "type": "object"
     },
     "v1CanceledFailureInfo": {
       "type": "object",
@@ -12987,7 +13323,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/v1Link"
+            "$ref": "#/definitions/apiCommonV1Link"
           },
           "description": "Links associated with the event."
         },
@@ -13237,18 +13573,6 @@
         }
       },
       "description": "IntervalSpec matches times that can be expressed as:\nepoch + n * interval + phase\nwhere n is an integer.\nphase defaults to zero if missing. interval is required.\nBoth interval and phase must be non-negative and are truncated to the nearest\nsecond before any calculations.\nFor example, an interval of 1 hour with phase of zero would match every hour,\non the hour. The same interval but a phase of 19 minutes would match every\nxx:19:00. An interval of 28 days with phase zero would match\n2022-02-17T00:00:00Z (among other times). The same interval with a phase of 3\ndays, 5 hours, and 23 minutes would match 2022-02-20T05:23:00Z instead."
-    },
-    "v1Link": {
-      "type": "object",
-      "properties": {
-        "workflowEvent": {
-          "$ref": "#/definitions/LinkWorkflowEvent"
-        },
-        "batchJob": {
-          "$ref": "#/definitions/LinkBatchJob"
-        }
-      },
-      "description": "Link can be associated with history events. It might contain information about an external entity\nrelated to the history event. For example, workflow A makes a Nexus call that starts workflow B:\nin this case, a history event in workflow A could contain a Link to the workflow started event in\nworkflow B, and vice-versa."
     },
     "v1ListActivityExecutionsResponse": {
       "type": "object",
@@ -15836,6 +16160,28 @@
         }
       }
     },
+    "v1StartNexusOperationResponse": {
+      "type": "object",
+      "properties": {
+        "syncSuccess": {
+          "$ref": "#/definitions/StartNexusOperationResponseSyncSuccess"
+        },
+        "asyncSuccess": {
+          "$ref": "#/definitions/StartNexusOperationResponseAsyncSuccess"
+        },
+        "operationFailure": {
+          "$ref": "#/definitions/StartNexusOperationResponseOperationFailure"
+        },
+        "links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apiNexusV1Link"
+          },
+          "description": "Links associated with the operation, as returned by the handler."
+        }
+      }
+    },
     "v1StartWorkflowExecutionResponse": {
       "type": "object",
       "properties": {
@@ -15856,7 +16202,7 @@
           "description": "When `request_eager_execution` is set on the `StartWorkflowExecutionRequest`, the server - if supported - will\nreturn the first workflow task to be eagerly executed.\nThe caller is expected to have a worker available to process the task."
         },
         "link": {
-          "$ref": "#/definitions/v1Link",
+          "$ref": "#/definitions/apiCommonV1Link",
           "description": "Link to the workflow event."
         }
       }

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -1343,6 +1343,114 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/nexus-requests/endpoints/{endpoint}/services/{service}/operations/{operation}:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        StartNexusOperation starts a Nexus operation on an endpoint, communicating directly with the
+         endpoint using the caller's namespace credentials.
+         The response follows the Nexus RPC spec semantics: synchronous completion, asynchronous start,
+         or operation error.
+         Handler errors (e.g., NOT_FOUND, BAD_REQUEST) are returned as gRPC errors.
+      operationId: StartNexusOperation
+      parameters:
+        - name: namespace
+          in: path
+          description: The namespace to authenticate to. This may be different from the target namespace of the specified endpoint.
+          required: true
+          schema:
+            type: string
+        - name: endpoint
+          in: path
+          description: Endpoint name, resolved via the Temporal service's endpoint registry.
+          required: true
+          schema:
+            type: string
+        - name: service
+          in: path
+          description: Nexus service name.
+          required: true
+          schema:
+            type: string
+        - name: operation
+          in: path
+          description: Nexus operation name.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StartNexusOperationRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StartNexusOperationResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/nexus-requests/endpoints/{endpoint}/services/{service}/operations/{operation}/cancel:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        CancelNexusOperation requests cancellation of a previously started asynchronous Nexus operation.
+         Cancellation is cooperative: this forwards a cancel request to the handler, but the operation
+         will only transition to canceled if the handler processes it.
+      operationId: CancelNexusOperation
+      parameters:
+        - name: namespace
+          in: path
+          description: The namespace to authenticate to. This may be different from the target namespace of the specified endpoint.
+          required: true
+          schema:
+            type: string
+        - name: endpoint
+          in: path
+          description: Endpoint name, resolved via the Temporal service's endpoint registry.
+          required: true
+          schema:
+            type: string
+        - name: service
+          in: path
+          description: Nexus service name.
+          required: true
+          schema:
+            type: string
+        - name: operation
+          in: path
+          description: Nexus operation name.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CancelNexusOperationRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CancelNexusOperationResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
   /api/v1/namespaces/{namespace}/schedule-count:
     get:
       tags:
@@ -5436,6 +5544,114 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/nexus-requests/endpoints/{endpoint}/services/{service}/operations/{operation}:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        StartNexusOperation starts a Nexus operation on an endpoint, communicating directly with the
+         endpoint using the caller's namespace credentials.
+         The response follows the Nexus RPC spec semantics: synchronous completion, asynchronous start,
+         or operation error.
+         Handler errors (e.g., NOT_FOUND, BAD_REQUEST) are returned as gRPC errors.
+      operationId: StartNexusOperation
+      parameters:
+        - name: namespace
+          in: path
+          description: The namespace to authenticate to. This may be different from the target namespace of the specified endpoint.
+          required: true
+          schema:
+            type: string
+        - name: endpoint
+          in: path
+          description: Endpoint name, resolved via the Temporal service's endpoint registry.
+          required: true
+          schema:
+            type: string
+        - name: service
+          in: path
+          description: Nexus service name.
+          required: true
+          schema:
+            type: string
+        - name: operation
+          in: path
+          description: Nexus operation name.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StartNexusOperationRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StartNexusOperationResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/nexus-requests/endpoints/{endpoint}/services/{service}/operations/{operation}/cancel:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        CancelNexusOperation requests cancellation of a previously started asynchronous Nexus operation.
+         Cancellation is cooperative: this forwards a cancel request to the handler, but the operation
+         will only transition to canceled if the handler processes it.
+      operationId: CancelNexusOperation
+      parameters:
+        - name: namespace
+          in: path
+          description: The namespace to authenticate to. This may be different from the target namespace of the specified endpoint.
+          required: true
+          schema:
+            type: string
+        - name: endpoint
+          in: path
+          description: Endpoint name, resolved via the Temporal service's endpoint registry.
+          required: true
+          schema:
+            type: string
+        - name: service
+          in: path
+          description: Nexus service name.
+          required: true
+          schema:
+            type: string
+        - name: operation
+          in: path
+          description: Nexus operation name.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CancelNexusOperationRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CancelNexusOperationResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
   /namespaces/{namespace}/schedule-count:
     get:
       tags:
@@ -8807,6 +9023,30 @@ components:
           additionalProperties:
             type: string
           description: Header to attach to callback request.
+    CancelNexusOperationRequest:
+      type: object
+      properties:
+        namespace:
+          type: string
+          description: The namespace to authenticate to. This may be different from the target namespace of the specified endpoint.
+        identity:
+          type: string
+          description: The identity of the client who initiated this request.
+        endpoint:
+          type: string
+          description: Endpoint name, resolved via the Temporal service's endpoint registry.
+        service:
+          type: string
+          description: Nexus service name.
+        operation:
+          type: string
+          description: Nexus operation name.
+        operationToken:
+          type: string
+          description: Operation token from StartNexusOperationResponse.AsyncSuccess.
+    CancelNexusOperationResponse:
+      type: object
+      properties: {}
     CanceledFailureInfo:
       type: object
       properties:
@@ -13833,6 +14073,70 @@ components:
           allOf:
             - $ref: '#/components/schemas/Priority'
           description: Priority metadata
+    StartNexusOperationRequest:
+      type: object
+      properties:
+        namespace:
+          type: string
+          description: The namespace to authenticate to. This may be different from the target namespace of the specified endpoint.
+        identity:
+          type: string
+          description: The identity of the client who initiated this request.
+        requestId:
+          type: string
+          description: A unique identifier for this request, used as an idempotency key.
+        endpoint:
+          type: string
+          description: Endpoint name, resolved via the Temporal service's endpoint registry.
+        service:
+          type: string
+          description: Nexus service name.
+        operation:
+          type: string
+          description: Nexus operation name.
+        input:
+          allOf:
+            - $ref: '#/components/schemas/Payload'
+          description: Serialized input to the operation.
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+          description: Links for associating the caller with the operation.
+    StartNexusOperationResponse:
+      type: object
+      properties:
+        syncSuccess:
+          $ref: '#/components/schemas/StartNexusOperationResponse_SyncSuccess'
+        asyncSuccess:
+          $ref: '#/components/schemas/StartNexusOperationResponse_AsyncSuccess'
+        operationFailure:
+          $ref: '#/components/schemas/StartNexusOperationResponse_OperationFailure'
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+          description: Links associated with the operation, as returned by the handler.
+    StartNexusOperationResponse_AsyncSuccess:
+      type: object
+      properties:
+        operationToken:
+          type: string
+      description: An operation was started asynchronously. The token can be used for cancellation.
+    StartNexusOperationResponse_OperationFailure:
+      type: object
+      properties:
+        failure:
+          $ref: '#/components/schemas/Failure'
+      description: |-
+        The operation completed unsuccessfully.
+         The operation is considered canceled if the failure has a CanceledFailureInfo object attached.
+    StartNexusOperationResponse_SyncSuccess:
+      type: object
+      properties:
+        payload:
+          $ref: '#/components/schemas/Payload'
+      description: An operation completed successfully and synchronously.
     StartWorkflowExecutionRequest:
       type: object
       properties:

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2919,3 +2919,76 @@ message DeleteActivityExecutionRequest {
 
 message DeleteActivityExecutionResponse {
 }
+
+message StartNexusOperationRequest {
+    // The namespace to authenticate to. This may be different from the target namespace of the specified endpoint.
+    string namespace = 1;
+    // The identity of the client who initiated this request.
+    string identity = 2;
+    // A unique identifier for this request, used as an idempotency key.
+    string request_id = 3;
+
+    // Endpoint name, resolved via the Temporal service's endpoint registry.
+    string endpoint = 4;
+    // Nexus service name.
+    string service = 5;
+    // Nexus operation name.
+    string operation = 6;
+
+    // Serialized input to the operation.
+    temporal.api.common.v1.Payload input = 7;
+
+    // Links for associating the caller with the operation.
+    repeated temporal.api.common.v1.Link links = 8;
+
+    // TODO: The following fields will be supported in the future:
+    // - nexus_header: map<string, string> for Nexus request headers (tracing, etc.)
+    // - callback: string for async completion delivery URL
+    // - callback_header: map<string, string> for callback request headers
+}
+
+message StartNexusOperationResponse {
+    // An operation completed successfully and synchronously.
+    message SyncSuccess {
+        temporal.api.common.v1.Payload payload = 1;
+    }
+
+    // An operation was started asynchronously. The token can be used for cancellation.
+    message AsyncSuccess {
+        string operation_token = 1;
+    }
+
+    // The operation completed unsuccessfully.
+    // The operation is considered canceled if the failure has a CanceledFailureInfo object attached.
+    message OperationFailure {
+        temporal.api.failure.v1.Failure failure = 1;
+    }
+
+    oneof variant {
+        SyncSuccess sync_success = 1;
+        AsyncSuccess async_success = 2;
+        OperationFailure operation_failure = 3;
+    }
+
+    // Links associated with the operation, as returned by the handler.
+    repeated temporal.api.nexus.v1.Link links = 4;
+}
+
+message CancelNexusOperationRequest {
+    // The namespace to authenticate to. This may be different from the target namespace of the specified endpoint.
+    string namespace = 1;
+    // The identity of the client who initiated this request.
+    string identity = 2;
+
+    // Endpoint name, resolved via the Temporal service's endpoint registry.
+    string endpoint = 3;
+    // Nexus service name.
+    string service = 4;
+    // Nexus operation name.
+    string operation = 5;
+    // Operation token from StartNexusOperationResponse.AsyncSuccess.
+    string operation_token = 6;
+}
+
+message CancelNexusOperationResponse {
+}

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -1458,4 +1458,34 @@ service WorkflowService {
     // (-- api-linter: core::0127::http-annotation=disabled
     //     aip.dev/not-precedent: Activity deletion not exposed to HTTP, users should use cancel or terminate. --)
     rpc DeleteActivityExecution (DeleteActivityExecutionRequest) returns (DeleteActivityExecutionResponse) {}
+
+    // StartNexusOperation starts a Nexus operation on an endpoint, communicating directly with the
+    // endpoint using the caller's namespace credentials.
+    // The response follows the Nexus RPC spec semantics: synchronous completion, asynchronous start,
+    // or operation error.
+    // Handler errors (e.g., NOT_FOUND, BAD_REQUEST) are returned as gRPC errors.
+    rpc StartNexusOperation (StartNexusOperationRequest) returns (StartNexusOperationResponse) {
+        option (google.api.http) = {
+            post: "/namespaces/{namespace}/nexus-requests/endpoints/{endpoint}/services/{service}/operations/{operation}"
+            body: "*"
+            additional_bindings {
+                post: "/api/v1/namespaces/{namespace}/nexus-requests/endpoints/{endpoint}/services/{service}/operations/{operation}"
+                body: "*"
+            }
+        };
+    }
+
+    // CancelNexusOperation requests cancellation of a previously started asynchronous Nexus operation.
+    // Cancellation is cooperative: this forwards a cancel request to the handler, but the operation
+    // will only transition to canceled if the handler processes it.
+    rpc CancelNexusOperation (CancelNexusOperationRequest) returns (CancelNexusOperationResponse) {
+        option (google.api.http) = {
+            post: "/namespaces/{namespace}/nexus-requests/endpoints/{endpoint}/services/{service}/operations/{operation}/cancel"
+            body: "*"
+            additional_bindings {
+                post: "/api/v1/namespaces/{namespace}/nexus-requests/endpoints/{endpoint}/services/{service}/operations/{operation}/cancel"
+                body: "*"
+            }
+        };
+    }
 }


### PR DESCRIPTION
**What changed?**

Added two new RPCs for making direct Nexus requests using namespace credentials: `StartNexusOperation` and `CancelNexusOperation`.

There's an open PR (#685) that adds support for standalone Nexus operations (with APIs named `StartNexusOperationExecution`, etc...), which is different than this.
Direct calls do not instantiate a state machine on the caller namespace, they go directly to the handler that is registered for the given endpoint.

The API was modeled after https://github.com/nexus-rpc/api/blob/main/SPEC.md but uses Temporal concepts such a payloads instead Nexus contents. This API is intentionally not compatible with the HTTP spec.

Note that the HTTP routes explicitly qualify these APIs as "requests" to contrast standalone Nexus operation routes, which qualify as "operations". The semantics of the two are different enough that it was deemed the right approach to separate these APIs.

**Why?**

Allows backing UIs and CLIs with Nexus handlers running on Temporal workers or invoking synchronous system Nexus endpoint operations with minimal overhead.

**Server PR**

Not yet.