### PR TITLE
RFC: report compute providers and release stage per Namespace

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -15074,6 +15074,35 @@
       },
       "description": "ComputeProvider stores information used by a worker control plane controller\nto respond to worker lifecycle events. For example, when a Task is received\non a TaskQueue that has no active pollers, a serverless worker lifecycle\ncontroller might need to invoke an AWS Lambda Function that itself ends up\ncalling the SDK's worker.New() function."
     },
+    "v1ComputeProviderReleaseStage": {
+      "type": "string",
+      "enum": [
+        "COMPUTE_PROVIDER_RELEASE_STAGE_UNSPECIFIED",
+        "COMPUTE_PROVIDER_RELEASE_STAGE_PRE_RELEASE",
+        "COMPUTE_PROVIDER_RELEASE_STAGE_PUBLIC_PREVIEW",
+        "COMPUTE_PROVIDER_RELEASE_STAGE_GENERALLY_AVAILABLE"
+      ],
+      "default": "COMPUTE_PROVIDER_RELEASE_STAGE_UNSPECIFIED",
+      "description": "How far along its rollout a compute provider is. Clients use this to label a\nprovider in a picker, and to decide whether to offer it prominently, so the\nlabel follows the server rather than being hardcoded per client.\n\n - COMPUTE_PROVIDER_RELEASE_STAGE_UNSPECIFIED: Release stage is not specified. Clients should treat the provider as\nusable but unlabeled.\n - COMPUTE_PROVIDER_RELEASE_STAGE_PRE_RELEASE: The provider is implemented but not yet ready for general use. Expect\nbreaking changes. Clients should label it accordingly and may choose not\nto offer it by default.\n - COMPUTE_PROVIDER_RELEASE_STAGE_PUBLIC_PREVIEW: The provider is available to all users but still gathering feedback, and\nmay change in backwards-incompatible ways before becoming generally\navailable.\n - COMPUTE_PROVIDER_RELEASE_STAGE_GENERALLY_AVAILABLE: The provider is generally available and covered by compatibility\nguarantees."
+    },
+    "v1ComputeProviderStatus": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The provider type, matching ComputeProvider.type. This is the value a\nclient sends back when configuring a scaling group, so it is the\nprovider's identity, not a display name."
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether this Service will accept a ComputeConfig naming this provider.\nDepends both on the build and on Service configuration, the same way the\nper-capability booleans in GetSystemInfoResponse.Capabilities do."
+        },
+        "releaseStage": {
+          "$ref": "#/definitions/v1ComputeProviderReleaseStage",
+          "description": "How far along its rollout the provider is. Lets a client label a\nprovider without shipping its own release-stage table, and lets the\nlabel change without a client release."
+        }
+      },
+      "description": "ComputeProviderStatus describes one compute provider this Service knows\nabout, so a client can discover which providers exist and how to present\nthem without hardcoding a list of its own.\n\nA Service reports a provider it recognizes even when that provider is\ndisabled, so a client can tell \"this Service has never heard of AgentCore\"\napart from \"this Service knows AgentCore but it is turned off here\", and say\nso rather than silently omitting the option."
+    },
     "v1ComputeScaler": {
       "type": "object",
       "properties": {
@@ -16270,6 +16299,14 @@
         "capabilities": {
           "$ref": "#/definitions/v1GetSystemInfoResponseCapabilities",
           "description": "All capabilities the system supports."
+        },
+        "computeProviders": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ComputeProviderStatus"
+          },
+          "description": "The compute providers this Service knows about, whether each is enabled\nhere, and how far along its rollout each one is.\n\nThis supersedes adding a boolean to Capabilities per compute provider.\nA boolean answers only \"is this one provider usable\", so every new\nprovider costs a proto field, an api release, and a server release\nbefore a client can even gate on it, and it carries no release stage,\nleaving each client to hardcode its own. A repeated message lets a\nService add a provider without a proto change, and lets a provider move\nfrom pre-release to generally available without a client release."
         }
       }
     },
@@ -16326,7 +16363,7 @@
         },
         "serverScaledProviderCloudRun": {
           "type": "boolean",
-          "description": "True if the server supports the Cloud Run compute provider for\nserver-scaled deployments. Dependent on server version and the\nprovider being enabled via server configuration."
+          "description": "True if the server supports the Cloud Run compute provider for\nserver-scaled deployments. Dependent on server version and the\nprovider being enabled via server configuration.\n\nSuperseded by GetSystemInfoResponse.compute_providers, which reports\nevery provider and its release stage rather than one boolean per\nprovider. Retained for wire compatibility with clients that already\nread it; a Service setting this should also report the equivalent\nentry in compute_providers. No further per-provider booleans should\nbe added here."
         }
       },
       "description": "System capability details."

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -15101,7 +15101,7 @@
           "description": "How far along its rollout the provider is. Lets a client label a\nprovider without shipping its own release-stage table, and lets the\nlabel change without a client release."
         }
       },
