### PR TITLE
Add external payload transfer stats for workflow tasks

### DIFF
--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -393,3 +393,24 @@ message OnConflictOptions {
     // Attaches the links to the running execution.
     bool attach_links = 3;
 }
+
+// External payload transfer stats, broken down by storage driver.
+message ExternalPayloadTransferStats {
+    repeated StorageDriverStats drivers = 1;
+
+    message StorageDriverStats {
+        // Storage driver these stats are for. Matches `StorageDriverInfo.type`.
+        string driver_type = 1;
+        // Accumulated upload stats.
+        TransferStats uploaded = 2;
+        // Accumulated download stats.
+        TransferStats downloaded = 3;
+    }
+
+    message TransferStats {
+        // Number of payloads transferred
+        int64 total_count = 1;
+        // Total size of payloads transferred in bytes
+        int64 total_size_bytes = 2;
+    }
+}

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -420,6 +420,9 @@ message RespondWorkflowTaskCompletedRequest {
     // tasks (e.g. activity cancellation) to this specific worker instance.
     string worker_control_task_queue = 20;
 
+    // External payload transfer stats accumulated for this task.
+    temporal.api.common.v1.ExternalPayloadTransferStats external_payload_transfer_stats = 21;
+
     // SDK capability details.
     message Capabilities {
         // True if the SDK can handle speculative workflow task with command events. If true, the


### PR DESCRIPTION
**What changed?**
Added `ExternalPayloadTransferStats` and a corresponding `external_payload_transfer_stats` field on `RespondWorkflowTaskCompletedRequest`.  The message carries a list of per-storage-driver entries, each with upload/download counts and byte totals. `ExternalPayloadTransferStats` is in common/v1 so we can extend it to other requests in the future if needed, e.g. `StartWorkflowExecutionRequest`. 

<!-- Tell your future self why have you made these changes -->
**Why?**
Lets SDKs report external payload transfer activity per workflow task so the server can emit workflow task latency metrics tagged by driver, and correlate latency with transferred bytes/count.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
None.

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
WIP