### PR TITLE
Expose signal-with-start request headers

### DIFF
--- a/nexus/deps/nexus-temporal-types/model.wit
+++ b/nexus/deps/nexus-temporal-types/model.wit
@@ -98,6 +98,17 @@ interface model {
   /// @nexus.type python="collections.abc.Mapping[str, typing.Any]" typescript="Record<string, unknown>" dotnet="IReadOnlyDictionary<string, object?>"
   type memo = placeholder;
 
+  /// @nexus.proto "temporal.api.common.v1.Header" typescript-import="@temporalio/proto"
+  /// @nexus.type
+  ///   python="collections.abc.Mapping[str, typing.Any]"
+  ///   typescript="common.Headers"
+  ///   go="map[string]any"
+  ///   dotnet="IReadOnlyDictionary<string, object?>"
+  ///   dotnet-from="ProtoExtensions.FromHeaderProto"
+  ///   dotnet-to="ProtoExtensions.ToHeaderProto"
+  ///   typescript-import="@temporalio/common"
+  type header = placeholder;
+
   /// @nexus.proto "temporal.api.common.v1.SearchAttributes" typescript-import="@temporalio/proto"
   /// @nexus.type
   ///   python="temporalio.common.TypedSearchAttributes"

--- a/nexus/workflow-service.wit
+++ b/nexus/workflow-service.wit
@@ -13,6 +13,7 @@ world system {
 interface workflow-service {
   use nexus:temporal-types/model@1.0.0.{
     duration,
+    header,
     memo,
     payloads,
     placeholder,
@@ -89,8 +90,9 @@ interface workflow-service {
     namespace: string,
     /// @nexus.omit
     control: placeholder,
-    /// @nexus.omit
-    header: placeholder,
+    /// @nexus.api-omit
+    /// @nexus.proto-field "header"
+    headers: option<header>,
     /// @nexus.omit
     links: placeholder,
     /// @nexus.omit


### PR DESCRIPTION
Expose the SignalWithStart request header field in the System Nexus WIT source.
Intended to enable tracing propagation. See https://github.com/temporalio/sdk-python/pull/1682