### PR TITLE
Task queue config for whole-queue concurrency limit

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -15071,6 +15071,27 @@
       },
       "description": "ComputeStatus represents compute-related configuration and health for a Worker Deployment Version."
     },
+    "v1ConcurrencyLimit": {
+      "type": "object",
+      "properties": {
+        "concurrentTasks": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of concurrent tasks that may be running at a time across the whole task\nqueue. Note that in situations like network partitions, the server's idea of what is\nrunning on workers may be out of date, and this limit could be exceeded from the point\nof view of workers."
+        }
+      }
+    },
+    "v1ConcurrencyLimitConfig": {
+      "type": "object",
+      "properties": {
+        "concurrencyLimit": {
+          "$ref": "#/definitions/v1ConcurrencyLimit"
+        },
+        "metadata": {
+          "$ref": "#/definitions/v1ConfigMetadata"
+        }
+      }
+    },
     "v1ConfigMetadata": {
       "type": "object",
       "properties": {
@@ -20012,6 +20033,10 @@
             "format": "float"
           },
           "description": "If set, overrides the fairness weights for the corresponding fairness keys."
+        },
+        "queueConcurrencyLimit": {
+          "$ref": "#/definitions/v1ConcurrencyLimitConfig",
+          "description": "Concurrency limit for the whole queue."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -11342,16 +11342,29 @@
       "default": "RUNTIME_TYPE_UNSPECIFIED",
       "description": " - RUNTIME_TYPE_UNSPECIFIED: Should never actually be set, exists to follow convention of having a default.\nSDKs should just leave `runtimes` empty if none can be determined."
     },
+    "UpdateTaskQueueConfigRequestConcurrencyLimitUpdate": {
+      "type": "object",
+      "properties": {
+        "concurrencyLimit": {
+          "$ref": "#/definitions/v1ConcurrencyLimit",
+          "title": "Limit to be updated"
+        },
+        "reason": {
+          "type": "string",
+          "title": "Reason why the limit was updated"
+        }
+      }
+    },
     "UpdateTaskQueueConfigRequestRateLimitUpdate": {
       "type": "object",
       "properties": {
         "rateLimit": {
           "$ref": "#/definitions/v1RateLimit",
-          "title": "Rate Limit to be updated"
+          "title": "Rate limit to be updated"
         },
         "reason": {
           "type": "string",
-          "description": "Reason for why the rate limit was set."
+          "title": "Reason why the rate limit was updated"
         }
       }
     },
@@ -13210,6 +13223,10 @@
             "type": "string"
           },
           "description": "If set, removes any existing fairness weight overrides for each specified fairness key.\nFairness weights for corresponding keys fall back to the values set during task creation (if any),\nor to the default weight of 1.0."