-      "description": "ComputeProviderStatus describes one compute provider this Service knows\nabout, so a client can discover which providers exist and how to present\nthem without hardcoding a list of its own.\n\nA Service reports a provider it recognizes even when that provider is\ndisabled, so a client can tell \"this Service has never heard of AgentCore\"\napart from \"this Service knows AgentCore but it is turned off here\", and say\nso rather than silently omitting the option."
+      "description": "ComputeProviderStatus describes one compute provider this Service knows\nabout, so a client can discover which providers exist and how to present\nthem without hardcoding a list of its own.\n\nThis is typed where ComputeProvider.details is an opaque Payload, and the\ndifference is deliberate. Provider *config* is open-ended and genuinely\nprovider-specific: a Lambda ARN, a Cloud Run worker pool, and an AgentCore\nendpoint ARN share no shape, which is why an earlier typed\nProviderDetailAWSLambda gave way to a Payload. Provider *status* is uniform.\nEvery provider has an identity, an enabled bit, and a release stage, and none\nneeds a field the others do not.\n\nA Service reports a provider it recognizes even when that provider is\ndisabled, so a client can tell \"this Service has never heard of AgentCore\"\napart from \"this Service knows AgentCore but it is turned off here\", and say\nso rather than silently omitting the option."
     },
     "v1ComputeScaler": {
       "type": "object",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -16299,14 +16299,6 @@
         "capabilities": {
           "$ref": "#/definitions/v1GetSystemInfoResponseCapabilities",
           "description": "All capabilities the system supports."
-        },
-        "computeProviders": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/v1ComputeProviderStatus"
-          },
-          "description": "The compute providers this Service knows about, whether each is enabled\nhere, and how far along its rollout each one is.\n\nThis supersedes adding a boolean to Capabilities per compute provider.\nA boolean answers only \"is this one provider usable\", so every new\nprovider costs a proto field, an api release, and a server release\nbefore a client can even gate on it, and it carries no release stage,\nleaving each client to hardcode its own. A repeated message lets a\nService add a provider without a proto change, and lets a provider move\nfrom pre-release to generally available without a client release."
         }
       }
     },
@@ -16363,7 +16355,7 @@
         },
         "serverScaledProviderCloudRun": {
           "type": "boolean",
-          "description": "True if the server supports the Cloud Run compute provider for\nserver-scaled deployments. Dependent on server version and the\nprovider being enabled via server configuration.\n\nSuperseded by GetSystemInfoResponse.compute_providers, which reports\nevery provider and its release stage rather than one boolean per\nprovider. Retained for wire compatibility with clients that already\nread it; a Service setting this should also report the equivalent\nentry in compute_providers. No further per-provider booleans should\nbe added here."
+          "description": "True if the server supports the Cloud Run compute provider for\nserver-scaled deployments. Dependent on server version and the\nprovider being enabled via server configuration.\n\nSuperseded by NamespaceInfo.compute_providers, which reports every\nprovider and its release stage per Namespace rather than one boolean\nper provider for the whole Service. Retained for wire compatibility\nwith clients that already read it. No further per-provider booleans\nshould be added here: this response is served as a fixed payload in\nsome deployments, so it cannot express per-Namespace availability."
         }
       },
       "description": "System capability details."
