### PR TITLE
Add TypeScript SignalWithStart WIT annotations

### DIFF
--- a/nexus/deps/nexus-temporal-types/model.wit
+++ b/nexus/deps/nexus-temporal-types/model.wit
@@ -117,7 +117,7 @@ interface model {
   /// @nexus.proto "temporal.api.common.v1.Header" typescript-import="@temporalio/proto"
   /// @nexus.type
   ///   python="collections.abc.Mapping[str, typing.Any]"
-  ///   typescript="common.Headers"
+  ///   typescript="Record<string, unknown>"
   ///   go="map[string]any"
   ///   dotnet="IReadOnlyDictionary<string, object?>"
   ///   dotnet-from="ProtoExtensions.FromHeaderProto"

--- a/nexus/deps/nexus-temporal-types/model.wit
+++ b/nexus/deps/nexus-temporal-types/model.wit
@@ -86,9 +86,9 @@ interface model {
   ///   typescript-name-extractor="signalFunctionName"
   ///   dotnet-name-extractor="TemporalFunctionNames.SignalName"
   ///   dotnet-call-extractor="TemporalFunctionNames.ExtractCall"
-  ///   typescript-value-type="workflow.SignalDefinition<any[]>"
-  ///   typescript-args-type="Value extends workflow.SignalDefinition<infer Args, any> ? Args : never"
-  ///   typescript-import="@temporalio/workflow"
+  ///   typescript-value-type="common.SignalDefinition<any[]>"
+  ///   typescript-args-type="Value extends common.SignalDefinition<infer Args, any> ? Args : never"
+  ///   typescript-import="@temporalio/common"
   /// @nexus.add-rpc-compatible-with "string"
   type signal-function = placeholder;
 

--- a/nexus/workflow-service.wit
+++ b/nexus/workflow-service.wit
@@ -126,13 +126,14 @@ interface workflow-service {
   /// @nexus.output-transform
   ///   python-type="temporalio.workflow.ExternalWorkflowHandle[WorkflowResult]"
   ///   python="temporalio.workflow.get_external_workflow_handle(request.id, run_id=result.run_id)"
-  ///   typescript-type="workflow.ExternalWorkflowHandle"
+  ///   typescript-type="ExternalWorkflowHandle"
+  ///   typescript-type-import="../../../../workflow-handle"
   ///   typescript="workflow.getExternalWorkflowHandle(request.id, result.runId ?? undefined)"
   ///   typescript-import="@temporalio/workflow"
   ///   dotnet-type="Temporalio.Workflows.ExternalWorkflowHandle"
   ///   dotnet="Temporalio.Workflows.Workflow.GetExternalWorkflowHandle(request.Id, result.RunId)"
   /// @nexus.operation name="SignalWithStartWorkflowExecution"
-  /// @nexus.serialization-context python="signal_with_start_workflow_serialization_context" dotnet="WorkflowServiceSerializationContexts.SignalWithStartWorkflow"
+  /// @nexus.serialization-context python="signal_with_start_workflow_serialization_context" typescript="signalWithStartWorkflowSerializationContext" dotnet="WorkflowServiceSerializationContexts.SignalWithStartWorkflow"
   /// @nexus.experimental
   signal-with-start-workflow: func(
     request: signal-with-start-workflow-request,


### PR DESCRIPTION
## Summary

- Add the TypeScript SignalWithStart serialization-context factory annotation.
- Describe the TypeScript ExternalWorkflowHandle output transform and its generated import.
- Reference SignalDefinition from Common so generated Workflow bindings do not self-import the Workflow package.
- Represent System Nexus headers as application values, matching the generated scoped payload conversion.

This makes the shared WIT files used by the TypeScript SDK identical to their temporary SDK copies.

## Validation

- git diff --check
- compared the shared workflow-service and model WIT files with the SDK temporary copies