### PR TITLE
Fix comments on ResourceExhaustedScope enum values.

### DIFF
--- a/temporal/api/enums/v1/failed_cause.proto
+++ b/temporal/api/enums/v1/failed_cause.proto
@@ -139,8 +139,8 @@ enum ResourceExhaustedCause {
 
 enum ResourceExhaustedScope {
     RESOURCE_EXHAUSTED_SCOPE_UNSPECIFIED = 0;
-    // Exhausted resource is a system-level resource.
-    RESOURCE_EXHAUSTED_SCOPE_NAMESPACE = 1;
     // Exhausted resource is a namespace-level resource.
+    RESOURCE_EXHAUSTED_SCOPE_NAMESPACE = 1;
+    // Exhausted resource is a system-level resource.
     RESOURCE_EXHAUSTED_SCOPE_SYSTEM = 2;
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Fixed comments on `RESOURCE_EXHAUSTED_SCOPE_NAMESPACE` and `RESOURCE_EXHAUSTED_SCOPE_SYSTEM`. They were reversed.

<!-- Tell your future self why have you made these changes -->
**Why?**

Because they were reversed.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**

Nope, comment only change.

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**

n/a