### PR TITLE
Remove experimental markers from Worker Deployment RPCs

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -1451,7 +1451,7 @@
     },
     "/api/v1/namespaces/{namespace}/current-deployment/{deployment.seriesName}": {
       "post": {
-        "summary": "Sets a deployment as the current deployment for its deployment series. Can optionally update\nthe metadata of the deployment as well.\nExperimental. This API might significantly change or be removed in a future release.\nDeprecated. Replaced by `SetWorkerDeploymentCurrentVersion`.",
+        "summary": "Sets a deployment as the current deployment for its deployment series. Can optionally update\nthe metadata of the deployment as well.\nDeprecated. Replaced by `SetWorkerDeploymentCurrentVersion`.",
         "operationId": "SetCurrentDeployment2",
         "responses": {
           "200": {
@@ -1497,7 +1497,7 @@
     },
     "/api/v1/namespaces/{namespace}/current-deployment/{seriesName}": {
       "get": {
-        "summary": "Returns the current deployment (and its info) for a given deployment series.\nExperimental. This API might significantly change or be removed in a future release.\nDeprecated. Replaced by `current_version` returned by `DescribeWorkerDeployment`.",
+        "summary": "Returns the current deployment (and its info) for a given deployment series.\nDeprecated. Replaced by `current_version` returned by `DescribeWorkerDeployment`.",
         "operationId": "GetCurrentDeployment2",
         "responses": {
           "200": {
@@ -1534,7 +1534,7 @@
     },
     "/api/v1/namespaces/{namespace}/deployments": {
       "get": {
-        "summary": "Lists worker deployments in the namespace. Optionally can filter based on deployment series\nname.\nExperimental. This API might significantly change or be removed in a future release.\nDeprecated. Replaced with `ListWorkerDeployments`.",
+        "summary": "Lists worker deployments in the namespace. Optionally can filter based on deployment series\nname.\nDeprecated. Replaced with `ListWorkerDeployments`.",
         "operationId": "ListDeployments2",
         "responses": {
           "200": {
@@ -1586,7 +1586,7 @@
     },
     "/api/v1/namespaces/{namespace}/deployments/{deployment.seriesName}/{deployment.buildId}": {
       "get": {
-        "summary": "Describes a worker deployment.\nExperimental. This API might significantly change or be removed in a future release.\nDeprecated. Replaced with `DescribeWorkerDeploymentVersion`.",
+        "summary": "Describes a worker deployment.\nDeprecated. Replaced with `DescribeWorkerDeploymentVersion`.",
         "operationId": "DescribeDeployment2",
         "responses": {
           "200": {
@@ -1631,7 +1631,7 @@
     },
     "/api/v1/namespaces/{namespace}/deployments/{deployment.seriesName}/{deployment.buildId}/reachability": {
       "get": {
-        "summary": "Returns the reachability level of a worker deployment to help users decide when it is time\nto decommission a deployment. Reachability level is calculated based on the deployment's\n`status` and existing workflows that depend on the given deployment for their execution.\nCalculating reachability is relatively expensive. Therefore, server might return a recently\ncached value. In such a case, the `last_update_time` will inform you about the actual\nreachability calculation time.\nExperimental. This API might significantly change or be removed in a future release.\nDeprecated. Replaced with `DrainageInfo` returned by `DescribeWorkerDeploymentVersion`.",
+        "summary": "Returns the reachability level of a worker deployment to help users decide when it is time\nto decommission a deployment. Reachability level is calculated based on the deployment's\n`status` and existing workflows that depend on the given deployment for their execution.\nCalculating reachability is relatively expensive. Therefore, server might return a recently\ncached value. In such a case, the `last_update_time` will inform you about the actual\nreachability calculation time.\nDeprecated. Replaced with `DrainageInfo` returned by `DescribeWorkerDeploymentVersion`.",
         "operationId": "GetDeploymentReachability2",
         "responses": {
           "200": {
@@ -2849,7 +2849,7 @@
     },
     "/api/v1/namespaces/{namespace}/worker-deployment-versions/{deploymentVersion.deploymentName}/{deploymentVersion.buildId}": {
       "get": {
-        "summary": "Describes a worker deployment version.\nExperimental. This API might significantly change or be removed in a future release.",
+        "summary": "Describes a worker deployment version.",
         "operationId": "DescribeWorkerDeploymentVersion2",
         "responses": {
           "200": {
@@ -2906,7 +2906,7 @@
         ]
       },
       "delete": {
-        "summary": "Used for manual deletion of Versions. User can delete a Version only when all the\nfollowing conditions are met:\n - It is not the Current or Ramping Version of its Deployment.\n - It has no active pollers (none of the task queues in the Version have pollers)\n - It is not draining (see WorkerDeploymentVersionInfo.drainage_info). This condition\n   can be skipped by passing `skip-drainage=true`.\nExperimental. This API might significantly change or be removed in a future release.",
+        "summary": "Used for manual deletion of Versions. User can delete a Version only when all the\nfollowing conditions are met:\n - It is not the Current or Ramping Version of its Deployment.\n - It has no active pollers (none of the task queues in the Version have pollers)\n - It is not draining (see WorkerDeploymentVersionInfo.drainage_info). This condition\n   can be skipped by passing `skip-drainage=true`.",
         "operationId": "DeleteWorkerDeploymentVersion2",
         "responses": {
           "200": {
@@ -3025,7 +3025,7 @@
     },
     "/api/v1/namespaces/{namespace}/worker-deployment-versions/{deploymentVersion.deploymentName}/{deploymentVersion.buildId}/update-metadata": {
       "post": {
-        "summary": "Updates the user-given metadata attached to a Worker Deployment Version.\nExperimental. This API might significantly change or be removed in a future release.",
+        "summary": "Updates the user-given metadata attached to a Worker Deployment Version.",
         "operationId": "UpdateWorkerDeploymentVersionMetadata2",
         "responses": {
           "200": {
@@ -3131,7 +3131,7 @@
     },
     "/api/v1/namespaces/{namespace}/worker-deployments": {
       "get": {
-        "summary": "Lists all Worker Deployments that are tracked in the Namespace.\nExperimental. This API might significantly change or be removed in a future release.",
+        "summary": "Lists all Worker Deployments that are tracked in the Namespace.",
         "operationId": "ListWorkerDeployments2",
         "responses": {
           "200": {
@@ -3176,7 +3176,7 @@
     },
     "/api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}": {
       "get": {
-        "summary": "Describes a Worker Deployment.\nExperimental. This API might significantly change or be removed in a future release.",
+        "summary": "Describes a Worker Deployment.",
         "operationId": "DescribeWorkerDeployment2",
         "responses": {
           "200": {
@@ -3211,7 +3211,7 @@
         ]
       },
       "delete": {
-        "summary": "Deletes records of (an old) Deployment. A deployment can only be deleted if\nit has no Version in it.\nExperimental. This API might significantly change or be removed in a future release.",
+        "summary": "Deletes records of (an old) Deployment. A deployment can only be deleted if\nit has no Version in it.",
         "operationId": "DeleteWorkerDeployment2",
         "responses": {
           "200": {
@@ -3300,7 +3300,7 @@
     },
     "/api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}/set-current-version": {
       "post": {
-        "summary": "Set/unset the Current Version of a Worker Deployment. Automatically unsets the Ramping\nVersion if it is the Version being set as Current.\nExperimental. This API might significantly change or be removed in a future release.",
+        "summary": "Set/unset the Current Version of a Worker Deployment. Automatically unsets the Ramping\nVersion if it is the Version being set as Current.",
         "operationId": "SetWorkerDeploymentCurrentVersion2",
         "responses": {
           "200": {
@@ -3390,7 +3390,7 @@
     },
     "/api/v1/namespaces/{namespace}/worker-deployments/{deploymentName}/set-ramping-version": {
       "post": {
-        "summary": "Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for\ngradual ramp to unversioned workers too.\nExperimental. This API might significantly change or be removed in a future release.",
+        "summary": "Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for\ngradual ramp to unversioned workers too.",
         "operationId": "SetWorkerDeploymentRampingVersion2",
         "responses": {
           "200": {
@@ -7104,7 +7104,7 @@
     },
     "/namespaces/{namespace}/current-deployment/{deployment.seriesName}": {
       "post": {
-        "summary": "Sets a deployment as the current deployment for its deployment series. Can optionally update\nthe metadata of the deployment as well.\nExperimental. This API might significantly change or be removed in a future release.\nDeprecated. Replaced by `SetWorkerDeploymentCurrentVersion`.",
+        "summary": "Sets a deployment as the current deployment for its deployment series. Can optionally update\nthe metadata of the deployment as well.\nDeprecated. Replaced by `SetWorkerDeploymentCurrentVersion`.",
         "operationId": "SetCurrentDeployment",
         "responses": {
           "200": {
@@ -7150,7 +7150,7 @@
     },
     "/namespaces/{namespace}/current-deployment/{seriesName}": {
       "get": {
-        "summary": "Returns the current deployment (and its info) for a given deployment series.\nExperimental. This API might significantly change or be removed in a future release.\nDeprecated. Replaced by `current_version` returned by `DescribeWorkerDeployment`.",
+        "summary": "Returns the current deployment (and its info) for a given deployment series.\nDeprecated. Replaced by `current_version` returned by `DescribeWorkerDeployment`.",
         "operationId": "GetCurrentDeployment",
         "responses": {
           "200": {
@@ -7187,7 +7187,7 @@
     },
     "/namespaces/{namespace}/deployments": {
       "get": {
-        "summary": "Lists worker deployments in the namespace. Optionally can filter based on deployment series\nname.\nExperimental. This API might significantly change or be removed in a future release.\nDeprecated. Replaced with `ListWorkerDeployments`.",
+        "summary": "Lists worker deployments in the namespace. Optionally can filter based on deployment series\nname.\nDeprecated. Replaced with `ListWorkerDeployments`.",
         "operationId": "ListDeployments",
         "responses": {
           "200": {
@@ -7239,7 +7239,7 @@
     },
     "/namespaces/{namespace}/deployments/{deployment.seriesName}/{deployment.buildId}": {
       "get": {
-        "summary": "Describes a worker deployment.\nExperimental. This API might significantly change or be removed in a future release.\nDeprecated. Replaced with `DescribeWorkerDeploymentVersion`.",
+        "summary": "Describes a worker deployment.\nDeprecated. Replaced with `DescribeWorkerDeploymentVersion`.",
         "operationId": "DescribeDeployment",
         "responses": {
           "200": {
@@ -7284,7 +7284,7 @@
     },
     "/namespaces/{namespace}/deployments/{deployment.seriesName}/{deployment.buildId}/reachability": {
       "get": {
-        "summary": "Returns the reachability level of a worker deployment to help users decide when it is time\nto decommission a deployment. Reachability level is calculated based on the deployment's\n`status` and existing workflows that depend on the given deployment for their execution.\nCalculating reachability is relatively expensive. Therefore, server might return a recently\ncached value. In such a case, the `last_update_time` will inform you about the actual\nreachability calculation time.\nExperimental. This API might significantly change or be removed in a future release.\nDeprecated. Replaced with `DrainageInfo` returned by `DescribeWorkerDeploymentVersion`.",
+        "summary": "Returns the reachability level of a worker deployment to help users decide when it is time\nto decommission a deployment. Reachability level is calculated based on the deployment's\n`status` and existing workflows that depend on the given deployment for their execution.\nCalculating reachability is relatively expensive. Therefore, server might return a recently\ncached value. In such a case, the `last_update_time` will inform you about the actual\nreachability calculation time.\nDeprecated. Replaced with `DrainageInfo` returned by `DescribeWorkerDeploymentVersion`.",
         "operationId": "GetDeploymentReachability",
         "responses": {
           "200": {
@@ -8432,7 +8432,7 @@
     },
     "/namespaces/{namespace}/worker-deployment-versions/{deploymentVersion.deploymentName}/{deploymentVersion.buildId}": {
       "get": {
-        "summary": "Describes a worker deployment version.\nExperimental. This API might significantly change or be removed in a future release.",
+        "summary": "Describes a worker deployment version.",
         "operationId": "DescribeWorkerDeploymentVersion",
         "responses": {
           "200": {
@@ -8489,7 +8489,7 @@
         ]
       },
       "delete": {
-        "summary": "Used for manual deletion of Versions. User can delete a Version only when all the\nfollowing conditions are met:\n - It is not the Current or Ramping Version of its Deployment.\n - It has no active pollers (none of the task queues in the Version have pollers)\n - It is not draining (see WorkerDeploymentVersionInfo.drainage_info). This condition\n   can be skipped by passing `skip-drainage=true`.\nExperimental. This API might significantly change or be removed in a future release.",
+        "summary": "Used for manual deletion of Versions. User can delete a Version only when all the\nfollowing conditions are met:\n - It is not the Current or Ramping Version of its Deployment.\n - It has no active pollers (none of the task queues in the Version have pollers)\n - It is not draining (see WorkerDeploymentVersionInfo.drainage_info). This condition\n   can be skipped by passing `skip-drainage=true`.",
         "operationId": "DeleteWorkerDeploymentVersion",
         "responses": {
           "200": {
@@ -8608,7 +8608,7 @@
     },
     "/namespaces/{namespace}/worker-deployment-versions/{deploymentVersion.deploymentName}/{deploymentVersion.buildId}/update-metadata": {
       "post": {
-        "summary": "Updates the user-given metadata attached to a Worker Deployment Version.\nExperimental. This API might significantly change or be removed in a future release.",
+        "summary": "Updates the user-given metadata attached to a Worker Deployment Version.",
         "operationId": "UpdateWorkerDeploymentVersionMetadata",
         "responses": {
           "200": {
@@ -8714,7 +8714,7 @@
     },
     "/namespaces/{namespace}/worker-deployments": {
       "get": {
-        "summary": "Lists all Worker Deployments that are tracked in the Namespace.\nExperimental. This API might significantly change or be removed in a future release.",
+        "summary": "Lists all Worker Deployments that are tracked in the Namespace.",
         "operationId": "ListWorkerDeployments",
         "responses": {
           "200": {
@@ -8759,7 +8759,7 @@
     },
     "/namespaces/{namespace}/worker-deployments/{deploymentName}": {
       "get": {
-        "summary": "Describes a Worker Deployment.\nExperimental. This API might significantly change or be removed in a future release.",
+        "summary": "Describes a Worker Deployment.",
         "operationId": "DescribeWorkerDeployment",
         "responses": {
           "200": {
@@ -8794,7 +8794,7 @@
         ]
       },
       "delete": {
-        "summary": "Deletes records of (an old) Deployment. A deployment can only be deleted if\nit has no Version in it.\nExperimental. This API might significantly change or be removed in a future release.",
+        "summary": "Deletes records of (an old) Deployment. A deployment can only be deleted if\nit has no Version in it.",
         "operationId": "DeleteWorkerDeployment",
         "responses": {
           "200": {
@@ -8883,7 +8883,7 @@
     },
     "/namespaces/{namespace}/worker-deployments/{deploymentName}/set-current-version": {
       "post": {
-        "summary": "Set/unset the Current Version of a Worker Deployment. Automatically unsets the Ramping\nVersion if it is the Version being set as Current.\nExperimental. This API might significantly change or be removed in a future release.",
+        "summary": "Set/unset the Current Version of a Worker Deployment. Automatically unsets the Ramping\nVersion if it is the Version being set as Current.",
         "operationId": "SetWorkerDeploymentCurrentVersion",
         "responses": {
           "200": {
@@ -8973,7 +8973,7 @@
     },
     "/namespaces/{namespace}/worker-deployments/{deploymentName}/set-ramping-version": {
       "post": {
-        "summary": "Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for\ngradual ramp to unversioned workers too.\nExperimental. This API might significantly change or be removed in a future release.",
+        "summary": "Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for\ngradual ramp to unversioned workers too.",
         "operationId": "SetWorkerDeploymentRampingVersion",
         "responses": {
           "200": {

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -1324,7 +1324,6 @@ paths:
       description: |-
         Sets a deployment as the current deployment for its deployment series. Can optionally update
          the metadata of the deployment as well.
-         Experimental. This API might significantly change or be removed in a future release.
          Deprecated. Replaced by `SetWorkerDeploymentCurrentVersion`.
       operationId: SetCurrentDeployment
       parameters:
@@ -1363,7 +1362,6 @@ paths:
         - WorkflowService
       description: |-
         Returns the current deployment (and its info) for a given deployment series.
-         Experimental. This API might significantly change or be removed in a future release.
          Deprecated. Replaced by `current_version` returned by `DescribeWorkerDeployment`.
       operationId: GetCurrentDeployment
       parameters:
@@ -1397,7 +1395,6 @@ paths:
       description: |-
         Lists worker deployments in the namespace. Optionally can filter based on deployment series
          name.
-         Experimental. This API might significantly change or be removed in a future release.
          Deprecated. Replaced with `ListWorkerDeployments`.
       operationId: ListDeployments
       parameters:
@@ -1440,7 +1437,6 @@ paths:
         - WorkflowService
       description: |-
         Describes a worker deployment.
-         Experimental. This API might significantly change or be removed in a future release.
          Deprecated. Replaced with `DescribeWorkerDeploymentVersion`.
       operationId: DescribeDeployment
       parameters:
@@ -1500,7 +1496,6 @@ paths:
          Calculating reachability is relatively expensive. Therefore, server might return a recently
          cached value. In such a case, the `last_update_time` will inform you about the actual
          reachability calculation time.
-         Experimental. This API might significantly change or be removed in a future release.
          Deprecated. Replaced with `DrainageInfo` returned by `DescribeWorkerDeploymentVersion`.
       operationId: GetDeploymentReachability
       parameters:
@@ -2570,9 +2565,7 @@ paths:
     get:
       tags:
         - WorkflowService
-      description: |-
-        Describes a worker deployment version.
-         Experimental. This API might significantly change or be removed in a future release.
+      description: Describes a worker deployment version.
       operationId: DescribeWorkerDeploymentVersion
       parameters:
         - name: namespace
@@ -2637,7 +2630,6 @@ paths:
           - It has no active pollers (none of the task queues in the Version have pollers)
           - It is not draining (see WorkerDeploymentVersionInfo.drainage_info). This condition
             can be skipped by passing `skip-drainage=true`.
-         Experimental. This API might significantly change or be removed in a future release.
       operationId: DeleteWorkerDeploymentVersion
       parameters:
         - name: namespace
@@ -2746,9 +2738,7 @@ paths:
   : post:
       tags:
         - WorkflowService
-      description: |-
-        Updates the user-given metadata attached to a Worker Deployment Version.
-         Experimental. This API might significantly change or be removed in a future release.
+      description: Updates the user-given metadata attached to a Worker Deployment Version.
       operationId: UpdateWorkerDeploymentVersionMetadata
       parameters:
         - name: namespace
@@ -2832,9 +2822,7 @@ paths:
     get:
       tags:
         - WorkflowService
-      description: |-
-        Lists all Worker Deployments that are tracked in the Namespace.
-         Experimental. This API might significantly change or be removed in a future release.
+      description: Lists all Worker Deployments that are tracked in the Namespace.
       operationId: ListWorkerDeployments
       parameters:
         - name: namespace
@@ -2869,9 +2857,7 @@ paths:
     get:
       tags:
         - WorkflowService
-      description: |-
-        Describes a Worker Deployment.
-         Experimental. This API might significantly change or be removed in a future release.
+      description: Describes a Worker Deployment.
       operationId: DescribeWorkerDeployment
       parameters:
         - name: namespace
@@ -2945,7 +2931,6 @@ paths:
       description: |-
         Deletes records of (an old) Deployment. A deployment can only be deleted if
          it has no Version in it.
-         Experimental. This API might significantly change or be removed in a future release.
       operationId: DeleteWorkerDeployment
       parameters:
         - name: namespace
@@ -2983,7 +2968,6 @@ paths:
       description: |-
         Set/unset the Current Version of a Worker Deployment. Automatically unsets the Ramping
          Version if it is the Version being set as Current.
-         Experimental. This API might significantly change or be removed in a future release.
       operationId: SetWorkerDeploymentCurrentVersion
       parameters:
         - name: namespace
@@ -3060,7 +3044,6 @@ paths:
       description: |-
         Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for
          gradual ramp to unversioned workers too.
-         Experimental. This API might significantly change or be removed in a future release.
       operationId: SetWorkerDeploymentRampingVersion
       parameters:
         - name: namespace
@@ -6422,7 +6405,6 @@ paths:
       description: |-
         Sets a deployment as the current deployment for its deployment series. Can optionally update
          the metadata of the deployment as well.
-         Experimental. This API might significantly change or be removed in a future release.
          Deprecated. Replaced by `SetWorkerDeploymentCurrentVersion`.
       operationId: SetCurrentDeployment
       parameters:
@@ -6461,7 +6443,6 @@ paths:
         - WorkflowService
       description: |-
         Returns the current deployment (and its info) for a given deployment series.
-         Experimental. This API might significantly change or be removed in a future release.
          Deprecated. Replaced by `current_version` returned by `DescribeWorkerDeployment`.
       operationId: GetCurrentDeployment
       parameters:
@@ -6495,7 +6476,6 @@ paths:
       description: |-
         Lists worker deployments in the namespace. Optionally can filter based on deployment series
          name.
-         Experimental. This API might significantly change or be removed in a future release.
          Deprecated. Replaced with `ListWorkerDeployments`.
       operationId: ListDeployments
       parameters:
@@ -6538,7 +6518,6 @@ paths:
         - WorkflowService
       description: |-
         Describes a worker deployment.
-         Experimental. This API might significantly change or be removed in a future release.
          Deprecated. Replaced with `DescribeWorkerDeploymentVersion`.
       operationId: DescribeDeployment
       parameters:
@@ -6598,7 +6577,6 @@ paths:
          Calculating reachability is relatively expensive. Therefore, server might return a recently
          cached value. In such a case, the `last_update_time` will inform you about the actual
          reachability calculation time.
-         Experimental. This API might significantly change or be removed in a future release.
          Deprecated. Replaced with `DrainageInfo` returned by `DescribeWorkerDeploymentVersion`.
       operationId: GetDeploymentReachability
       parameters:
@@ -7610,9 +7588,7 @@ paths:
     get:
       tags:
         - WorkflowService
-      description: |-
-        Describes a worker deployment version.
-         Experimental. This API might significantly change or be removed in a future release.
+      description: Describes a worker deployment version.
       operationId: DescribeWorkerDeploymentVersion
       parameters:
         - name: namespace
@@ -7677,7 +7653,6 @@ paths:
           - It has no active pollers (none of the task queues in the Version have pollers)
           - It is not draining (see WorkerDeploymentVersionInfo.drainage_info). This condition
             can be skipped by passing `skip-drainage=true`.
-         Experimental. This API might significantly change or be removed in a future release.
       operationId: DeleteWorkerDeploymentVersion
       parameters:
         - name: namespace
@@ -7786,9 +7761,7 @@ paths:
   : post:
       tags:
         - WorkflowService
-      description: |-
-        Updates the user-given metadata attached to a Worker Deployment Version.
-         Experimental. This API might significantly change or be removed in a future release.
+      description: Updates the user-given metadata attached to a Worker Deployment Version.
       operationId: UpdateWorkerDeploymentVersionMetadata
       parameters:
         - name: namespace
@@ -7872,9 +7845,7 @@ paths:
     get:
       tags:
         - WorkflowService
-      description: |-
-        Lists all Worker Deployments that are tracked in the Namespace.
-         Experimental. This API might significantly change or be removed in a future release.
+      description: Lists all Worker Deployments that are tracked in the Namespace.
       operationId: ListWorkerDeployments
       parameters:
         - name: namespace
@@ -7909,9 +7880,7 @@ paths:
     get:
       tags:
         - WorkflowService
-      description: |-
-        Describes a Worker Deployment.
-         Experimental. This API might significantly change or be removed in a future release.
+      description: Describes a Worker Deployment.
       operationId: DescribeWorkerDeployment
       parameters:
         - name: namespace
@@ -7985,7 +7954,6 @@ paths:
       description: |-
         Deletes records of (an old) Deployment. A deployment can only be deleted if
          it has no Version in it.
-         Experimental. This API might significantly change or be removed in a future release.
       operationId: DeleteWorkerDeployment
       parameters:
         - name: namespace
@@ -8023,7 +7991,6 @@ paths:
       description: |-
         Set/unset the Current Version of a Worker Deployment. Automatically unsets the Ramping
          Version if it is the Version being set as Current.
-         Experimental. This API might significantly change or be removed in a future release.
       operationId: SetWorkerDeploymentCurrentVersion
       parameters:
         - name: namespace
@@ -8100,7 +8067,6 @@ paths:
       description: |-
         Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for
          gradual ramp to unversioned workers too.
-         Experimental. This API might significantly change or be removed in a future release.
       operationId: SetWorkerDeploymentRampingVersion
       parameters:
         - name: namespace

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -953,7 +953,6 @@ service WorkflowService {
     }
 
     // Describes a worker deployment.
-    // Experimental. This API might significantly change or be removed in a future release.
     // Deprecated. Replaced with `DescribeWorkerDeploymentVersion`.
     rpc DescribeDeployment (DescribeDeploymentRequest) returns (DescribeDeploymentResponse) {
         option (google.api.http) = {
@@ -965,7 +964,6 @@ service WorkflowService {
     }
 
     // Describes a worker deployment version.
-    // Experimental. This API might significantly change or be removed in a future release.
     rpc DescribeWorkerDeploymentVersion (DescribeWorkerDeploymentVersionRequest) returns (DescribeWorkerDeploymentVersionResponse) {
         option (google.api.http) = {
             get: "/namespaces/{namespace}/worker-deployment-versions/{deployment_version.deployment_name}/{deployment_version.build_id}"
@@ -981,7 +979,6 @@ service WorkflowService {
 
     // Lists worker deployments in the namespace. Optionally can filter based on deployment series
     // name.
-    // Experimental. This API might significantly change or be removed in a future release.
     // Deprecated. Replaced with `ListWorkerDeployments`.
     rpc ListDeployments (ListDeploymentsRequest) returns (ListDeploymentsResponse) {
         option (google.api.http) = {
@@ -998,7 +995,6 @@ service WorkflowService {
     // Calculating reachability is relatively expensive. Therefore, server might return a recently
     // cached value. In such a case, the `last_update_time` will inform you about the actual
     // reachability calculation time.
-    // Experimental. This API might significantly change or be removed in a future release.
     // Deprecated. Replaced with `DrainageInfo` returned by `DescribeWorkerDeploymentVersion`.
     rpc GetDeploymentReachability (GetDeploymentReachabilityRequest) returns (GetDeploymentReachabilityResponse) {
         option (google.api.http) = {
@@ -1010,7 +1006,6 @@ service WorkflowService {
     }
 
     // Returns the current deployment (and its info) for a given deployment series.
-    // Experimental. This API might significantly change or be removed in a future release.
     // Deprecated. Replaced by `current_version` returned by `DescribeWorkerDeployment`.
     rpc GetCurrentDeployment (GetCurrentDeploymentRequest) returns (GetCurrentDeploymentResponse) {
         option (google.api.http) = {
@@ -1023,7 +1018,6 @@ service WorkflowService {
 
     // Sets a deployment as the current deployment for its deployment series. Can optionally update
     // the metadata of the deployment as well.
-    // Experimental. This API might significantly change or be removed in a future release.
     // Deprecated. Replaced by `SetWorkerDeploymentCurrentVersion`.
     rpc SetCurrentDeployment (SetCurrentDeploymentRequest) returns (SetCurrentDeploymentResponse) {
         option (google.api.http) = {
@@ -1038,7 +1032,6 @@ service WorkflowService {
 
     // Set/unset the Current Version of a Worker Deployment. Automatically unsets the Ramping
     // Version if it is the Version being set as Current.
-    // Experimental. This API might significantly change or be removed in a future release.
     rpc SetWorkerDeploymentCurrentVersion (SetWorkerDeploymentCurrentVersionRequest) returns (SetWorkerDeploymentCurrentVersionResponse) {
         option (google.api.http) = {
             post: "/namespaces/{namespace}/worker-deployments/{deployment_name}/set-current-version"
@@ -1055,7 +1048,6 @@ service WorkflowService {
     }
 
     // Describes a Worker Deployment.
-    // Experimental. This API might significantly change or be removed in a future release.
     rpc DescribeWorkerDeployment (DescribeWorkerDeploymentRequest) returns (DescribeWorkerDeploymentResponse) {
         option (google.api.http) = {
             get: "/namespaces/{namespace}/worker-deployments/{deployment_name}"
@@ -1071,7 +1063,6 @@ service WorkflowService {
 
     // Deletes records of (an old) Deployment. A deployment can only be deleted if
     // it has no Version in it.
-    // Experimental. This API might significantly change or be removed in a future release.
     rpc DeleteWorkerDeployment (DeleteWorkerDeploymentRequest) returns (DeleteWorkerDeploymentResponse) {
         option (google.api.http) = {
             delete: "/namespaces/{namespace}/worker-deployments/{deployment_name}"
@@ -1092,7 +1083,6 @@ service WorkflowService {
     //  - It has no active pollers (none of the task queues in the Version have pollers)
     //  - It is not draining (see WorkerDeploymentVersionInfo.drainage_info). This condition
     //    can be skipped by passing `skip-drainage=true`.
-    // Experimental. This API might significantly change or be removed in a future release.
     rpc DeleteWorkerDeploymentVersion (DeleteWorkerDeploymentVersionRequest) returns (DeleteWorkerDeploymentVersionResponse) {
         option (google.api.http) = {
             delete: "/namespaces/{namespace}/worker-deployment-versions/{deployment_version.deployment_name}/{deployment_version.build_id}"
@@ -1108,7 +1098,6 @@ service WorkflowService {
 
     // Set/unset the Ramping Version of a Worker Deployment and its ramp percentage. Can be used for
     // gradual ramp to unversioned workers too.
-    // Experimental. This API might significantly change or be removed in a future release.
     rpc SetWorkerDeploymentRampingVersion (SetWorkerDeploymentRampingVersionRequest) returns (SetWorkerDeploymentRampingVersionResponse) {
         option (google.api.http) = {
             post: "/namespaces/{namespace}/worker-deployments/{deployment_name}/set-ramping-version"
@@ -1125,7 +1114,6 @@ service WorkflowService {
     }
 
     // Lists all Worker Deployments that are tracked in the Namespace.
-    // Experimental. This API might significantly change or be removed in a future release.
     rpc ListWorkerDeployments (ListWorkerDeploymentsRequest) returns (ListWorkerDeploymentsResponse) {
         option (google.api.http) = {
             get: "/namespaces/{namespace}/worker-deployments"
@@ -1192,7 +1180,6 @@ service WorkflowService {
     }
 
     // Updates the user-given metadata attached to a Worker Deployment Version.
-    // Experimental. This API might significantly change or be removed in a future release.
     rpc UpdateWorkerDeploymentVersionMetadata (UpdateWorkerDeploymentVersionMetadataRequest) returns (UpdateWorkerDeploymentVersionMetadataResponse) {
         option (google.api.http) = {
             post: "/namespaces/{namespace}/worker-deployment-versions/{deployment_version.deployment_name}/{deployment_version.build_id}/update-metadata"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Drop experimental tags

<!-- Tell your future self why have you made these changes -->
**Why?**

It's not experimental anymore.
Also PHP SDK uses this api files to generate PHP classes and every time it adds `@experimental` tags which was removed several months ago https://github.com/temporalio/sdk-php/commit/3ca71a553f66904009b5c906aad7ccdcef428f1b



<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