@@ -17219,6 +17211,14 @@
         "limits": {
           "$ref": "#/definitions/NamespaceInfoLimits",
           "title": "Namespace configured limits"
+        },
+        "computeProviders": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ComputeProviderStatus"
+          },
+          "description": "The compute providers available for server-scaled Worker Deployments in\nthis Namespace: which ones this Namespace can use, whether each is\ncurrently enabled, and how far along its rollout each one is.\n\nNamespace-scoped rather than Service-scoped for two reasons. Availability\ngenuinely varies per Namespace: a provider is tied to the cloud a\nNamespace runs in, so an AWS Namespace and a GCP Namespace do not offer\nthe same set, and managed deployments gate providers per account.\nGetSystemInfo cannot express either, and is served as a fixed payload\nahead of the Service in some deployments, so a per-provider boolean there\nis not reachable as a real signal."
         },
         "supportsSchedules": {
           "type": "boolean",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -11255,6 +11255,42 @@ components:
          on a TaskQueue that has no active pollers, a serverless worker lifecycle
          controller might need to invoke an AWS Lambda Function that itself ends up
          calling the SDK's worker.New() function.
+    ComputeProviderStatus:
+      type: object
+      properties:
+        type:
+          type: string
+          description: |-
+            The provider type, matching ComputeProvider.type. This is the value a
+             client sends back when configuring a scaling group, so it is the
+             provider's identity, not a display name.
+        enabled:
+          type: boolean
+          description: |-
+            Whether this Service will accept a ComputeConfig naming this provider.
+             Depends both on the build and on Service configuration, the same way the
+             per-capability booleans in GetSystemInfoResponse.Capabilities do.
+        releaseStage:
+          enum:
+            - COMPUTE_PROVIDER_RELEASE_STAGE_UNSPECIFIED
+            - COMPUTE_PROVIDER_RELEASE_STAGE_PRE_RELEASE
+            - COMPUTE_PROVIDER_RELEASE_STAGE_PUBLIC_PREVIEW
+            - COMPUTE_PROVIDER_RELEASE_STAGE_GENERALLY_AVAILABLE
+          type: string
+          description: |-
+            How far along its rollout the provider is. Lets a client label a
+             provider without shipping its own release-stage table, and lets the
+             label change without a client release.
+          format: enum
+      description: |-
+        ComputeProviderStatus describes one compute provider this Service knows
+         about, so a client can discover which providers exist and how to present
+         them without hardcoding a list of its own.
+
+         A Service reports a provider it recognizes even when that provider is
+         disabled, so a client can tell "this Service has never heard of AgentCore"
+         apart from "this Service knows AgentCore but it is turned off here", and say
+         so rather than silently omitting the option.
     ComputeScaler:
       type: object
       properties:
@@ -12588,6 +12624,21 @@ components:
           allOf:
             - $ref: '#/components/schemas/GetSystemInfoResponse_Capabilities'
           description: All capabilities the system supports.
+        computeProviders:
+          type: array
+          items:
+            $ref: '#/components/schemas/ComputeProviderStatus'
+          description: |-
+            The compute providers this Service knows about, whether each is enabled
+             here, and how far along its rollout each one is.
+
+             This supersedes adding a boolean to Capabilities per compute provider.
+             A boolean answers only "is this one provider usable", so every new
+             provider costs a proto field, an api release, and a server release
+             before a client can even gate on it, and it carries no release stage,
+             leaving each client to hardcode its own. A repeated message lets a
+             Service add a provider without a proto change, and lets a provider move
+             from pre-release to generally available without a client release.
     GetSystemInfoResponse_Capabilities:
       type: object
       properties:
@@ -12648,6 +12699,13 @@ components:
             True if the server supports the Cloud Run compute provider for
              server-scaled deployments. Dependent on server version and the
              provider being enabled via server configuration.
+
+             Superseded by GetSystemInfoResponse.compute_providers, which reports
+             every provider and its release stage rather than one boolean per
+             provider. Retained for wire compatibility with clients that already
+             read it; a Service setting this should also report the equivalent
+             entry in compute_providers. No further per-provider booleans should
+             be added here.
       description: System capability details.
     GetWorkerBuildIdCompatibilityResponse:
       type: object

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -11287,6 +11287,14 @@ components:
          about, so a client can discover which providers exist and how to present
          them without hardcoding a list of its own.
 
+         This is typed where ComputeProvider.details is an opaque Payload, and the
+         difference is deliberate. Provider *config* is open-ended and genuinely
+         provider-specific: a Lambda ARN, a Cloud Run worker pool, and an AgentCore
+         endpoint ARN share no shape, which is why an earlier typed
+         ProviderDetailAWSLambda gave way to a Payload. Provider *status* is uniform.
+         Every provider has an identity, an enabled bit, and a release stage, and none
+         needs a field the others do not.
+
          A Service reports a provider it recognizes even when that provider is
          disabled, so a client can tell "this Service has never heard of AgentCore"
          apart from "this Service knows AgentCore but it is turned off here", and say

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -12624,21 +12624,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/GetSystemInfoResponse_Capabilities'
           description: All capabilities the system supports.
-        computeProviders:
-          type: array
-          items:
-            $ref: '#/components/schemas/ComputeProviderStatus'
-          description: |-
-            The compute providers this Service knows about, whether each is enabled
-             here, and how far along its rollout each one is.
-
-             This supersedes adding a boolean to Capabilities per compute provider.
-             A boolean answers only "is this one provider usable", so every new
-             provider costs a proto field, an api release, and a server release
-             before a client can even gate on it, and it carries no release stage,
-             leaving each client to hardcode its own. A repeated message lets a
-             Service add a provider without a proto change, and lets a provider move
-             from pre-release to generally available without a client release.
     GetSystemInfoResponse_Capabilities:
       type: object
       properties:
@@ -12700,12 +12685,12 @@ components:
              server-scaled deployments. Dependent on server version and the
              provider being enabled via server configuration.
 
-             Superseded by GetSystemInfoResponse.compute_providers, which reports
-             every provider and its release stage rather than one boolean per
-             provider. Retained for wire compatibility with clients that already
-             read it; a Service setting this should also report the equivalent
-             entry in compute_providers. No further per-provider booleans should
-             be added here.
+             Superseded by NamespaceInfo.compute_providers, which reports every
+             provider and its release stage per Namespace rather than one boolean
+             per provider for the whole Service. Retained for wire compatibility
+             with clients that already read it. No further per-provider booleans
+             should be added here: this response is served as a fixed payload in
+             some deployments, so it cannot express per-Namespace availability.
       description: System capability details.
     GetWorkerBuildIdCompatibilityResponse:
       type: object
@@ -13538,6 +13523,22 @@ components:
           allOf:
             - $ref: '#/components/schemas/NamespaceInfo_Limits'
           description: Namespace configured limits
+        computeProviders:
+          type: array
+          items:
+            $ref: '#/components/schemas/ComputeProviderStatus'
+          description: |-
+            The compute providers available for server-scaled Worker Deployments in
+             this Namespace: which ones this Namespace can use, whether each is
+             currently enabled, and how far along its rollout each one is.
+
+             Namespace-scoped rather than Service-scoped for two reasons. Availability
+             genuinely varies per Namespace: a provider is tied to the cloud a
+             Namespace runs in, so an AWS Namespace and a GCP Namespace do not offer
+             the same set, and managed deployments gate providers per account.
+             GetSystemInfo cannot express either, and is served as a fixed payload
+             ahead of the Service in some deployments, so a per-provider boolean there
+             is not reachable as a real signal.
         supportsSchedules:
           type: boolean
           description: |-

--- a/temporal/api/compute/v1/status.proto
+++ b/temporal/api/compute/v1/status.proto
@@ -15,6 +15,14 @@ import "temporal/api/enums/v1/compute.proto";
 // about, so a client can discover which providers exist and how to present
 // them without hardcoding a list of its own.
 //
+// This is typed where ComputeProvider.details is an opaque Payload, and the
+// difference is deliberate. Provider *config* is open-ended and genuinely
+// provider-specific: a Lambda ARN, a Cloud Run worker pool, and an AgentCore
+// endpoint ARN share no shape, which is why an earlier typed
+// ProviderDetailAWSLambda gave way to a Payload. Provider *status* is uniform.
+// Every provider has an identity, an enabled bit, and a release stage, and none
+// needs a field the others do not.
+//
 // A Service reports a provider it recognizes even when that provider is
 // disabled, so a client can tell "this Service has never heard of AgentCore"
 // apart from "this Service knows AgentCore but it is turned off here", and say

--- a/temporal/api/compute/v1/status.proto
+++ b/temporal/api/compute/v1/status.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+
+package temporal.api.compute.v1;
+
+option go_package = "go.temporal.io/api/compute/v1;compute";
+option java_package = "io.temporal.api.compute.v1";
+option java_multiple_files = true;
+option java_outer_classname = "StatusProto";
+option ruby_package = "Temporalio::Api::Compute::V1";
+option csharp_namespace = "Temporalio.Api.Compute.V1";
+
+import "temporal/api/enums/v1/compute.proto";
+
+// ComputeProviderStatus describes one compute provider this Service knows
+// about, so a client can discover which providers exist and how to present
+// them without hardcoding a list of its own.
+//
+// A Service reports a provider it recognizes even when that provider is
+// disabled, so a client can tell "this Service has never heard of AgentCore"
+// apart from "this Service knows AgentCore but it is turned off here", and say
+// so rather than silently omitting the option.
+message ComputeProviderStatus {
+    // The provider type, matching ComputeProvider.type. This is the value a
+    // client sends back when configuring a scaling group, so it is the
+    // provider's identity, not a display name.
+    string type = 1;
+
+    // Whether this Service will accept a ComputeConfig naming this provider.
+    // Depends both on the build and on Service configuration, the same way the
+    // per-capability booleans in GetSystemInfoResponse.Capabilities do.
+    bool enabled = 2;
+
+    // How far along its rollout the provider is. Lets a client label a
+    // provider without shipping its own release-stage table, and lets the
+    // label change without a client release.
+    temporal.api.enums.v1.ComputeProviderReleaseStage release_stage = 3;
+}

--- a/temporal/api/enums/v1/compute.proto
+++ b/temporal/api/enums/v1/compute.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package temporal.api.enums.v1;
+
+option go_package = "go.temporal.io/api/enums/v1;enums";
+option java_package = "io.temporal.api.enums.v1";
+option java_multiple_files = true;
+option java_outer_classname = "ComputeProto";
+option ruby_package = "Temporalio::Api::Enums::V1";
+option csharp_namespace = "Temporalio.Api.Enums.V1";
+
+// How far along its rollout a compute provider is. Clients use this to label a
+// provider in a picker, and to decide whether to offer it prominently, so the
+// label follows the server rather than being hardcoded per client.
+enum ComputeProviderReleaseStage {
+    // Release stage is not specified. Clients should treat the provider as
+    // usable but unlabeled.
+    COMPUTE_PROVIDER_RELEASE_STAGE_UNSPECIFIED = 0;
+    // The provider is implemented but not yet ready for general use. Expect
+    // breaking changes. Clients should label it accordingly and may choose not
+    // to offer it by default.
+    COMPUTE_PROVIDER_RELEASE_STAGE_PRE_RELEASE = 1;
+    // The provider is available to all users but still gathering feedback, and
+    // may change in backwards-incompatible ways before becoming generally
+    // available.
+    COMPUTE_PROVIDER_RELEASE_STAGE_PUBLIC_PREVIEW = 2;
+    // The provider is generally available and covered by compatibility
+    // guarantees.
+    COMPUTE_PROVIDER_RELEASE_STAGE_GENERALLY_AVAILABLE = 3;
+}

--- a/temporal/api/namespace/v1/message.proto
+++ b/temporal/api/namespace/v1/message.proto
@@ -12,6 +12,7 @@ option csharp_namespace = "Temporalio.Api.Namespace.V1";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
+import "temporal/api/compute/v1/status.proto";
 import "temporal/api/enums/v1/namespace.proto";
 
 
@@ -82,6 +83,19 @@ message NamespaceInfo {
         // WORKFLOW_TASK_FAILED_CAUSE_REQUEST_TOO_LARGE. 0 means no explicit limit.
         int64 workflow_task_completion_size_limit_error = 3;
     }
+
+    // The compute providers available for server-scaled Worker Deployments in
+    // this Namespace: which ones this Namespace can use, whether each is
+    // currently enabled, and how far along its rollout each one is.
+    //
+    // Namespace-scoped rather than Service-scoped for two reasons. Availability
+    // genuinely varies per Namespace: a provider is tied to the cloud a
+    // Namespace runs in, so an AWS Namespace and a GCP Namespace do not offer
+    // the same set, and managed deployments gate providers per account.
+    // GetSystemInfo cannot express either, and is served as a fixed payload
+    // ahead of the Service in some deployments, so a per-provider boolean there
+    // is not reachable as a real signal.
+    repeated temporal.api.compute.v1.ComputeProviderStatus compute_providers = 9;
 
     // Whether scheduled workflows are supported on this namespace. This is only needed
     // temporarily while the feature is experimental, so we can give it a high tag.

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -28,6 +28,7 @@ import "temporal/api/history/v1/message.proto";
 import "temporal/api/workflow/v1/message.proto";
 import "temporal/api/command/v1/message.proto";
 import "temporal/api/compute/v1/config.proto";
+import "temporal/api/compute/v1/status.proto";
 import "temporal/api/deployment/v1/message.proto";
 import "temporal/api/failure/v1/message.proto";
 import "temporal/api/filter/v1/message.proto";
@@ -1340,6 +1341,18 @@ message GetSystemInfoResponse {
     // All capabilities the system supports.
     Capabilities capabilities = 2;
 
+    // The compute providers this Service knows about, whether each is enabled
+    // here, and how far along its rollout each one is.
+    //
+    // This supersedes adding a boolean to Capabilities per compute provider.
+    // A boolean answers only "is this one provider usable", so every new
+    // provider costs a proto field, an api release, and a server release
+    // before a client can even gate on it, and it carries no release stage,
+    // leaving each client to hardcode its own. A repeated message lets a
+    // Service add a provider without a proto change, and lets a provider move
+    // from pre-release to generally available without a client release.
+    repeated temporal.api.compute.v1.ComputeProviderStatus compute_providers = 3;
+
     // System capability details.
     message Capabilities {
         // True if signal and query headers are supported.
@@ -1392,6 +1405,13 @@ message GetSystemInfoResponse {
         // True if the server supports the Cloud Run compute provider for
         // server-scaled deployments. Dependent on server version and the
         // provider being enabled via server configuration.
+        //
+        // Superseded by GetSystemInfoResponse.compute_providers, which reports
+        // every provider and its release stage rather than one boolean per
+        // provider. Retained for wire compatibility with clients that already
+        // read it; a Service setting this should also report the equivalent
+        // entry in compute_providers. No further per-provider booleans should
+        // be added here.
         bool server_scaled_provider_cloud_run = 13;
 
     }

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -28,7 +28,6 @@ import "temporal/api/history/v1/message.proto";
 import "temporal/api/workflow/v1/message.proto";
 import "temporal/api/command/v1/message.proto";
 import "temporal/api/compute/v1/config.proto";
-import "temporal/api/compute/v1/status.proto";
 import "temporal/api/deployment/v1/message.proto";
 import "temporal/api/failure/v1/message.proto";
 import "temporal/api/filter/v1/message.proto";
@@ -1341,18 +1340,6 @@ message GetSystemInfoResponse {
     // All capabilities the system supports.
     Capabilities capabilities = 2;
 
-    // The compute providers this Service knows about, whether each is enabled
-    // here, and how far along its rollout each one is.
-    //
-    // This supersedes adding a boolean to Capabilities per compute provider.
-    // A boolean answers only "is this one provider usable", so every new
-    // provider costs a proto field, an api release, and a server release
-    // before a client can even gate on it, and it carries no release stage,
-    // leaving each client to hardcode its own. A repeated message lets a
-    // Service add a provider without a proto change, and lets a provider move
-    // from pre-release to generally available without a client release.
-    repeated temporal.api.compute.v1.ComputeProviderStatus compute_providers = 3;
-
     // System capability details.
     message Capabilities {
         // True if signal and query headers are supported.
@@ -1406,12 +1393,12 @@ message GetSystemInfoResponse {
         // server-scaled deployments. Dependent on server version and the
         // provider being enabled via server configuration.
         //
-        // Superseded by GetSystemInfoResponse.compute_providers, which reports
-        // every provider and its release stage rather than one boolean per
-        // provider. Retained for wire compatibility with clients that already
-        // read it; a Service setting this should also report the equivalent
-        // entry in compute_providers. No further per-provider booleans should
-        // be added here.
+        // Superseded by NamespaceInfo.compute_providers, which reports every
+        // provider and its release stage per Namespace rather than one boolean
+        // per provider for the whole Service. Retained for wire compatibility
+        // with clients that already read it. No further per-provider booleans
+        // should be added here: this response is served as a fixed payload in
+        // some deployments, so it cannot express per-Namespace availability.
         bool server_scaled_provider_cloud_run = 13;
 
     }


### PR DESCRIPTION
## RFC — not for merge as-is

Proposes one source of truth for **which compute providers a Namespace can use, whether each is enabled, and what release stage each is in** — replacing the pattern of adding a boolean to `Capabilities` per provider.

**Revised after review.** The first draft put this on `GetSystemInfoResponse`. [@Quinn-Klassen](https://github.com/Quinn-Klassen) pointed out that will not work, because Cloud serves that endpoint as a fixed response at the reverse proxy layer, and suggested a Namespace-scoped surface. That is what this now does, and the objection turned out to be right on the mechanism *and* on the correct scope. History is kept so the argument is reviewable.

The AgentCore work this came out of does not depend on this and is not blocked by it.

## The problem with a boolean per provider

`server_scaled_provider_cloud_run = 13` (#799) works, but it only answers *"is this one provider usable, Service-wide"*. Three costs follow.

**A new provider needs a full release train before a client can even gate on it.** Proto field → api release → server release. Cloud Run is the worked example: the UI shipped the option in temporalio/ui#3518 on 2026-06-12, the capability field landed 2026-07-06, and the UI could not consume it until an api bump on 2026-08-13. Two months, for a boolean.

**It carries no release stage, so every client hardcodes its own.** temporalio/ui has this table today:

```ts
export const defaultReleaseStage = {
  lambda: 'public-preview',
  agentcore: 'pre-release',
  'cloud-run': 'pre-release',
};
```

Moving Lambda to GA is a UI release. cloud-ui keeps a parallel list, the CLI keeps one for scaler pairing, and temporal-auto-scaled-workers — the actual authority — keeps the real one.

**Service scope cannot express what is actually true.** Provider availability varies per Namespace: a provider is tied to the cloud its Namespace runs in. cloud-ui already encodes this, deriving the list from the Namespace's `RegionID_CloudProvider` — an AWS Namespace offers Lambda and AgentCore, a GCP Namespace offers Cloud Run. A single Service-wide boolean has no way to say that.

**All three are live right now:**

- The server has *never* set `ServerScaledProviderCloudRun`. `GetSystemInfo` in `workflow_handler.go` stops at `ServerScaledDeployments: true`. Two months after the field landed, Cloud Run is still "Coming Soon" on OSS.
- AgentCore is merged in temporal-auto-scaled-workers (#117/#118) and shipped in CLI v1.8.3 (#1177) with **no capability field at all**. temporalio/ui#3884 gates it on a field that does not exist, declared as a local type intersection, because that was cheaper than waiting.

## Proposed shape

```proto
message ComputeProviderStatus {
    // Matches ComputeProvider.type — the provider's identity, not a display name.
    string type = 1;
    // Whether a ComputeConfig naming this provider will be accepted here.
    bool enabled = 2;
    temporal.api.enums.v1.ComputeProviderReleaseStage release_stage = 3;
}
```

on `NamespaceInfo`, alongside the existing `capabilities` and `limits`:

```proto
repeated temporal.api.compute.v1.ComputeProviderStatus compute_providers = 9;
```

A Service adds a provider without a proto change. A provider moves from pre-release to GA without a client release. Availability can differ per Namespace. And clients drop their hardcoded tables.

### Why NamespaceInfo, concretely

Both halves of Quinn's point check out in the client code:

- **`GetSystemInfo` does not reach Cloud.** temporalio/ui's `fetchSystemInfo` returns `{}` outright when `isCloud`, and cloud-ui synthesizes the entire `systemInfo` object client-side from account feature flags rather than calling the endpoint. A per-provider boolean there is not a reachable signal.
- **`NamespaceInfo` does.** cloud-ui already reads `namespace.namespaceInfo?.capabilities` in `standalone-nexus-guard.svelte`. `NamespaceInfo.Capabilities` is a live, actively growing surface — 17 fields, most recently `standalone_activity_operator_commands`.

### Cloud already has a working model for this, and it is two-key

Worth spelling out, because it decides whether the server populating this is
useful or academic.

`NamespaceInfo.capabilities` is **not** synthesized by cloud-ui the way
`systemInfo` is. cloud-ui fetches the real namespace from the data plane and
reads the capabilities off the wire (`src/lib/services/settings.ts`):

```ts
`${webUrl}/api/v1/namespaces/${namespace?.namespace}`
→ dataplaneNamespace?.namespaceInfo?.capabilities
```

It then overlays account state on top, with two distinct idioms:

```ts
capabilities: {
  ...dataplaneNamespace?.namespaceInfo?.capabilities,
  workerHeartbeats: dataplane...?.workerHeartbeats ?? true,
  // TODO: Update these to use the dataplaneNamespace value when feature flag is removed
  standaloneActivityStartDelay: standaloneActivitiesGAEnabled,
  // dataplaneNamespace?.namespaceInfo?.capabilities?.standaloneActivityStartDelay ?? true,
}
```

`?? true` for capabilities Cloud knows are universally on, so an older data
plane that does not report one is treated as capable. Feature-flag
substitution for a capability still rolling out, with the real read commented
out beneath it and a TODO to swap at GA.

And consumers **AND** the two keys rather than choosing between them
(`standalone-nexus-guard.svelte`):

```ts
namespace.namespaceInfo?.capabilities?.standaloneNexusOperation &&
  $CurrentUser.hasFeatureFlag('enable_standalone_nexus_operations')
```

The namespace capability answers *is this possible here*; the account flag
answers *is this account permitted*. That is the shape a provider list wants
too, and it already works.

The `standaloneActivityStartDelay` lines are also, by hand, exactly the
lifecycle this proposal describes: flag first, server-reported value later,
with the swap tracked in a comment. `release_stage` is what lets the server say
"this is generally available now" instead of a client releasing to delete a
TODO.

### Prior art: this package started typed and moved away from it

api#704 introduced `compute.v1` on the `serverless` branch in February, and
#752 reshaped it when that branch merged to master. Two things did not survive,
and both bear on this proposal.

**Per-provider config was typed, then deliberately untyped.** #704 carried a
`ProviderDetailAWSLambda` message holding the function ARN and an optional role
ARN. Today `ComputeProvider.details` is an opaque `Payload`. So a reviewer
should ask why this proposes a typed message after the package moved the other
way.

The answer is that those two things are different in kind. Provider *config* is
open-ended and genuinely provider-specific — a Lambda ARN, a Cloud Run worker
pool, an AgentCore endpoint ARN share no shape, and every new provider would
otherwise cost a proto message. Provider *status* is uniform: every provider has
an identity, an enabled bit, and a release stage, and no provider needs a field
the others do not. Untyping config was right for the same reason typing status
is: the shape either varies per provider or it does not.

**`ComputeConfig.task_queues` was removed.** #704 declared task queues as
name-and-type tuples; main keeps only `task_queue_types`. That is why a
serverless Version has no task queue until something teaches matching one: the
first invoke starts a Worker, it polls with versioning, and that registration
is the association. Nothing in the current API can state it up front. Not this
proposal's problem, but it is the reason `create-version` takes no task queue,
which surprises everyone who meets it.

### Two other deliberate choices

**It reports disabled providers too, rather than omitting them.** That lets a client distinguish *"this Namespace has never heard of AgentCore"* from *"it knows AgentCore but it is off here"* and say so, instead of silently dropping the option. It is the difference between a "Coming Soon" badge and a provider that appears not to exist.

**A repeated message rather than more booleans in `NamespaceInfo.Capabilities`.** Booleans there would inherit the same two problems — a proto field per provider, and no release stage.

`server_scaled_provider_cloud_run` is kept for wire compatibility and marked superseded, with a note recording *why* no further per-provider booleans belong on that response.

## Open questions for reviewers

1. **`NamespaceInfo`, or a dedicated RPC?** `NamespaceInfo` is where namespace capability data already lives and already reaches Cloud, so it is the cheap and consistent choice. A `ListComputeProviders` would be more discoverable and could carry more per-provider detail later.
2. **Should `release_stage` live in the api at all?** It is arguably product metadata, not a capability. The counter-argument is that it is *already* in every client, just duplicated and going stale.
3. **Where does the value come from?** temporal-auto-scaled-workers has the real registry — `iface.ComputeProviderType` and `RegisterComputeProvider`. The server should derive this from it rather than maintaining a third list. Worth confirming that is exposable.
4. ~~**Does Cloud populate this per Namespace, or keep overlaying account flags in cloud-ui?**~~ **Resolved:** neither is a lift. The data plane populates `NamespaceInfo.capabilities` today and Cloud passes it through; saas-control-plane writes no namespace capabilities at all, so nothing new is asked of the control plane. cloud-ui keeps its account-flag overlay during rollout and drops it at GA, which is what it already does for `standaloneActivities`. See "Cloud already has a working model" above.

5. **Should the enabled bit be per Namespace, or is per Service enough in practice?** Availability varies per Namespace because of the cloud a Namespace runs in, which is static. If nothing varies it *dynamically*, a Service-level list plus the Namespace's cloud provider would also work and be cheaper to populate.

## Verification

- `make http-api-docs` run; `openapi/openapiv2.json` and `openapi/openapiv3.yaml` regenerated and committed.
- `make buf-lint` clean.
- `make api-linter` clean.
- `protoc -I. --descriptor_set_out=/dev/null $(find temporal -name '*.proto')` clean across the whole tree.
- `make buf-breaking` reports 18 errors, **all pre-existing** — `ExecutionType` in `enums/v1/common.proto`, `CallbackInfo.request_id`, and several Nexus fields. Clean `main` reports the same 18. None involve `compute/v1` or `namespace/v1`; this change adds no breaking change.

## Nothing else already does this

Checked before proposing, on current `main` of each repository:

- `NamespaceInfo` has no compute, provider, agentcore, or serverless field, and no capability has been added to it since this RFC opened.
- The server's `namespace_handler.go` sets five worker-related capabilities and nothing provider-related.
- saas-proto mentions serverless only as infrastructure plumbing — an `isServerless` flag on internal service-account provisioning, and `serverless_worker` as a Key Vault cert purpose. Cloud has built certs and identity for server-scaled Workers; it has not built a surface for which providers a Namespace may use.

## What is not done

- **No server implementation.** Nothing populates `compute_providers` yet. This PR is the contract argument only.

## Context

- temporalio/ui#3884 — AgentCore in the serverless Worker forms
- temporalio/cloud-ui#3221 — enabling it for Cloud accounts
- temporalio/saas-control-plane#15687 — the account feature flag
- temporalio/api#704 — where `compute.v1` originated, on the `serverless` branch
- temporalio/api#752 — the merge to master that reshaped it