+        },
+        "updateQueueConcurrencyLimit": {
+          "$ref": "#/definitions/UpdateTaskQueueConfigRequestConcurrencyLimitUpdate",
+          "description": "Update queue-wide concurrency limit.\nIf not set, this configuration is unchanged.\nIf the `concurrency_limit` field in the `ConcurrencyLimitUpdate` is missing, remove the existing limit."
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -11284,6 +11284,24 @@ components:
       description: |-
         ProviderValidationStatus represents the result of the most recent
          connectivity check between Temporal and a customer's compute provider.
+    ConcurrencyLimit:
+      type: object
+      properties:
+        concurrentTasks:
+          type: integer
+          description: |-
+            Maximum number of concurrent tasks that may be running at a time across the whole task
+             queue. Note that in situations like network partitions, the server's idea of what is
+             running on workers may be out of date, and this limit could be exceeded from the point
+             of view of workers.
+          format: int32
+    ConcurrencyLimitConfig:
+      type: object
+      properties:
+        concurrencyLimit:
+          $ref: '#/components/schemas/ConcurrencyLimit'
+        metadata:
+          $ref: '#/components/schemas/ConfigMetadata'
     ConfigMetadata:
       type: object
       properties:
@@ -17649,6 +17667,10 @@ components:
             type: number
             format: float
           description: If set, overrides the fairness weights for the corresponding fairness keys.
+        queueConcurrencyLimit:
+          allOf:
+            - $ref: '#/components/schemas/ConcurrencyLimitConfig'
+          description: Concurrency limit for the whole queue.
     TaskQueueReachability:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -18555,16 +18555,33 @@ components:
             If set, removes any existing fairness weight overrides for each specified fairness key.
              Fairness weights for corresponding keys fall back to the values set during task creation (if any),
              or to the default weight of 1.0.
+        updateQueueConcurrencyLimit:
+          allOf:
+            - $ref: '#/components/schemas/UpdateTaskQueueConfigRequest_ConcurrencyLimitUpdate'
+          description: |-
+            Update queue-wide concurrency limit.
+             If not set, this configuration is unchanged.
+             If the `concurrency_limit` field in the `ConcurrencyLimitUpdate` is missing, remove the existing limit.
+    UpdateTaskQueueConfigRequest_ConcurrencyLimitUpdate:
+      type: object
+      properties:
+        concurrencyLimit:
+          allOf:
+            - $ref: '#/components/schemas/ConcurrencyLimit'
+          description: Limit to be updated
+        reason:
+          type: string
+          description: Reason why the limit was updated
     UpdateTaskQueueConfigRequest_RateLimitUpdate:
       type: object
       properties:
         rateLimit:
           allOf:
             - $ref: '#/components/schemas/RateLimit'
-          description: Rate Limit to be updated
+          description: Rate limit to be updated
         reason:
           type: string
-          description: Reason for why the rate limit was set.
+          description: Reason why the rate limit was updated
     UpdateTaskQueueConfigResponse:
       type: object
       properties:

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -342,6 +342,14 @@ message RateLimit {
     float requests_per_second = 1;
 }
 
+message ConcurrencyLimit {
+    // Maximum number of concurrent tasks that may be running at a time across the whole task
+    // queue. Note that in situations like network partitions, the server's idea of what is
+    // running on workers may be out of date, and this limit could be exceeded from the point
+    // of view of workers.
+    int32 concurrent_tasks = 1;
+}
+
 message ConfigMetadata {
     // Reason for why the config was set.
     string reason = 1;
@@ -359,6 +367,11 @@ message RateLimitConfig {
     ConfigMetadata metadata = 2;
 }
 
+message ConcurrencyLimitConfig {
+    ConcurrencyLimit concurrency_limit = 1;
+    ConfigMetadata metadata = 2;
+}
+
 message TaskQueueConfig {
     // Unless modified, this is the system-defined rate limit.
     RateLimitConfig queue_rate_limit = 1;
@@ -366,4 +379,6 @@ message TaskQueueConfig {
     RateLimitConfig fairness_keys_rate_limit_default = 2;
     // If set, overrides the fairness weights for the corresponding fairness keys.
     map<string, float> fairness_weight_overrides = 3;
+    // Concurrency limit for the whole queue.
+    ConcurrencyLimitConfig queue_concurrency_limit = 4;
 }

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -337,7 +337,7 @@ message PollerScalingDecision {
   int32 poll_request_delta_suggestion = 1;
 }
 
-message RateLimit { 
+message RateLimit {
     // Zero is a valid rate limit.
     float requests_per_second = 1;
 }
@@ -349,13 +349,13 @@ message ConfigMetadata {
     // Identity of the last updater.
     // Set by the request's identity field.
     string update_identity = 2;
-    
+
     // Time of the last update.
     google.protobuf.Timestamp update_time = 3;
 }
 
-message RateLimitConfig { 
-    RateLimit rate_limit = 1;    
+message RateLimitConfig {
+    RateLimit rate_limit = 1;
     ConfigMetadata metadata = 2;
 }
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -3043,9 +3043,16 @@ message ListWorkersResponse {
 
 message UpdateTaskQueueConfigRequest {
     message RateLimitUpdate {
-        // Rate Limit to be updated
+        // Rate limit to be updated
         temporal.api.taskqueue.v1.RateLimit rate_limit = 1;
-        // Reason for why the rate limit was set.
+        // Reason why the rate limit was updated
+        string reason = 2;
+    }
+
+    message ConcurrencyLimitUpdate {
+        // Limit to be updated
+        temporal.api.taskqueue.v1.ConcurrencyLimit concurrency_limit = 1;
+        // Reason why the limit was updated
         string reason = 2;
     }
 
@@ -3070,6 +3077,10 @@ message UpdateTaskQueueConfigRequest {
     // Fairness weights for corresponding keys fall back to the values set during task creation (if any),
     // or to the default weight of 1.0.
     repeated string unset_fairness_weight_overrides = 8;
+    // Update queue-wide concurrency limit.
+    // If not set, this configuration is unchanged.
+    // If the `concurrency_limit` field in the `ConcurrencyLimitUpdate` is missing, remove the existing limit.
+    ConcurrencyLimitUpdate update_queue_concurrency_limit = 9;
 }
 
 message UpdateTaskQueueConfigResponse {


### PR DESCRIPTION
**What changed?**
Add whole-queue concurrency limit config to task queue config.

**Why?**
Simplest possible concurrency limit. Server-side implementation is easier to manage than worker slots.