### PR TITLE
Make SDK sole owner of WIT files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,5 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 *                       @temporalio/server @temporalio/sdk
+*.wit                   @temporalio/sdk
 api/temporal/api/sdk/*  @temporalio/sdk


### PR DESCRIPTION
**What changed?**

Added a CODEOWNERS rule assigning all WIT files exclusively to @temporalio/sdk.

**Why?**

WIT files are owned by the SDK team.

**Breaking changes**

None.

**Server PR**

N/A